### PR TITLE
Adds waiting for all TF errors if timeout is specified in lookup_a_tform_b

### DIFF
--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -565,7 +565,8 @@ def get_from_env_and_fall_back_to_param(env_name, node, param_name, default_valu
         val = node.get_parameter(param_name).value
     return val
 
-# Timeout only works if you use spin_thread when creating your tf_listener!
+# Timeout only works if your tf_listener is being updated in a separate thread from which this is called!
+# You can do that by creating a multi-threaded executor.
 def lookup_a_tform_b(tf_buffer, frame_a, frame_b, transform_time=None, timeout=None):
     if transform_time is None:
         transform_time = rclpy.time.Time()

--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -570,14 +570,14 @@ def lookup_a_tform_b(tf_buffer, frame_a, frame_b, transform_time=None, timeout=N
     if transform_time is None:
         transform_time = rclpy.time.Time()
     if timeout is None:
-        timeout = rclpy.time.Duration()
+        timeout_py = rclpy.time.Duration()
     else:
-        timeout = rclpy.time.Duration(seconds=timeout)
+        timeout_py = rclpy.time.Duration(seconds=timeout)
     start_time = time.time()
     while True:
         try:
             return ros_transform_to_se3_pose(tf_buffer.lookup_transform(frame_a, frame_b, time=transform_time,
-                                                                        timeout=timeout).transform)
+                                                                        timeout=timeout_py).transform)
         except tf2.TransformException as e:
             now = time.time()
             if timeout is None or now - start_time > timeout:

--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -566,9 +566,9 @@ def get_from_env_and_fall_back_to_param(env_name, node, param_name, default_valu
     return val
 
 # Timeout only works if you use spin_thread when creating your tf_listener!
-def lookup_a_tform_b(tf_buffer, frame_a, frame_b, time=None, timeout=None):
-    if time is None:
-        time = rclpy.time.Time()
+def lookup_a_tform_b(tf_buffer, frame_a, frame_b, transform_time=None, timeout=None):
+    if transform_time is None:
+        transform_time = rclpy.time.Time()
     if timeout is None:
         timeout = rclpy.time.Duration()
     else:
@@ -578,7 +578,7 @@ def lookup_a_tform_b(tf_buffer, frame_a, frame_b, time=None, timeout=None):
         duration = timeout.sec + timeout.nanosec / 1e9
     while True:
         try:
-            return ros_transform_to_se3_pose(tf_buffer.lookup_transform(frame_a, frame_b, time=time,
+            return ros_transform_to_se3_pose(tf_buffer.lookup_transform(frame_a, frame_b, time=transform_time,
                                                                         timeout=timeout).transform)
         except tf2.TransformException as e:
             now = time.time()

--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -574,14 +574,12 @@ def lookup_a_tform_b(tf_buffer, frame_a, frame_b, transform_time=None, timeout=N
     else:
         timeout = rclpy.time.Duration(seconds=timeout)
     start_time = time.time()
-    if timeout is not None:
-        duration = timeout.sec + timeout.nanosec / 1e9
     while True:
         try:
             return ros_transform_to_se3_pose(tf_buffer.lookup_transform(frame_a, frame_b, time=transform_time,
                                                                         timeout=timeout).transform)
         except tf2.TransformException as e:
             now = time.time()
-            if timeout is None or now - start_time > duration:
+            if timeout is None or now - start_time > timeout:
                 raise e
             time.sleep(0.01)


### PR DESCRIPTION
As with many ROS2 things, this is fragile depending on the way the user has their nodes and executors set up :(