### PR TITLE
Increase timeout to 10 sec (from 3 sec)

### DIFF
--- a/spot_driver/spot_driver/spot_wrapper.py
+++ b/spot_driver/spot_driver/spot_wrapper.py
@@ -296,7 +296,7 @@ class SpotWrapper():
             return
 
         self._logger.info("Establishing time sync with robot - this could take some time.")
-        self._robot.time_sync.wait_for_sync()
+        self._robot.time_sync.wait_for_sync(10.0)
 
         if self._robot:
             # Clients


### PR DESCRIPTION
This change helped me resolve the issue that 
the spot process keeps dying after launching. 