### PR TITLE
Fix publishing of images

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Boston Dynamics AI Institute contributors:
 * Daniel Gonzalez
 * David Surovik
 * Jiuguang Wang
+* David Watkins
 
 [Linköping University](https://liu.se/en/organisation/liu/ida) contributors:
 

--- a/spot_driver/launch/point_cloud_xyzrgb.launch.py
+++ b/spot_driver/launch/point_cloud_xyzrgb.launch.py
@@ -38,7 +38,7 @@ from launch import LaunchDescription
 import launch_ros.actions
 import launch_ros.descriptions
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration, TextSubstitution, PathJoinSubstitution
 
 
 def generate_launch_description():

--- a/spot_driver/launch/point_cloud_xyzrgb.launch.py
+++ b/spot_driver/launch/point_cloud_xyzrgb.launch.py
@@ -38,7 +38,7 @@ from launch import LaunchDescription
 import launch_ros.actions
 import launch_ros.descriptions
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, TextSubstitution, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 
 
 def generate_launch_description():
@@ -99,15 +99,24 @@ def generate_launch_description():
             package='rclcpp_components',
             executable='component_container',
             composable_node_descriptions=[
+                launch_ros.descriptions.ComposableNode(
+                    package='depth_image_proc',
+                    plugin='depth_image_proc::PointCloudXyzrgbNode',
+                    name='point_cloud_xyzrgb_node',
+                    remappings=[('rgb/camera_info', '/camera/color/camera_info'),
+                                ('rgb/image_rect_color', '/camera/color/image_raw'),
+                                ('depth_registered/image_rect', '/camera/aligned_depth_to_color/image_raw'),
+                                ('points', '/camera/depth_registered/points')]
+                ),
                 # Driver itself
                 launch_ros.descriptions.ComposableNode(
                     package='depth_image_proc',
                     plugin='depth_image_proc::PointCloudXyzNode',
                     name='point_cloud_xyz_back',
                     remappings=[
-                        ('image_rect', PathJoinSubstitution([spot_name, "depth/back/image"])),
-                        ('camera_info', PathJoinSubstitution([spot_name, "depth/back/camera_info"])),
-                        ('image', PathJoinSubstitution([spot_name, "depth/back/image"])),
+                        ('rgb/camera_info', PathJoinSubstitution([spot_name, "depth/back/image"])),
+                        ('rgb/image_rect_color', PathJoinSubstitution([spot_name, "depth/back/camera_info"])),
+                        ('depth_registered/image_rect', PathJoinSubstitution([spot_name, "depth/back/image"])),
                         ('points', PathJoinSubstitution([spot_name, "depth/back/points"]))
                     ]
                 ),

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -1,7 +1,5 @@
 import launch
-from ament_index_python import get_package_share_directory
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 import launch_ros
 import os
@@ -40,27 +38,17 @@ def generate_launch_description():
         default_value="false",
     )
 
-    # include another launch file
-    spot_image_publishers_launch_include = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(
-                get_package_share_directory('spot_driver'),
-                'launch/spot_image_publishers.launch.py'
-            )
-        ),
-        launch_arguments=[
-            ("publish_rgb", publish_rgb),
-            ("publish_depth", publish_depth),
-            ("publish_depth_registered", publish_depth_registered),
-        ],
-    )
-
+    driver_params = {
+        'publish_rgb': publish_rgb,
+        'publish_depth': publish_depth,
+        'publish_depth_registered': publish_depth_registered
+    }
     spot_driver_node = launch_ros.actions.Node(
         package='spot_driver',
         executable='spot_ros2',
         name='spot_ros2',
         output='screen',
-        parameters=[config_file]
+        parameters=[config_file, driver_params]
     )
 
     params = {'robot_description': robot_desc}
@@ -71,7 +59,6 @@ def generate_launch_description():
         parameters=[params])
 
     return launch.LaunchDescription([
-        spot_image_publishers_launch_include,
         publish_rgb_arg,
         publish_depth_arg,
         publish_depth_registered_arg,

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -1,5 +1,7 @@
 import launch
-from launch.actions import DeclareLaunchArgument
+from ament_index_python import get_package_share_directory
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 import launch_ros
 import os
@@ -9,15 +11,49 @@ import xacro
 
 def generate_launch_description():
     config_file = LaunchConfiguration('config_file')
-    config_file_arg = DeclareLaunchArgument('config_file',
-                                            description='Path to configuration file for the driver.')
-
+    config_file_arg = DeclareLaunchArgument('config_file', description='Path to configuration file for the driver.')
 
     pkg_share = FindPackageShare('spot_description').find('spot_description')
     urdf_dir = os.path.join(pkg_share, 'urdf')
     xacro_file = os.path.join(urdf_dir, 'spot.urdf.xacro')
     doc = xacro.process_file(xacro_file)
     robot_desc = doc.toprettyxml(indent='  ')
+
+    publish_rgb = LaunchConfiguration("publish_rgb", default="true")
+    publish_rgb_arg = DeclareLaunchArgument(
+        "publish_rgb",
+        description="Start publishing all RGB channels on Spot cameras",
+        default_value="true",
+    )
+
+    publish_depth = LaunchConfiguration("publish_depth", default="true")
+    publish_depth_arg = DeclareLaunchArgument(
+        "publish_depth",
+        description="Start publishing all depth channels on Spot cameras",
+        default_value="true",
+    )
+
+    publish_depth_registered = LaunchConfiguration("publish_depth_registered", default="true")
+    publish_depth_registered_arg = DeclareLaunchArgument(
+        "publish_depth_registered",
+        description="Start publishing all depth_registered channels on Spot cameras",
+        default_value="false",
+    )
+
+    # include another launch file
+    spot_image_publishers_launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory('spot_driver'),
+                'launch/spot_image_publishers.launch.py'
+            )
+        ),
+        launch_arguments=[
+            ("publish_rgb", publish_rgb),
+            ("publish_depth", publish_depth),
+            ("publish_depth_registered", publish_depth_registered),
+        ],
+    )
 
     spot_driver_node = launch_ros.actions.Node(
         package='spot_driver',
@@ -35,6 +71,10 @@ def generate_launch_description():
         parameters=[params])
 
     return launch.LaunchDescription([
+        spot_image_publishers_launch_include,
+        publish_rgb_arg,
+        publish_depth_arg,
+        publish_depth_registered_arg,
         config_file_arg,
         spot_driver_node,
         robot_state_publisher,

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -31,7 +31,7 @@ def generate_launch_description():
         default_value="true",
     )
 
-    publish_depth_registered = LaunchConfiguration("publish_depth_registered", default="true")
+    publish_depth_registered = LaunchConfiguration("publish_depth_registered", default="false")
     publish_depth_registered_arg = DeclareLaunchArgument(
         "publish_depth_registered",
         description="Start publishing all depth_registered channels on Spot cameras",

--- a/spot_driver/launch/spot_driver_with_namespace.launch.py
+++ b/spot_driver/launch/spot_driver_with_namespace.launch.py
@@ -34,7 +34,7 @@ def generate_launch_description():
         default_value="true",
     )
 
-    publish_depth_registered = LaunchConfiguration("publish_depth_registered", default="true")
+    publish_depth_registered = LaunchConfiguration("publish_depth_registered", default="false")
     publish_depth_registered_arg = DeclareLaunchArgument(
         "publish_depth_registered",
         description="Start publishing all depth_registered channels on Spot cameras",

--- a/spot_driver/launch/spot_driver_with_namespace.launch.py
+++ b/spot_driver/launch/spot_driver_with_namespace.launch.py
@@ -1,7 +1,5 @@
 import launch
-from ament_index_python import get_package_share_directory
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 import launch_ros
 import os
@@ -43,23 +41,12 @@ def generate_launch_description():
         default_value="false",
     )
 
-    # include another launch file
-    spot_image_publishers_launch_include = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(
-                get_package_share_directory('spot_driver'),
-                'launch/spot_image_publishers.launch.py'
-            )
-        ),
-        launch_arguments=[
-            ("spot_name", spot_name),
-            ("publish_rgb", publish_rgb),
-            ("publish_depth", publish_depth),
-            ("publish_depth_registered", publish_depth_registered),
-        ],
-    )
-
-    driver_params = {'spot_name': spot_name}
+    driver_params = {
+        'spot_name': spot_name,
+        'publish_rgb': publish_rgb,
+        'publish_depth': publish_depth,
+        'publish_depth_registered': publish_depth_registered,
+    }
     spot_driver_node = launch_ros.actions.Node(
         package='spot_driver',
         executable='spot_ros2',
@@ -78,7 +65,6 @@ def generate_launch_description():
         parameters=[params])
 
     return launch.LaunchDescription([
-        spot_image_publishers_launch_include,
         publish_rgb_arg,
         publish_depth_arg,
         publish_depth_registered_arg,

--- a/spot_driver/launch/spot_driver_with_namespace.launch.py
+++ b/spot_driver/launch/spot_driver_with_namespace.launch.py
@@ -1,26 +1,63 @@
 import launch
-from launch.actions import DeclareLaunchArgument
+from ament_index_python import get_package_share_directory
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 import launch_ros
 import os
 from launch_ros.substitutions import FindPackageShare
 import xacro
 
+
 def generate_launch_description():
     spot_name = LaunchConfiguration('spot_name')
-
     spot_name_arg = DeclareLaunchArgument('spot_name', description='Name of spot')
 
     config_file = LaunchConfiguration('config_file')
-    config_file_arg = DeclareLaunchArgument('config_file',
-                                            description='Path to configuration file for the driver.')
-
+    config_file_arg = DeclareLaunchArgument('config_file', description='Path to configuration file for the driver.')
 
     pkg_share = FindPackageShare('spot_description').find('spot_description')
     urdf_dir = os.path.join(pkg_share, 'urdf')
     xacro_file = os.path.join(urdf_dir, 'spot.urdf.xacro')
     doc = xacro.process_file(xacro_file)
     robot_desc = doc.toprettyxml(indent='  ')
+
+    publish_rgb = LaunchConfiguration("publish_rgb", default="true")
+    publish_rgb_arg = DeclareLaunchArgument(
+        "publish_rgb",
+        description="Start publishing all RGB channels on Spot cameras",
+        default_value="true",
+    )
+
+    publish_depth = LaunchConfiguration("publish_depth", default="true")
+    publish_depth_arg = DeclareLaunchArgument(
+        "publish_depth",
+        description="Start publishing all depth channels on Spot cameras",
+        default_value="true",
+    )
+
+    publish_depth_registered = LaunchConfiguration("publish_depth_registered", default="true")
+    publish_depth_registered_arg = DeclareLaunchArgument(
+        "publish_depth_registered",
+        description="Start publishing all depth_registered channels on Spot cameras",
+        default_value="false",
+    )
+
+    # include another launch file
+    spot_image_publishers_launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory('spot_driver'),
+                'launch/spot_image_publishers.launch.py'
+            )
+        ),
+        launch_arguments=[
+            ("spot_name", spot_name),
+            ("publish_rgb", publish_rgb),
+            ("publish_depth", publish_depth),
+            ("publish_depth_registered", publish_depth_registered),
+        ],
+    )
 
     driver_params = {'spot_name': spot_name}
     spot_driver_node = launch_ros.actions.Node(
@@ -41,6 +78,10 @@ def generate_launch_description():
         parameters=[params])
 
     return launch.LaunchDescription([
+        spot_image_publishers_launch_include,
+        publish_rgb_arg,
+        publish_depth_arg,
+        publish_depth_registered_arg,
         spot_name_arg,
         config_file_arg,
         spot_driver_node,

--- a/spot_driver/launch/spot_image_publishers.launch.py
+++ b/spot_driver/launch/spot_image_publishers.launch.py
@@ -1,0 +1,43 @@
+# Copyright [2023] Boston Dynamics AI Institute, Inc.
+
+import launch
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+import launch_ros
+
+
+# camera_sources = ["frontleft", "frontright", "left", "right", "back"]
+# camera_types = ["camera", "depth", "depth_registered"]
+
+camera_sources = ["frontleft"]
+camera_types = ["camera"]
+
+
+def generate_launch_description():
+    spot_name = LaunchConfiguration('spot_name')
+    spot_name_arg = DeclareLaunchArgument('spot_name', description='Name of spot')
+
+    image_publish_rate = LaunchConfiguration("image_publish_rate")
+    image_publish_rate_arg = DeclareLaunchArgument(
+        "image_publish_rate",
+        description='Rate in (hz) of image publishing',
+        default_value="10",
+    )
+
+    nodes = [spot_name_arg, image_publish_rate_arg]
+    camera_node = launch_ros.actions.Node(
+        package="spot_driver",
+        executable="publish_camera",
+        name=f"image_publisher",
+        output="screen",
+        namespace=spot_name,
+        parameters=[
+            {
+                "spot_name": spot_name,
+                "image_publish_rate": image_publish_rate,
+            }
+        ]
+    )
+    nodes.append(camera_node)
+
+    return launch.LaunchDescription(nodes)

--- a/spot_driver/launch/spot_image_publishers.launch.py
+++ b/spot_driver/launch/spot_image_publishers.launch.py
@@ -32,7 +32,7 @@ def generate_launch_description():
         default_value="true",
     )
 
-    publish_depth_registered = LaunchConfiguration("publish_depth_registered", default="true")
+    publish_depth_registered = LaunchConfiguration("publish_depth_registered", default="false")
     publish_depth_registered_arg = DeclareLaunchArgument(
         "publish_depth_registered",
         description="Start publishing all depth_registered channels on Spot cameras",

--- a/spot_driver/launch/spot_image_publishers.launch.py
+++ b/spot_driver/launch/spot_image_publishers.launch.py
@@ -6,13 +6,6 @@ from launch.substitutions import LaunchConfiguration
 import launch_ros
 
 
-# camera_sources = ["frontleft", "frontright", "left", "right", "back"]
-# camera_types = ["camera", "depth", "depth_registered"]
-
-camera_sources = ["frontleft"]
-camera_types = ["camera"]
-
-
 def generate_launch_description():
     spot_name = LaunchConfiguration('spot_name')
     spot_name_arg = DeclareLaunchArgument('spot_name', description='Name of spot')
@@ -27,7 +20,7 @@ def generate_launch_description():
     nodes = [spot_name_arg, image_publish_rate_arg]
     camera_node = launch_ros.actions.Node(
         package="spot_driver",
-        executable="publish_camera",
+        executable="spot_publish_cameras",
         name=f"image_publisher",
         output="screen",
         namespace=spot_name,

--- a/spot_driver/launch/spot_image_publishers.launch.py
+++ b/spot_driver/launch/spot_image_publishers.launch.py
@@ -2,13 +2,14 @@
 
 import launch
 from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
 import launch_ros
 
 
 def generate_launch_description():
-    spot_name = LaunchConfiguration('spot_name')
-    spot_name_arg = DeclareLaunchArgument('spot_name', description='Name of spot')
+    spot_name = LaunchConfiguration("spot_name", default="")
+    spot_name_arg = DeclareLaunchArgument("spot_name", description="Name of spot", default_value="")
 
     image_publish_rate = LaunchConfiguration("image_publish_rate")
     image_publish_rate_arg = DeclareLaunchArgument(
@@ -17,20 +18,46 @@ def generate_launch_description():
         default_value="10",
     )
 
-    nodes = [spot_name_arg, image_publish_rate_arg]
-    camera_node = launch_ros.actions.Node(
-        package="spot_driver",
-        executable="spot_publish_cameras",
-        name=f"image_publisher",
-        output="screen",
-        namespace=spot_name,
-        parameters=[
-            {
-                "spot_name": spot_name,
-                "image_publish_rate": image_publish_rate,
-            }
-        ]
+    publish_rgb = LaunchConfiguration("publish_rgb", default="true")
+    publish_rgb_arg = DeclareLaunchArgument(
+        "publish_rgb",
+        description="Start publishing all RGB channels on Spot cameras",
+        default_value="true",
     )
-    nodes.append(camera_node)
+
+    publish_depth = LaunchConfiguration("publish_depth", default="true")
+    publish_depth_arg = DeclareLaunchArgument(
+        "publish_depth",
+        description="Start publishing all depth channels on Spot cameras",
+        default_value="true",
+    )
+
+    publish_depth_registered = LaunchConfiguration("publish_depth_registered", default="true")
+    publish_depth_registered_arg = DeclareLaunchArgument(
+        "publish_depth_registered",
+        description="Start publishing all depth_registered channels on Spot cameras",
+        default_value="false",
+    )
+
+    nodes = [spot_name_arg, image_publish_rate_arg, publish_rgb_arg, publish_depth_arg, publish_depth_registered_arg]
+    camera_types = ["camera", "depth", "depth_registered"]
+    publish_camera_types = [publish_rgb, publish_depth, publish_depth_registered]
+    for camera_type, publish_camera_type in zip(camera_types, publish_camera_types):
+        camera_node = launch_ros.actions.Node(
+            package="spot_driver",
+            executable="spot_publish_cameras",
+            name=f"spot_image_publisher_{camera_type}",
+            output="screen",
+            namespace=spot_name,
+            parameters=[
+                {
+                    "spot_name": spot_name,
+                    "image_publish_rate": image_publish_rate,
+                    "camera_type": camera_type,
+                }
+            ],
+            condition=IfCondition(publish_camera_type)
+        )
+        nodes.append(camera_node)
 
     return launch.LaunchDescription(nodes)

--- a/spot_driver/setup.py
+++ b/spot_driver/setup.py
@@ -27,7 +27,7 @@ setup(
         'console_scripts': [
             'spot_ros2 = spot_driver.spot_ros2:main',
             'command_spot = spot_driver.command_spot_driver:main',
-            'publish_camera = spot_driver.publish_camera:main',
+            'spot_publish_cameras = spot_driver.publish_cameras:main',
         ],
     },
 )

--- a/spot_driver/setup.py
+++ b/spot_driver/setup.py
@@ -27,6 +27,7 @@ setup(
         'console_scripts': [
             'spot_ros2 = spot_driver.spot_ros2:main',
             'command_spot = spot_driver.command_spot_driver:main',
+            'publish_camera = spot_driver.publish_camera:main',
         ],
     },
 )

--- a/spot_driver/spot_driver/publish_camera.py
+++ b/spot_driver/spot_driver/publish_camera.py
@@ -1,0 +1,306 @@
+# Copyright [2023] Boston Dynamics AI Institute, Inc.
+
+import os
+import sys
+
+import rclpy
+from sensor_msgs.msg import CameraInfo, Image
+import bosdyn.client
+import bosdyn.client.util
+from bosdyn.api import image_pb2
+from bosdyn.client.image import ImageClient, build_image_request
+from google.protobuf.timestamp_pb2 import Timestamp
+from builtin_interfaces.msg import Time, Duration
+from spot_driver.ros_helpers import get_from_env_and_fall_back_to_param
+import rclpy.node
+
+
+ROTATION_ANGLE = {
+    'back_fisheye_image': 0,
+    'frontleft_fisheye_image': -78,
+    'frontright_fisheye_image': -102,
+    'left_fisheye_image': 0,
+    'right_fisheye_image': 180
+}
+
+
+def translate_ros_camera_name_to_bosdyn(camera_source: str, camera_type: str):
+    if camera_source == "back":
+        if camera_type == "camera":
+            return "back_fisheye_image"
+        elif camera_type == "depth":
+            return "back_depth"
+        else:  # self._camera_type == "depth_registered":
+            return "back_depth_in_visual_frame"
+    elif camera_source == "frontleft":
+        if camera_type == "camera":
+            return "frontleft_fisheye_image"
+        elif camera_type == "depth":
+            return "frontleft_depth"
+        else:  # self._camera_type == "depth_registered":
+            return "frontleft_depth_in_visual_frame"
+    elif camera_source == "frontright":
+        if camera_type == "camera":
+            return "frontright_fisheye_image"
+        elif camera_type == "depth":
+            return "frontright_depth"
+        else:  # self._camera_type == "depth_registered":
+            return "frontright_depth_in_visual_frame"
+    elif camera_source == "hand":
+        if camera_type == "camera":
+            return "hand_color_image"
+        elif camera_type == "depth":
+            return "hand_depth"
+        else:  # self._camera_type == "depth_registered":
+            return "hand_depth_in_hand_color_frame"
+    elif camera_source == "left":
+        if camera_type == "camera":
+            return "left_fisheye_image"
+        elif camera_type == "depth":
+            return "left_depth"
+        else:  # self._camera_type == "depth_registered":
+            return "left_depth_in_visual_frame"
+    elif camera_source == "right":
+        if camera_type == "camera":
+            return "right_fisheye_image"
+        elif camera_type == "depth":
+            return "right_depth"
+        else:  # self._camera_type == "depth_registered":
+            return "right_depth_in_visual_frame"
+
+    raise ValueError(f"Invalid camera source {camera_source} or camera_type {camera_type} supplied")
+
+
+class SpotImagePublisher(rclpy.node.Node):
+    def __init__(self):
+        # super().__init__(f"{self._spot_name}_{self._camera_source}_{self._camera_type}_image_publisher")
+        super().__init__(f"spot_image_publisher")
+        self.declare_parameter("camera_source", "")
+        self._camera_source = self.get_parameter("camera_source").value
+        self.declare_parameter("camera_type", "")
+        self._camera_type = self.get_parameter("camera_type").value
+        self.declare_parameter('spot_name', '')
+        self._spot_name = self.get_parameter('spot_name').value
+
+        self._username = get_from_env_and_fall_back_to_param("BOSDYN_CLIENT_USERNAME", self, "username", "user")
+        self._password = get_from_env_and_fall_back_to_param("BOSDYN_CLIENT_PASSWORD", self, "password", "password")
+        self._robot_hostname = get_from_env_and_fall_back_to_param("SPOT_IP", self, "hostname", "10.0.0.3")
+
+        self.declare_parameter("image_service", ImageClient.default_service_name)
+        self._image_service = self.get_parameter("image_service").value
+
+        try:
+            self._sdk = bosdyn.client.create_standard_sdk('image_publisher')
+        except Exception as e:
+            self._logger.error("Error creating SDK object: %s", e)
+            self._valid = False
+            return
+
+        # Create robot object with an image client.
+        self._robot = self._sdk.create_robot(self._robot_hostname)
+
+        try:
+            self._robot.authenticate(self._username, self._password)
+            self._robot.start_time_sync()
+        except bosdyn.client.RpcError as err:
+            self._logger.error("Failed to communicate with robot: %s", err)
+            self._valid = False
+            return
+
+        sdk = bosdyn.client.create_standard_sdk('image_capture')
+        robot = sdk.create_robot(self._robot_hostname)
+        bosdyn.client.util.authenticate(robot)
+        robot.sync_with_directory()
+        robot.time_sync.wait_for_sync()
+        self._image_client = robot.ensure_client(self._image_service)
+
+        self.declare_parameter("image_publish_rate", 10)
+        self._image_publish_rate = self.get_parameter("image_publish_rate").value
+
+        self._topic_prefix = self._frame_prefix = ''
+        if self._spot_name != "":
+            self._topic_prefix = self._frame_prefix = f"{self._spot_name}/"
+
+        # TODO: Add Hand
+        self._image_requests = []
+        self._image_publishers = {}
+        self._camera_info_publishers = {}
+        camera_sources = ["frontleft", "frontright", "left", "right", "back"]
+        # camera_types = ["camera", "depth", "depth_registered"]
+        camera_types = ["camera"]
+        for camera_source in camera_sources:
+            for camera_type in camera_types:
+                if camera_type == "camera":
+                    pixel_format = image_pb2.Image.PIXEL_FORMAT_RGB_U8
+                else:
+                    pixel_format = image_pb2.Image.PIXEL_FORMAT_DEPTH_U16
+                bosdyn_camera_source = translate_ros_camera_name_to_bosdyn(camera_source, camera_type)
+                image_request = build_image_request(bosdyn_camera_source, pixel_format=pixel_format)
+                self._image_requests.append(image_request)
+
+                self._camera_info_publishers[bosdyn_camera_source] = self.create_publisher(
+                    CameraInfo,
+                    f"{camera_type}/{camera_source}/camera_info",
+                    10,
+                )
+
+                self._image_publishers[bosdyn_camera_source] = self.create_publisher(
+                    Image,
+                    f"{camera_type}/{camera_source}/image",
+                    10,
+                )
+
+        self._image_publisher_timer = self.create_timer(1/self._image_publish_rate, self.publish_image)
+
+    def robot_to_local_time(self, timestamp):
+        """Takes a timestamp and an estimated skew and return seconds and nano seconds in local time
+
+        Args:
+            timestamp: google.protobuf.Timestamp
+        Returns:
+            google.protobuf.Timestamp
+        """
+
+        rtime = Timestamp()
+
+        time_skew = self._robot.time_sync.endpoint.clock_skew
+        rtime.seconds = timestamp.seconds - time_skew.seconds
+        rtime.nanos = timestamp.nanos - time_skew.nanos
+        if rtime.nanos < 0:
+            rtime.nanos = rtime.nanos + 1000000000
+            rtime.seconds = rtime.seconds - 1
+
+        # Workaround for timestamps being incomplete
+        if rtime.seconds < 0:
+            rtime.seconds = 0
+            rtime.nanos = 0
+
+        return rtime
+
+    def bosdyn_data_to_image_and_camera_info_msgs(self, data):
+        """Takes the image and camera data and populates the necessary ROS messages
+        Args:
+            data: Image proto
+        Returns:
+            (tuple):
+                * Image: message of the image captured
+                * CameraInfo: message to define the state and config of the camera that took the image
+        """
+        image_msg = Image()
+        local_time = self.robot_to_local_time(data.shot.acquisition_time)
+        image_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
+        image_msg.header.frame_id = self._frame_prefix + data.shot.frame_name_image_sensor
+        image_msg.height = data.shot.image.rows
+        image_msg.width = data.shot.image.cols
+
+        # Color/greyscale formats.
+        # JPEG format
+        if data.shot.image.format == image_pb2.Image.FORMAT_JPEG:
+            image_msg.encoding = "rgb8"
+            image_msg.is_bigendian = True
+            image_msg.step = 3 * data.shot.image.cols
+            image_msg.data = data.shot.image.data
+
+        # Uncompressed.  Requires pixel_format.
+        if data.shot.image.format == image_pb2.Image.FORMAT_RAW:
+            # One byte per pixel.
+            if data.shot.image.pixel_format == image_pb2.Image.PIXEL_FORMAT_GREYSCALE_U8:
+                image_msg.encoding = "mono8"
+                image_msg.is_bigendian = True
+                image_msg.step = data.shot.image.cols
+                image_msg.data = data.shot.image.data
+
+            # Three bytes per pixel.
+            if data.shot.image.pixel_format == image_pb2.Image.PIXEL_FORMAT_RGB_U8:
+                image_msg.encoding = "rgb8"
+                image_msg.is_bigendian = True
+                image_msg.step = 3 * data.shot.image.cols
+                image_msg.data = data.shot.image.data
+
+            # Four bytes per pixel.
+            if data.shot.image.pixel_format == image_pb2.Image.PIXEL_FORMAT_RGBA_U8:
+                image_msg.encoding = "rgba8"
+                image_msg.is_bigendian = True
+                image_msg.step = 4 * data.shot.image.cols
+                image_msg.data = data.shot.image.data
+
+            # Little-endian uint16 z-distance from camera (mm).
+            if data.shot.image.pixel_format == image_pb2.Image.PIXEL_FORMAT_DEPTH_U16:
+                image_msg.encoding = "16UC1"
+                image_msg.is_bigendian = False
+                image_msg.step = 2 * data.shot.image.cols
+                image_msg.data = data.shot.image.data
+
+        # camera_info_msg = createDefaulCameraInfo(camera_info_msg)
+        camera_info_msg = CameraInfo()
+        camera_info_msg.distortion_model = "plumb_bob"
+
+        camera_info_msg.d.append(0)
+        camera_info_msg.d.append(0)
+        camera_info_msg.d.append(0)
+        camera_info_msg.d.append(0)
+        camera_info_msg.d.append(0)
+
+        camera_info_msg.k[1] = 0
+        camera_info_msg.k[3] = 0
+        camera_info_msg.k[6] = 0
+        camera_info_msg.k[7] = 0
+        camera_info_msg.k[8] = 1
+
+        camera_info_msg.r[0] = 1
+        camera_info_msg.r[1] = 0
+        camera_info_msg.r[2] = 0
+        camera_info_msg.r[3] = 0
+        camera_info_msg.r[4] = 1
+        camera_info_msg.r[5] = 0
+        camera_info_msg.r[6] = 0
+        camera_info_msg.r[7] = 0
+        camera_info_msg.r[8] = 1
+
+        camera_info_msg.p[1] = 0
+        camera_info_msg.p[3] = 0
+        camera_info_msg.p[4] = 0
+        camera_info_msg.p[7] = 0
+        camera_info_msg.p[8] = 0
+        camera_info_msg.p[9] = 0
+        camera_info_msg.p[10] = 1
+        camera_info_msg.p[11] = 0
+        local_time = self.robot_to_local_time(data.shot.acquisition_time)
+        camera_info_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
+        camera_info_msg.header.frame_id = data.shot.frame_name_image_sensor
+        camera_info_msg.height = data.shot.image.rows
+        camera_info_msg.width = data.shot.image.cols
+
+        camera_info_msg.k[0] = data.source.pinhole.intrinsics.focal_length.x
+        camera_info_msg.k[2] = data.source.pinhole.intrinsics.principal_point.x
+        camera_info_msg.k[4] = data.source.pinhole.intrinsics.focal_length.y
+        camera_info_msg.k[5] = data.source.pinhole.intrinsics.principal_point.y
+
+        camera_info_msg.p[0] = data.source.pinhole.intrinsics.focal_length.x
+        camera_info_msg.p[2] = data.source.pinhole.intrinsics.principal_point.x
+        camera_info_msg.p[5] = data.source.pinhole.intrinsics.focal_length.y
+        camera_info_msg.p[6] = data.source.pinhole.intrinsics.principal_point.y
+
+        return image_msg, camera_info_msg
+
+    def publish_image(self):
+        image_responses = self._image_client.get_image(self._image_requests)
+        if len(image_responses) == 0:
+            self.get_logger().info("No images received")
+            return
+
+        for image_response in image_responses:
+            image_msg, camera_info_msg = self.bosdyn_data_to_image_and_camera_info_msgs(image_response)
+            self._image_publishers[image_response.source.name].publish(image_msg)
+            self._camera_info_publishers[image_response.source.name].publish(camera_info_msg)
+
+
+def main() -> None:
+    rclpy.init(args=sys.argv)
+    spot_image_publisher = SpotImagePublisher()
+    rclpy.spin(spot_image_publisher)
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/spot_driver/spot_driver/publish_cameras.py
+++ b/spot_driver/spot_driver/publish_cameras.py
@@ -16,15 +16,6 @@ from spot_driver.ros_helpers import get_from_env_and_fall_back_to_param
 import rclpy.node
 
 
-ROTATION_ANGLE = {
-    'back_fisheye_image': 0,
-    'frontleft_fisheye_image': -78,
-    'frontright_fisheye_image': -102,
-    'left_fisheye_image': 0,
-    'right_fisheye_image': 180
-}
-
-
 def translate_ros_camera_name_to_bosdyn(camera_source: str, camera_type: str):
     if camera_source == "back":
         if camera_type == "camera":

--- a/spot_driver/spot_driver/publish_cameras.py
+++ b/spot_driver/spot_driver/publish_cameras.py
@@ -143,7 +143,7 @@ class SpotImagePublisher(rclpy.node.Node):
 
         self._image_publisher_timer = self.create_timer(1/self._image_publish_rate, self.publish_image)
 
-    def robot_to_local_time(self, timestamp):
+    def robotToLocalTime(self, timestamp):
         """Takes a timestamp and an estimated skew and return seconds and nano seconds in local time
 
         Args:
@@ -178,7 +178,7 @@ class SpotImagePublisher(rclpy.node.Node):
                 * CameraInfo: message to define the state and config of the camera that took the image
         """
         image_msg = Image()
-        local_time = self.robot_to_local_time(data.shot.acquisition_time)
+        local_time = self.robotToLocalTime(data.shot.acquisition_time)
         image_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
         image_msg.header.frame_id = self._frame_prefix + data.shot.frame_name_image_sensor
         image_msg.height = data.shot.image.rows
@@ -256,7 +256,7 @@ class SpotImagePublisher(rclpy.node.Node):
         camera_info_msg.p[9] = 0
         camera_info_msg.p[10] = 1
         camera_info_msg.p[11] = 0
-        local_time = self.robot_to_local_time(data.shot.acquisition_time)
+        local_time = self.robotToLocalTime(data.shot.acquisition_time)
         camera_info_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
         camera_info_msg.header.frame_id = data.shot.frame_name_image_sensor
         camera_info_msg.height = data.shot.image.rows

--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -1,6 +1,5 @@
 import os
 import time
-import traceback
 import rclpy
 from builtin_interfaces.msg import Time, Duration
 

--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -1,9 +1,6 @@
 import os
 import time
 import traceback
-
-import cv2
-
 import rclpy
 from builtin_interfaces.msg import Time, Duration
 
@@ -156,7 +153,7 @@ def bosdyn_data_to_image_and_camera_info_msgs(data: image_pb2.ImageResponse, spo
         image_msg.encoding = "rgb8"
         image_msg.is_bigendian = True
         image_msg.step = 3 * data.shot.image.cols
-        image_msg.data = cv2.imdecode(data.shot.image.data, -1)
+        image_msg.data = data.shot.image.data
 
     # Uncompressed.  Requires pixel_format.
     if data.shot.image.format == image_pb2.Image.FORMAT_RAW:
@@ -172,7 +169,7 @@ def bosdyn_data_to_image_and_camera_info_msgs(data: image_pb2.ImageResponse, spo
             image_msg.encoding = "rgb8"
             image_msg.is_bigendian = True
             image_msg.step = 3 * data.shot.image.cols
-            image_msg.data = cv2.imdecode(data.shot.image.data, -1)
+            image_msg.data = data.shot.image.data
 
         # Four bytes per pixel.
         if data.shot.image.pixel_format == image_pb2.Image.PIXEL_FORMAT_RGBA_U8:

--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -140,7 +140,7 @@ def bosdyn_data_to_image_and_camera_info_msgs(data: image_pb2.ImageResponse, spo
             * CameraInfo: message to define the state and config of the camera that took the image
     """
     image_msg = Image()
-    local_time = spot_wrapper.robot_to_local_time(data.shot.acquisition_time)
+    local_time = spot_wrapper.robotToLocalTime(data.shot.acquisition_time)
     image_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
     image_msg.header.frame_id = spot_wrapper.frame_prefix + data.shot.frame_name_image_sensor
     image_msg.height = data.shot.image.rows
@@ -218,7 +218,7 @@ def bosdyn_data_to_image_and_camera_info_msgs(data: image_pb2.ImageResponse, spo
     camera_info_msg.p[9] = 0
     camera_info_msg.p[10] = 1
     camera_info_msg.p[11] = 0
-    local_time = spot_wrapper.robot_to_local_time(data.shot.acquisition_time)
+    local_time = spot_wrapper.robotToLocalTime(data.shot.acquisition_time)
     camera_info_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
     camera_info_msg.header.frame_id = data.shot.frame_name_image_sensor
     camera_info_msg.height = data.shot.image.rows
@@ -246,7 +246,7 @@ def GetJointStatesFromState(state, spot_wrapper):
         JointState message
     """
     joint_state = JointState()
-    local_time = spot_wrapper.robot_to_local_time(state.kinematic_state.acquisition_timestamp)
+    local_time = spot_wrapper.robotToLocalTime(state.kinematic_state.acquisition_timestamp)
     joint_state.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
     for joint in state.kinematic_state.joint_states:
         joint_state.name.append(friendly_joint_names.get(joint.name, "ERROR"))
@@ -267,7 +267,7 @@ def GetEStopStateFromState(state, spot_wrapper):
     estop_array_msg = EStopStateArray()
     for estop in state.estop_states:
         estop_msg = EStopState()
-        local_time = spot_wrapper.robot_to_local_time(estop.timestamp)
+        local_time = spot_wrapper.robotToLocalTime(estop.timestamp)
         estop_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
         estop_msg.name = estop.name
         estop_msg.type = estop.type
@@ -305,7 +305,7 @@ def GetOdomTwistFromState(state, spot_wrapper):
         TwistWithCovarianceStamped message
     """
     twist_odom_msg = TwistWithCovarianceStamped()
-    local_time = spot_wrapper.robot_to_local_time(state.kinematic_state.acquisition_timestamp)
+    local_time = spot_wrapper.robotToLocalTime(state.kinematic_state.acquisition_timestamp)
     twist_odom_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
     twist_odom_msg.twist.twist.linear.x = state.kinematic_state.velocity_of_body_in_odom.linear.x
     twist_odom_msg.twist.twist.linear.y = state.kinematic_state.velocity_of_body_in_odom.linear.y
@@ -324,7 +324,7 @@ def GetOdomFromState(state, spot_wrapper, use_vision=True):
         Odometry message
     """
     odom_msg = Odometry()
-    local_time = spot_wrapper.robot_to_local_time(state.kinematic_state.acquisition_timestamp)
+    local_time = spot_wrapper.robotToLocalTime(state.kinematic_state.acquisition_timestamp)
     odom_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
     if use_vision == True:
         odom_msg.header.frame_id = spot_wrapper.frame_prefix + 'vision'
@@ -380,7 +380,7 @@ def GetTFFromState(state, spot_wrapper, inverse_target_frame):
             try:
                 transform = state.kinematic_state.transforms_snapshot.child_to_parent_edge_map.get(
                     frame_name)
-                local_time = spot_wrapper.robot_to_local_time(
+                local_time = spot_wrapper.robotToLocalTime(
                     state.kinematic_state.acquisition_timestamp)
                 tf_time = Time(sec=local_time.seconds, nanosec=local_time.nanos)
                 if inverse_target_frame == frame_name:
@@ -426,7 +426,7 @@ def GetTFFromWorldObjects(world_objects, spot_wrapper, parent_frame):
                 spot_parent_frame = parent_frame[parent_frame.rfind('/') + 1:]
                 transform = get_a_tform_b(world_object.transforms_snapshot, spot_parent_frame,
                                           frame)
-                local_time = spot_wrapper.robot_to_local_time(world_object.acquisition_time)
+                local_time = spot_wrapper.robotToLocalTime(world_object.acquisition_time)
                 tf_time = Time(sec=local_time.seconds, nanosec=local_time.nanos)
                 new_tf = populateTransformStamped(tf_time,
                                                   parent_frame,
@@ -450,7 +450,7 @@ def GetBatteryStatesFromState(state, spot_wrapper):
     battery_states_array_msg = BatteryStateArray()
     for battery in state.battery_states:
         battery_msg = BatteryState()
-        local_time = spot_wrapper.robot_to_local_time(battery.timestamp)
+        local_time = spot_wrapper.robotToLocalTime(battery.timestamp)
         battery_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
 
         battery_msg.identifier = battery.identifier
@@ -475,7 +475,7 @@ def GetPowerStatesFromState(state, spot_wrapper):
         PowerState message
     """
     power_state_msg = PowerState()
-    local_time = spot_wrapper.robot_to_local_time(state.power_state.timestamp)
+    local_time = spot_wrapper.robotToLocalTime(state.power_state.timestamp)
     power_state_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
     power_state_msg.motor_power_state = state.power_state.motor_power_state
     power_state_msg.shore_power_state = state.power_state.shore_power_state
@@ -498,7 +498,7 @@ def getBehaviorFaults(behavior_faults, spot_wrapper):
     for fault in behavior_faults:
         new_fault = BehaviorFault()
         new_fault.behavior_fault_id = fault.behavior_fault_id
-        local_time = spot_wrapper.robot_to_local_time(fault.onset_timestamp)
+        local_time = spot_wrapper.robotToLocalTime(fault.onset_timestamp)
         new_fault.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
         new_fault.cause = fault.cause
         new_fault.status = fault.status
@@ -519,7 +519,7 @@ def getSystemFaults(system_faults, spot_wrapper):
     for fault in system_faults:
         new_fault = SystemFault()
         new_fault.name = fault.name
-        local_time = spot_wrapper.robot_to_local_time(fault.onset_timestamp)
+        local_time = spot_wrapper.robotToLocalTime(fault.onset_timestamp)
         new_fault.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
         new_fault.duration = Duration(sec=fault.duration.seconds, nanosec=fault.duration.nanos)
         new_fault.code = fault.code

--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -127,7 +127,7 @@ def createDefaulCameraInfo():
 
     return camera_info_msg
 
-def getImageMsg(data, spot_wrapper):
+def getImageMsg(data, spot_wrapper, frame_prefix=''):
     """Takes the imag and  camera data and populates the necessary ROS messages
     Args:
         data: Image proto
@@ -140,7 +140,7 @@ def getImageMsg(data, spot_wrapper):
     image_msg = Image()
     local_time = spot_wrapper.robotToLocalTime(data.shot.acquisition_time)
     image_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
-    image_msg.header.frame_id = data.shot.frame_name_image_sensor
+    image_msg.header.frame_id = frame_prefix + data.shot.frame_name_image_sensor
     image_msg.height = data.shot.image.rows
     image_msg.width = data.shot.image.cols
 

--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -1,6 +1,9 @@
 import os
 import time
 import traceback
+
+import cv2
+
 import rclpy
 from builtin_interfaces.msg import Time, Duration
 
@@ -153,7 +156,7 @@ def bosdyn_data_to_image_and_camera_info_msgs(data: image_pb2.ImageResponse, spo
         image_msg.encoding = "rgb8"
         image_msg.is_bigendian = True
         image_msg.step = 3 * data.shot.image.cols
-        image_msg.data = data.shot.image.data
+        image_msg.data = cv2.imdecode(data.shot.image.data, -1)
 
     # Uncompressed.  Requires pixel_format.
     if data.shot.image.format == image_pb2.Image.FORMAT_RAW:
@@ -169,7 +172,7 @@ def bosdyn_data_to_image_and_camera_info_msgs(data: image_pb2.ImageResponse, spo
             image_msg.encoding = "rgb8"
             image_msg.is_bigendian = True
             image_msg.step = 3 * data.shot.image.cols
-            image_msg.data = data.shot.image.data
+            image_msg.data = cv2.imdecode(data.shot.image.data, -1)
 
         # Four bytes per pixel.
         if data.shot.image.pixel_format == image_pb2.Image.PIXEL_FORMAT_RGBA_U8:

--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -29,6 +29,8 @@ from bosdyn.api import image_pb2
 from bosdyn.client.math_helpers import SE3Pose
 from bosdyn.client.frame_helpers import get_odom_tform_body, get_vision_tform_body, get_a_tform_b
 
+from .spot_wrapper import SpotWrapper
+
 try:
     from conversions import ros_transform_to_se3_pose
 except ModuleNotFoundError:
@@ -89,8 +91,8 @@ def populateTransformStamped(time, parent_frame, child_frame, transform, frame_p
 
     return new_tf
 
-def createDefaulCameraInfo():
 
+def createDefaulCameraInfo():
     camera_info_msg = CameraInfo()
     camera_info_msg.distortion_model = "plumb_bob"
 
@@ -127,20 +129,21 @@ def createDefaulCameraInfo():
 
     return camera_info_msg
 
-def getImageMsg(data, spot_wrapper, frame_prefix=''):
-    """Takes the imag and  camera data and populates the necessary ROS messages
+
+def bosdyn_data_to_image_and_camera_info_msgs(data: image_pb2.ImageResponse, spot_wrapper: SpotWrapper):
+    """Takes the image and camera data and populates the necessary ROS messages
     Args:
+        spot_wrapper: SpotWrapper
         data: Image proto
-        spot_wrapper: A SpotWrapper object
     Returns:
         (tuple):
             * Image: message of the image captured
             * CameraInfo: message to define the state and config of the camera that took the image
     """
     image_msg = Image()
-    local_time = spot_wrapper.robotToLocalTime(data.shot.acquisition_time)
+    local_time = spot_wrapper.robot_to_local_time(data.shot.acquisition_time)
     image_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
-    image_msg.header.frame_id = frame_prefix + data.shot.frame_name_image_sensor
+    image_msg.header.frame_id = spot_wrapper.frame_prefix + data.shot.frame_name_image_sensor
     image_msg.height = data.shot.image.rows
     image_msg.width = data.shot.image.cols
 
@@ -182,7 +185,7 @@ def getImageMsg(data, spot_wrapper, frame_prefix=''):
             image_msg.step = 2 * data.shot.image.cols
             image_msg.data = data.shot.image.data
 
-    #camera_info_msg = createDefaulCameraInfo(camera_info_msg)
+    # camera_info_msg = createDefaulCameraInfo(camera_info_msg)
     camera_info_msg = CameraInfo()
     camera_info_msg.distortion_model = "plumb_bob"
 
@@ -216,7 +219,7 @@ def getImageMsg(data, spot_wrapper, frame_prefix=''):
     camera_info_msg.p[9] = 0
     camera_info_msg.p[10] = 1
     camera_info_msg.p[11] = 0
-    local_time = spot_wrapper.robotToLocalTime(data.shot.acquisition_time)
+    local_time = spot_wrapper.robot_to_local_time(data.shot.acquisition_time)
     camera_info_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
     camera_info_msg.header.frame_id = data.shot.frame_name_image_sensor
     camera_info_msg.height = data.shot.image.rows
@@ -234,6 +237,7 @@ def getImageMsg(data, spot_wrapper, frame_prefix=''):
 
     return image_msg, camera_info_msg
 
+
 def GetJointStatesFromState(state, spot_wrapper):
     """Maps joint state data from robot state proto to ROS JointState message
     Args:
@@ -243,7 +247,7 @@ def GetJointStatesFromState(state, spot_wrapper):
         JointState message
     """
     joint_state = JointState()
-    local_time = spot_wrapper.robotToLocalTime(state.kinematic_state.acquisition_timestamp)
+    local_time = spot_wrapper.robot_to_local_time(state.kinematic_state.acquisition_timestamp)
     joint_state.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
     for joint in state.kinematic_state.joint_states:
         joint_state.name.append(friendly_joint_names.get(joint.name, "ERROR"))
@@ -264,7 +268,7 @@ def GetEStopStateFromState(state, spot_wrapper):
     estop_array_msg = EStopStateArray()
     for estop in state.estop_states:
         estop_msg = EStopState()
-        local_time = spot_wrapper.robotToLocalTime(estop.timestamp)
+        local_time = spot_wrapper.robot_to_local_time(estop.timestamp)
         estop_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
         estop_msg.name = estop.name
         estop_msg.type = estop.type
@@ -302,7 +306,7 @@ def GetOdomTwistFromState(state, spot_wrapper):
         TwistWithCovarianceStamped message
     """
     twist_odom_msg = TwistWithCovarianceStamped()
-    local_time = spot_wrapper.robotToLocalTime(state.kinematic_state.acquisition_timestamp)
+    local_time = spot_wrapper.robot_to_local_time(state.kinematic_state.acquisition_timestamp)
     twist_odom_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
     twist_odom_msg.twist.twist.linear.x = state.kinematic_state.velocity_of_body_in_odom.linear.x
     twist_odom_msg.twist.twist.linear.y = state.kinematic_state.velocity_of_body_in_odom.linear.y
@@ -321,7 +325,7 @@ def GetOdomFromState(state, spot_wrapper, use_vision=True):
         Odometry message
     """
     odom_msg = Odometry()
-    local_time = spot_wrapper.robotToLocalTime(state.kinematic_state.acquisition_timestamp)
+    local_time = spot_wrapper.robot_to_local_time(state.kinematic_state.acquisition_timestamp)
     odom_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
     if use_vision == True:
         odom_msg.header.frame_id = spot_wrapper.frame_prefix + 'vision'
@@ -377,7 +381,7 @@ def GetTFFromState(state, spot_wrapper, inverse_target_frame):
             try:
                 transform = state.kinematic_state.transforms_snapshot.child_to_parent_edge_map.get(
                     frame_name)
-                local_time = spot_wrapper.robotToLocalTime(
+                local_time = spot_wrapper.robot_to_local_time(
                     state.kinematic_state.acquisition_timestamp)
                 tf_time = Time(sec=local_time.seconds, nanosec=local_time.nanos)
                 if inverse_target_frame == frame_name:
@@ -423,7 +427,7 @@ def GetTFFromWorldObjects(world_objects, spot_wrapper, parent_frame):
                 spot_parent_frame = parent_frame[parent_frame.rfind('/') + 1:]
                 transform = get_a_tform_b(world_object.transforms_snapshot, spot_parent_frame,
                                           frame)
-                local_time = spot_wrapper.robotToLocalTime(world_object.acquisition_time)
+                local_time = spot_wrapper.robot_to_local_time(world_object.acquisition_time)
                 tf_time = Time(sec=local_time.seconds, nanosec=local_time.nanos)
                 new_tf = populateTransformStamped(tf_time,
                                                   parent_frame,
@@ -447,7 +451,7 @@ def GetBatteryStatesFromState(state, spot_wrapper):
     battery_states_array_msg = BatteryStateArray()
     for battery in state.battery_states:
         battery_msg = BatteryState()
-        local_time = spot_wrapper.robotToLocalTime(battery.timestamp)
+        local_time = spot_wrapper.robot_to_local_time(battery.timestamp)
         battery_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
 
         battery_msg.identifier = battery.identifier
@@ -472,7 +476,7 @@ def GetPowerStatesFromState(state, spot_wrapper):
         PowerState message
     """
     power_state_msg = PowerState()
-    local_time = spot_wrapper.robotToLocalTime(state.power_state.timestamp)
+    local_time = spot_wrapper.robot_to_local_time(state.power_state.timestamp)
     power_state_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
     power_state_msg.motor_power_state = state.power_state.motor_power_state
     power_state_msg.shore_power_state = state.power_state.shore_power_state
@@ -495,7 +499,7 @@ def getBehaviorFaults(behavior_faults, spot_wrapper):
     for fault in behavior_faults:
         new_fault = BehaviorFault()
         new_fault.behavior_fault_id = fault.behavior_fault_id
-        local_time = spot_wrapper.robotToLocalTime(fault.onset_timestamp)
+        local_time = spot_wrapper.robot_to_local_time(fault.onset_timestamp)
         new_fault.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
         new_fault.cause = fault.cause
         new_fault.status = fault.status
@@ -516,7 +520,7 @@ def getSystemFaults(system_faults, spot_wrapper):
     for fault in system_faults:
         new_fault = SystemFault()
         new_fault.name = fault.name
-        local_time = spot_wrapper.robotToLocalTime(fault.onset_timestamp)
+        local_time = spot_wrapper.robot_to_local_time(fault.onset_timestamp)
         new_fault.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
         new_fault.duration = Duration(sec=fault.duration.seconds, nanosec=fault.duration.nanos)
         new_fault.code = fault.code

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -157,7 +157,7 @@ class SpotROS:
         metrics = self.spot_wrapper.metrics
         if metrics:
             metrics_msg = Metrics()
-            local_time = self.spot_wrapper.robot_to_local_time(metrics.timestamp)
+            local_time = self.spot_wrapper.robotToLocalTime(metrics.timestamp)
             metrics_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
 
             for metric in metrics.metrics:
@@ -916,7 +916,7 @@ class SpotROS:
                 continue
 
             transform = image_data.shot.transforms_snapshot.child_to_parent_edge_map.get(frame_name)
-            local_time = self.spot_wrapper.robot_to_local_time(image_data.shot.acquisition_time)
+            local_time = self.spot_wrapper.robotToLocalTime(image_data.shot.acquisition_time)
             tf_time = Time(sec=local_time.seconds, nanosec=local_time.nanos)
             static_tf = populateTransformStamped(tf_time, transform.parent_frame_name, frame_name,
                                                  transform.parent_tform_child, frame_prefix)

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -245,11 +245,19 @@ class SpotROS():
             image_msg3, camera_info_msg3 = getImageMsg(data[3], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.frontright_depth_pub.publish(image_msg3)
             self.frontright_depth_info_pub.publish(camera_info_msg3)
+            image_msg4, camera_info_msg4 = getImageMsg(data[4], self.spot_wrapper, frame_prefix=self.frame_prefix)
+            self.frontright_depth_registered_pub.publish(image_msg4)
+            self.frontright_depth_registered_info_pub.publish(camera_info_msg4)
+            image_msg5, camera_info_msg5 = getImageMsg(data[5], self.spot_wrapper, frame_prefix=self.frame_prefix)
+            self.frontright_depth_registered_pub.publish(image_msg5)
+            self.frontright_depth_registered_info_pub.publish(camera_info_msg5)
 
             self.populate_camera_static_transforms(data[0])
             self.populate_camera_static_transforms(data[1])
             self.populate_camera_static_transforms(data[2])
             self.populate_camera_static_transforms(data[3])
+            self.populate_camera_static_transforms(data[4])
+            self.populate_camera_static_transforms(data[5])
 
     def SideImageCB(self, results):
         """Callback for when the Spot Wrapper gets new side image data.
@@ -270,11 +278,19 @@ class SpotROS():
             image_msg3, camera_info_msg3 = getImageMsg(data[3], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.right_depth_pub.publish(image_msg3)
             self.right_depth_info_pub.publish(camera_info_msg3)
+            image_msg4, camera_info_msg4 = getImageMsg(data[4], self.spot_wrapper, frame_prefix=self.frame_prefix)
+            self.right_depth_registered_pub.publish(image_msg4)
+            self.right_depth_registered_info_pub.publish(camera_info_msg4)
+            image_msg5, camera_info_msg5 = getImageMsg(data[5], self.spot_wrapper, frame_prefix=self.frame_prefix)
+            self.right_depth_registered_pub.publish(image_msg5)
+            self.right_depth_registered_info_pub.publish(camera_info_msg5)
 
             self.populate_camera_static_transforms(data[0])
             self.populate_camera_static_transforms(data[1])
             self.populate_camera_static_transforms(data[2])
             self.populate_camera_static_transforms(data[3])
+            self.populate_camera_static_transforms(data[4])
+            self.populate_camera_static_transforms(data[5])
 
     def RearImageCB(self, results):
         """Callback for when the Spot Wrapper gets new rear image data.
@@ -289,9 +305,13 @@ class SpotROS():
             mage_msg1, camera_info_msg1 = getImageMsg(data[1], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.back_depth_pub.publish(mage_msg1)
             self.back_depth_info_pub.publish(camera_info_msg1)
+            mage_msg2, camera_info_msg2 = getImageMsg(data[2], self.spot_wrapper, frame_prefix=self.frame_prefix)
+            self.back_depth_registered_pub.publish(mage_msg2)
+            self.back_depth_registered_info_pub.publish(camera_info_msg2)
 
             self.populate_camera_static_transforms(data[0])
             self.populate_camera_static_transforms(data[1])
+            self.populate_camera_static_transforms(data[2])
 
     def service_wrapper(self, name, handler, request, response):
         if self.spot_wrapper is None:
@@ -1068,6 +1088,12 @@ def main(args=None):
         spot_ros.frontright_depth_pub = node.create_publisher(Image, 'depth/frontright/image', 1)
         spot_ros.left_depth_pub = node.create_publisher(Image, 'depth/left/image', 1)
         spot_ros.right_depth_pub = node.create_publisher(Image, 'depth/right/image', 1)
+        # Depth Registered #
+        spot_ros.back_depth_registered_pub = node.create_publisher(Image, 'depth_registered/back/image', 1)
+        spot_ros.frontleft_depth_registered_pub = node.create_publisher(Image, 'depth_registered/frontleft/image', 1)
+        spot_ros.frontright_depth_registered_pub = node.create_publisher(Image, 'depth_registered/frontright/image', 1)
+        spot_ros.left_depth_registered_pub = node.create_publisher(Image, 'depth_registered/left/image', 1)
+        spot_ros.right_depth_registered_pub = node.create_publisher(Image, 'depth_registered/right/image', 1)
 
         # Image Camera Info #
         spot_ros.back_image_info_pub = node.create_publisher(CameraInfo, 'camera/back/camera_info', 1)
@@ -1081,6 +1107,17 @@ def main(args=None):
         spot_ros.frontright_depth_info_pub = node.create_publisher(CameraInfo, 'depth/frontright/camera_info', 1)
         spot_ros.left_depth_info_pub = node.create_publisher(CameraInfo, 'depth/left/camera_info', 1)
         spot_ros.right_depth_info_pub = node.create_publisher(CameraInfo, 'depth/right/camera_info', 1)
+        # Depth Registered Camera Info #
+        spot_ros.back_depth_registered_info_pub = \
+            node.create_publisher(CameraInfo, 'depth_registered/back/camera_info', 1)
+        spot_ros.frontleft_depth_registered_info_pub = \
+            node.create_publisher(CameraInfo, 'depth_registered/frontleft/camera_info', 1)
+        spot_ros.frontright_depth_registered_info_pub = \
+            node.create_publisher(CameraInfo, 'depth_registered/frontright/camera_info', 1)
+        spot_ros.left_depth_registered_info_pub = \
+            node.create_publisher(CameraInfo, 'depth_registered/left/camera_info', 1)
+        spot_ros.right_depth_registered_info_pub = \
+            node.create_publisher(CameraInfo, 'depth_registered/right/camera_info', 1)
 
         # Status Publishers #
         spot_ros.joint_state_pub = node.create_publisher(JointState, 'joint_states', 1)

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -107,9 +107,6 @@ class SpotROS():
         self.callbacks["metrics"] = self.MetricsCB
         self.callbacks["lease"] = self.LeaseCB
         self.callbacks["world_objects"] = self.WorldObjectsCB
-        self.callbacks["front_image"] = self.FrontImageCB
-        self.callbacks["side_image"] = self.SideImageCB
-        self.callbacks["rear_image"] = self.RearImageCB
 
     def RobotStateCB(self, results):
         """Callback for when the Spot Wrapper gets new robot state data.
@@ -225,93 +222,6 @@ class SpotROS():
                                            self.mode_parent_odom_tf.value)
             if len(tf_msg.transforms) > 0:
                 self.dynamic_broadcaster.sendTransform(tf_msg.transforms)
-
-    def FrontImageCB(self, results):
-        """Callback for when the Spot Wrapper gets new front image data.
-        Args:
-            results: FutureWrapper object of AsyncPeriodicQuery callback
-        """
-        data = self.spot_wrapper.front_images
-        if data:
-            image_msg0, camera_info_msg0 = getImageMsg(data[0], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            self.frontleft_image_pub.publish(image_msg0)
-            self.frontleft_image_info_pub.publish(camera_info_msg0)
-            image_msg1, camera_info_msg1 = getImageMsg(data[1], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            self.frontright_image_pub.publish(image_msg1)
-            self.frontright_image_info_pub.publish(camera_info_msg1)
-            image_msg2, camera_info_msg2 = getImageMsg(data[2], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            self.frontleft_depth_pub.publish(image_msg2)
-            self.frontleft_depth_info_pub.publish(camera_info_msg2)
-            image_msg3, camera_info_msg3 = getImageMsg(data[3], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            self.frontright_depth_pub.publish(image_msg3)
-            self.frontright_depth_info_pub.publish(camera_info_msg3)
-            # image_msg4, camera_info_msg4 = getImageMsg(data[4], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            # self.frontright_depth_registered_pub.publish(image_msg4)
-            # self.frontright_depth_registered_info_pub.publish(camera_info_msg4)
-            # image_msg5, camera_info_msg5 = getImageMsg(data[5], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            # self.frontright_depth_registered_pub.publish(image_msg5)
-            # self.frontright_depth_registered_info_pub.publish(camera_info_msg5)
-
-            self.populate_camera_static_transforms(data[0])
-            self.populate_camera_static_transforms(data[1])
-            self.populate_camera_static_transforms(data[2])
-            self.populate_camera_static_transforms(data[3])
-            # self.populate_camera_static_transforms(data[4])
-            # self.populate_camera_static_transforms(data[5])
-
-    def SideImageCB(self, results):
-        """Callback for when the Spot Wrapper gets new side image data.
-        Args:
-            results: FutureWrapper object of AsyncPeriodicQuery callback
-        """
-        data = self.spot_wrapper.side_images
-        if data:
-            image_msg0, camera_info_msg0 = getImageMsg(data[0], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            self.left_image_pub.publish(image_msg0)
-            self.left_image_info_pub.publish(camera_info_msg0)
-            image_msg1, camera_info_msg1 = getImageMsg(data[1], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            self.right_image_pub.publish(image_msg1)
-            self.right_image_info_pub.publish(camera_info_msg1)
-            image_msg2, camera_info_msg2 = getImageMsg(data[2], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            self.left_depth_pub.publish(image_msg2)
-            self.left_depth_info_pub.publish(camera_info_msg2)
-            image_msg3, camera_info_msg3 = getImageMsg(data[3], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            self.right_depth_pub.publish(image_msg3)
-            self.right_depth_info_pub.publish(camera_info_msg3)
-            # image_msg4, camera_info_msg4 = getImageMsg(data[4], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            # self.right_depth_registered_pub.publish(image_msg4)
-            # self.right_depth_registered_info_pub.publish(camera_info_msg4)
-            # image_msg5, camera_info_msg5 = getImageMsg(data[5], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            # self.right_depth_registered_pub.publish(image_msg5)
-            # self.right_depth_registered_info_pub.publish(camera_info_msg5)
-
-            self.populate_camera_static_transforms(data[0])
-            self.populate_camera_static_transforms(data[1])
-            self.populate_camera_static_transforms(data[2])
-            self.populate_camera_static_transforms(data[3])
-            # self.populate_camera_static_transforms(data[4])
-            # self.populate_camera_static_transforms(data[5])
-
-    def RearImageCB(self, results):
-        """Callback for when the Spot Wrapper gets new rear image data.
-        Args:
-            results: FutureWrapper object of AsyncPeriodicQuery callback
-        """
-        data = self.spot_wrapper.rear_images
-        if data:
-            mage_msg0, camera_info_msg0 = getImageMsg(data[0], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            self.back_image_pub.publish(mage_msg0)
-            self.back_image_info_pub.publish(camera_info_msg0)
-            mage_msg1, camera_info_msg1 = getImageMsg(data[1], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            self.back_depth_pub.publish(mage_msg1)
-            self.back_depth_info_pub.publish(camera_info_msg1)
-            # mage_msg2, camera_info_msg2 = getImageMsg(data[2], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            # self.back_depth_registered_pub.publish(mage_msg2)
-            # self.back_depth_registered_info_pub.publish(camera_info_msg2)
-
-            self.populate_camera_static_transforms(data[0])
-            self.populate_camera_static_transforms(data[1])
-            # self.populate_camera_static_transforms(data[2])
 
     def service_wrapper(self, name, handler, request, response):
         if self.spot_wrapper is None:
@@ -1076,49 +986,6 @@ def main(args=None):
         spot_ros.spot_wrapper = None
     # spot_ros.spot_wrapper = spot_wrapper
     if spot_ros.spot_wrapper is None or spot_ros.spot_wrapper.is_valid:
-        # Images #
-        spot_ros.back_image_pub = node.create_publisher(Image, 'camera/back/image', 1)
-        spot_ros.frontleft_image_pub = node.create_publisher(Image, 'camera/frontleft/image', 1)
-        spot_ros.frontright_image_pub = node.create_publisher(Image, 'camera/frontright/image', 1)
-        spot_ros.left_image_pub = node.create_publisher(Image, 'camera/left/image', 1)
-        spot_ros.right_image_pub = node.create_publisher(Image, 'camera/right/image', 1)
-        # Depth #
-        spot_ros.back_depth_pub = node.create_publisher(Image, 'depth/back/image', 1)
-        spot_ros.frontleft_depth_pub = node.create_publisher(Image, 'depth/frontleft/image', 1)
-        spot_ros.frontright_depth_pub = node.create_publisher(Image, 'depth/frontright/image', 1)
-        spot_ros.left_depth_pub = node.create_publisher(Image, 'depth/left/image', 1)
-        spot_ros.right_depth_pub = node.create_publisher(Image, 'depth/right/image', 1)
-        # Depth Registered #
-        # spot_ros.back_depth_registered_pub = node.create_publisher(Image, 'depth_registered/back/image', 1)
-        # spot_ros.frontleft_depth_registered_pub = node.create_publisher(Image, 'depth_registered/frontleft/image', 1)
-        # spot_ros.frontright_depth_registered_pub = node.create_publisher(Image, 'depth_registered/frontright/image', 1)
-        # spot_ros.left_depth_registered_pub = node.create_publisher(Image, 'depth_registered/left/image', 1)
-        # spot_ros.right_depth_registered_pub = node.create_publisher(Image, 'depth_registered/right/image', 1)
-
-        # Image Camera Info #
-        spot_ros.back_image_info_pub = node.create_publisher(CameraInfo, 'camera/back/camera_info', 1)
-        spot_ros.frontleft_image_info_pub = node.create_publisher(CameraInfo, 'camera/frontleft/camera_info', 1)
-        spot_ros.frontright_image_info_pub = node.create_publisher(CameraInfo, 'camera/frontright/camera_info', 1)
-        spot_ros.left_image_info_pub = node.create_publisher(CameraInfo, 'camera/left/camera_info', 1)
-        spot_ros.right_image_info_pub = node.create_publisher(CameraInfo, 'camera/right/camera_info', 1)
-        # Depth Camera Info #
-        spot_ros.back_depth_info_pub = node.create_publisher(CameraInfo, 'depth/back/camera_info', 1)
-        spot_ros.frontleft_depth_info_pub = node.create_publisher(CameraInfo, 'depth/frontleft/camera_info', 1)
-        spot_ros.frontright_depth_info_pub = node.create_publisher(CameraInfo, 'depth/frontright/camera_info', 1)
-        spot_ros.left_depth_info_pub = node.create_publisher(CameraInfo, 'depth/left/camera_info', 1)
-        spot_ros.right_depth_info_pub = node.create_publisher(CameraInfo, 'depth/right/camera_info', 1)
-        # Depth Registered Camera Info #
-        # spot_ros.back_depth_registered_info_pub = \
-        #     node.create_publisher(CameraInfo, 'depth_registered/back/camera_info', 1)
-        # spot_ros.frontleft_depth_registered_info_pub = \
-        #     node.create_publisher(CameraInfo, 'depth_registered/frontleft/camera_info', 1)
-        # spot_ros.frontright_depth_registered_info_pub = \
-        #     node.create_publisher(CameraInfo, 'depth_registered/frontright/camera_info', 1)
-        # spot_ros.left_depth_registered_info_pub = \
-        #     node.create_publisher(CameraInfo, 'depth_registered/left/camera_info', 1)
-        # spot_ros.right_depth_registered_info_pub = \
-        #     node.create_publisher(CameraInfo, 'depth_registered/right/camera_info', 1)
-
         # Status Publishers #
         spot_ros.joint_state_pub = node.create_publisher(JointState, 'joint_states', 1)
         spot_ros.dynamic_broadcaster = tf2_ros.TransformBroadcaster(node)

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -245,19 +245,19 @@ class SpotROS():
             image_msg3, camera_info_msg3 = getImageMsg(data[3], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.frontright_depth_pub.publish(image_msg3)
             self.frontright_depth_info_pub.publish(camera_info_msg3)
-            image_msg4, camera_info_msg4 = getImageMsg(data[4], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            self.frontright_depth_registered_pub.publish(image_msg4)
-            self.frontright_depth_registered_info_pub.publish(camera_info_msg4)
-            image_msg5, camera_info_msg5 = getImageMsg(data[5], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            self.frontright_depth_registered_pub.publish(image_msg5)
-            self.frontright_depth_registered_info_pub.publish(camera_info_msg5)
+            # image_msg4, camera_info_msg4 = getImageMsg(data[4], self.spot_wrapper, frame_prefix=self.frame_prefix)
+            # self.frontright_depth_registered_pub.publish(image_msg4)
+            # self.frontright_depth_registered_info_pub.publish(camera_info_msg4)
+            # image_msg5, camera_info_msg5 = getImageMsg(data[5], self.spot_wrapper, frame_prefix=self.frame_prefix)
+            # self.frontright_depth_registered_pub.publish(image_msg5)
+            # self.frontright_depth_registered_info_pub.publish(camera_info_msg5)
 
             self.populate_camera_static_transforms(data[0])
             self.populate_camera_static_transforms(data[1])
             self.populate_camera_static_transforms(data[2])
             self.populate_camera_static_transforms(data[3])
-            self.populate_camera_static_transforms(data[4])
-            self.populate_camera_static_transforms(data[5])
+            # self.populate_camera_static_transforms(data[4])
+            # self.populate_camera_static_transforms(data[5])
 
     def SideImageCB(self, results):
         """Callback for when the Spot Wrapper gets new side image data.
@@ -278,19 +278,19 @@ class SpotROS():
             image_msg3, camera_info_msg3 = getImageMsg(data[3], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.right_depth_pub.publish(image_msg3)
             self.right_depth_info_pub.publish(camera_info_msg3)
-            image_msg4, camera_info_msg4 = getImageMsg(data[4], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            self.right_depth_registered_pub.publish(image_msg4)
-            self.right_depth_registered_info_pub.publish(camera_info_msg4)
-            image_msg5, camera_info_msg5 = getImageMsg(data[5], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            self.right_depth_registered_pub.publish(image_msg5)
-            self.right_depth_registered_info_pub.publish(camera_info_msg5)
+            # image_msg4, camera_info_msg4 = getImageMsg(data[4], self.spot_wrapper, frame_prefix=self.frame_prefix)
+            # self.right_depth_registered_pub.publish(image_msg4)
+            # self.right_depth_registered_info_pub.publish(camera_info_msg4)
+            # image_msg5, camera_info_msg5 = getImageMsg(data[5], self.spot_wrapper, frame_prefix=self.frame_prefix)
+            # self.right_depth_registered_pub.publish(image_msg5)
+            # self.right_depth_registered_info_pub.publish(camera_info_msg5)
 
             self.populate_camera_static_transforms(data[0])
             self.populate_camera_static_transforms(data[1])
             self.populate_camera_static_transforms(data[2])
             self.populate_camera_static_transforms(data[3])
-            self.populate_camera_static_transforms(data[4])
-            self.populate_camera_static_transforms(data[5])
+            # self.populate_camera_static_transforms(data[4])
+            # self.populate_camera_static_transforms(data[5])
 
     def RearImageCB(self, results):
         """Callback for when the Spot Wrapper gets new rear image data.
@@ -305,13 +305,13 @@ class SpotROS():
             mage_msg1, camera_info_msg1 = getImageMsg(data[1], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.back_depth_pub.publish(mage_msg1)
             self.back_depth_info_pub.publish(camera_info_msg1)
-            mage_msg2, camera_info_msg2 = getImageMsg(data[2], self.spot_wrapper, frame_prefix=self.frame_prefix)
-            self.back_depth_registered_pub.publish(mage_msg2)
-            self.back_depth_registered_info_pub.publish(camera_info_msg2)
+            # mage_msg2, camera_info_msg2 = getImageMsg(data[2], self.spot_wrapper, frame_prefix=self.frame_prefix)
+            # self.back_depth_registered_pub.publish(mage_msg2)
+            # self.back_depth_registered_info_pub.publish(camera_info_msg2)
 
             self.populate_camera_static_transforms(data[0])
             self.populate_camera_static_transforms(data[1])
-            self.populate_camera_static_transforms(data[2])
+            # self.populate_camera_static_transforms(data[2])
 
     def service_wrapper(self, name, handler, request, response):
         if self.spot_wrapper is None:
@@ -1089,11 +1089,11 @@ def main(args=None):
         spot_ros.left_depth_pub = node.create_publisher(Image, 'depth/left/image', 1)
         spot_ros.right_depth_pub = node.create_publisher(Image, 'depth/right/image', 1)
         # Depth Registered #
-        spot_ros.back_depth_registered_pub = node.create_publisher(Image, 'depth_registered/back/image', 1)
-        spot_ros.frontleft_depth_registered_pub = node.create_publisher(Image, 'depth_registered/frontleft/image', 1)
-        spot_ros.frontright_depth_registered_pub = node.create_publisher(Image, 'depth_registered/frontright/image', 1)
-        spot_ros.left_depth_registered_pub = node.create_publisher(Image, 'depth_registered/left/image', 1)
-        spot_ros.right_depth_registered_pub = node.create_publisher(Image, 'depth_registered/right/image', 1)
+        # spot_ros.back_depth_registered_pub = node.create_publisher(Image, 'depth_registered/back/image', 1)
+        # spot_ros.frontleft_depth_registered_pub = node.create_publisher(Image, 'depth_registered/frontleft/image', 1)
+        # spot_ros.frontright_depth_registered_pub = node.create_publisher(Image, 'depth_registered/frontright/image', 1)
+        # spot_ros.left_depth_registered_pub = node.create_publisher(Image, 'depth_registered/left/image', 1)
+        # spot_ros.right_depth_registered_pub = node.create_publisher(Image, 'depth_registered/right/image', 1)
 
         # Image Camera Info #
         spot_ros.back_image_info_pub = node.create_publisher(CameraInfo, 'camera/back/camera_info', 1)
@@ -1108,16 +1108,16 @@ def main(args=None):
         spot_ros.left_depth_info_pub = node.create_publisher(CameraInfo, 'depth/left/camera_info', 1)
         spot_ros.right_depth_info_pub = node.create_publisher(CameraInfo, 'depth/right/camera_info', 1)
         # Depth Registered Camera Info #
-        spot_ros.back_depth_registered_info_pub = \
-            node.create_publisher(CameraInfo, 'depth_registered/back/camera_info', 1)
-        spot_ros.frontleft_depth_registered_info_pub = \
-            node.create_publisher(CameraInfo, 'depth_registered/frontleft/camera_info', 1)
-        spot_ros.frontright_depth_registered_info_pub = \
-            node.create_publisher(CameraInfo, 'depth_registered/frontright/camera_info', 1)
-        spot_ros.left_depth_registered_info_pub = \
-            node.create_publisher(CameraInfo, 'depth_registered/left/camera_info', 1)
-        spot_ros.right_depth_registered_info_pub = \
-            node.create_publisher(CameraInfo, 'depth_registered/right/camera_info', 1)
+        # spot_ros.back_depth_registered_info_pub = \
+        #     node.create_publisher(CameraInfo, 'depth_registered/back/camera_info', 1)
+        # spot_ros.frontleft_depth_registered_info_pub = \
+        #     node.create_publisher(CameraInfo, 'depth_registered/frontleft/camera_info', 1)
+        # spot_ros.frontright_depth_registered_info_pub = \
+        #     node.create_publisher(CameraInfo, 'depth_registered/frontright/camera_info', 1)
+        # spot_ros.left_depth_registered_info_pub = \
+        #     node.create_publisher(CameraInfo, 'depth_registered/left/camera_info', 1)
+        # spot_ros.right_depth_registered_info_pub = \
+        #     node.create_publisher(CameraInfo, 'depth_registered/right/camera_info', 1)
 
         # Status Publishers #
         spot_ros.joint_state_pub = node.create_publisher(JointState, 'joint_states', 1)

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -233,16 +233,16 @@ class SpotROS():
         """
         data = self.spot_wrapper.front_images
         if data:
-            image_msg0, camera_info_msg0 = getImageMsg(data[0], self.spot_wrapper)
+            image_msg0, camera_info_msg0 = getImageMsg(data[0], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.frontleft_image_pub.publish(image_msg0)
             self.frontleft_image_info_pub.publish(camera_info_msg0)
-            image_msg1, camera_info_msg1 = getImageMsg(data[1], self.spot_wrapper)
+            image_msg1, camera_info_msg1 = getImageMsg(data[1], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.frontright_image_pub.publish(image_msg1)
             self.frontright_image_info_pub.publish(camera_info_msg1)
-            image_msg2, camera_info_msg2 = getImageMsg(data[2], self.spot_wrapper)
+            image_msg2, camera_info_msg2 = getImageMsg(data[2], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.frontleft_depth_pub.publish(image_msg2)
             self.frontleft_depth_info_pub.publish(camera_info_msg2)
-            image_msg3, camera_info_msg3 = getImageMsg(data[3], self.spot_wrapper)
+            image_msg3, camera_info_msg3 = getImageMsg(data[3], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.frontright_depth_pub.publish(image_msg3)
             self.frontright_depth_info_pub.publish(camera_info_msg3)
 
@@ -258,16 +258,16 @@ class SpotROS():
         """
         data = self.spot_wrapper.side_images
         if data:
-            image_msg0, camera_info_msg0 = getImageMsg(data[0], self.spot_wrapper)
+            image_msg0, camera_info_msg0 = getImageMsg(data[0], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.left_image_pub.publish(image_msg0)
             self.left_image_info_pub.publish(camera_info_msg0)
-            image_msg1, camera_info_msg1 = getImageMsg(data[1], self.spot_wrapper)
+            image_msg1, camera_info_msg1 = getImageMsg(data[1], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.right_image_pub.publish(image_msg1)
             self.right_image_info_pub.publish(camera_info_msg1)
-            image_msg2, camera_info_msg2 = getImageMsg(data[2], self.spot_wrapper)
+            image_msg2, camera_info_msg2 = getImageMsg(data[2], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.left_depth_pub.publish(image_msg2)
             self.left_depth_info_pub.publish(camera_info_msg2)
-            image_msg3, camera_info_msg3 = getImageMsg(data[3], self.spot_wrapper)
+            image_msg3, camera_info_msg3 = getImageMsg(data[3], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.right_depth_pub.publish(image_msg3)
             self.right_depth_info_pub.publish(camera_info_msg3)
 
@@ -283,10 +283,10 @@ class SpotROS():
         """
         data = self.spot_wrapper.rear_images
         if data:
-            mage_msg0, camera_info_msg0 = getImageMsg(data[0], self.spot_wrapper)
+            mage_msg0, camera_info_msg0 = getImageMsg(data[0], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.back_image_pub.publish(mage_msg0)
             self.back_image_info_pub.publish(camera_info_msg0)
-            mage_msg1, camera_info_msg1 = getImageMsg(data[1], self.spot_wrapper)
+            mage_msg1, camera_info_msg1 = getImageMsg(data[1], self.spot_wrapper, frame_prefix=self.frame_prefix)
             self.back_depth_pub.publish(mage_msg1)
             self.back_depth_info_pub.publish(camera_info_msg1)
 
@@ -1025,6 +1025,7 @@ def main(args=None):
     frame_prefix = ''
     if spot_ros.name is not None:
         frame_prefix = spot_ros.name + '/'
+    spot_ros.frame_prefix = frame_prefix
     spot_ros.mode_parent_odom_tf = node.declare_parameter('mode_parent_odom_tf',
                                                           frame_prefix + 'odom') # 'vision' or 'odom'
     spot_ros.tf_name_kinematic_odom = node.declare_parameter('tf_name_kinematic_odom',

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1,32 +1,17 @@
-import os
-import time
-import traceback
-
-import rclpy
-from rclpy.node import Node
 from rclpy.executors import MultiThreadedExecutor
-from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.callback_groups import ReentrantCallbackGroup, MutuallyExclusiveCallbackGroup
 
 from rclpy.action import ActionServer
-import builtin_interfaces.msg
-from builtin_interfaces.msg import Time, Duration
 
 from std_srvs.srv import Trigger, SetBool
-from std_msgs.msg import Bool, Header
-from tf2_msgs.msg import TFMessage
-from geometry_msgs.msg import TransformStamped
-from sensor_msgs.msg import Image, CameraInfo
-from sensor_msgs.msg import JointState
-from geometry_msgs.msg import TwistWithCovarianceStamped, Twist, Pose
-from nav_msgs.msg import Odometry
+from geometry_msgs.msg import Twist, Pose
 
 
 from bosdyn.api import geometry_pb2, trajectory_pb2, robot_command_pb2, world_object_pb2
 from bosdyn.api.geometry_pb2 import Quaternion, SE2VelocityLimit
 from bosdyn.api.spot import robot_command_pb2 as spot_command_pb2
 from bosdyn.client import math_helpers
-import functools
-import bosdyn.geometry
+from google.protobuf.timestamp_pb2 import Timestamp
 import tf2_ros
 
 import spot_driver.conversions as conv
@@ -93,7 +78,7 @@ class WaitForGoal(object):
         self._at_goal = True
 
 
-class SpotROS():
+class SpotROS:
     """Parent class for using the wrapper.  Defines all callbacks and keeps the wrapper alive"""
 
     def __init__(self):
@@ -172,7 +157,7 @@ class SpotROS():
         metrics = self.spot_wrapper.metrics
         if metrics:
             metrics_msg = Metrics()
-            local_time = self.spot_wrapper.robotToLocalTime(metrics.timestamp)
+            local_time = self.spot_wrapper.robot_to_local_time(metrics.timestamp)
             metrics_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
 
             for metric in metrics.metrics:
@@ -222,6 +207,114 @@ class SpotROS():
                                            self.mode_parent_odom_tf.value)
             if len(tf_msg.transforms) > 0:
                 self.dynamic_broadcaster.sendTransform(tf_msg.transforms)
+
+    def publish_camera_images_callback(self):
+        image_bundle = self.spot_wrapper.get_camera_images()
+        frontleft_image_msg, frontleft_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+            image_bundle.frontleft, self.spot_wrapper
+        )
+        frontright_image_msg, frontright_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+            image_bundle.frontright, self.spot_wrapper
+        )
+        left_image_msg, left_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+            image_bundle.left, self.spot_wrapper
+        )
+        right_image_msg, right_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+            image_bundle.right, self.spot_wrapper
+        )
+        back_image_msg, back_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+            image_bundle.back, self.spot_wrapper
+        )
+
+        self.frontleft_image_pub.publish(frontleft_image_msg)
+        self.frontright_image_pub.publish(frontright_image_msg)
+        self.left_image_pub.publish(left_image_msg)
+        self.right_image_pub.publish(right_image_msg)
+        self.back_image_pub.publish(back_image_msg)
+
+        self.frontleft_image_info_pub.publish(frontleft_camera_info)
+        self.frontright_image_info_pub.publish(frontright_camera_info)
+        self.left_image_info_pub.publish(left_camera_info)
+        self.right_image_info_pub.publish(right_camera_info)
+        self.back_image_info_pub.publish(back_camera_info)
+
+        self.populate_camera_static_transforms(image_bundle.frontleft)
+        self.populate_camera_static_transforms(image_bundle.frontright)
+        self.populate_camera_static_transforms(image_bundle.left)
+        self.populate_camera_static_transforms(image_bundle.right)
+        self.populate_camera_static_transforms(image_bundle.back)
+
+    def publish_depth_images_callback(self):
+        image_bundle = self.spot_wrapper.get_depth_images()
+        frontleft_image_msg, frontleft_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+            image_bundle.frontleft, self.spot_wrapper
+        )
+        frontright_image_msg, frontright_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+            image_bundle.frontright, self.spot_wrapper
+        )
+        left_image_msg, left_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+            image_bundle.left, self.spot_wrapper
+        )
+        right_image_msg, right_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+            image_bundle.right, self.spot_wrapper
+        )
+        back_image_msg, back_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+            image_bundle.back, self.spot_wrapper
+        )
+
+        self.frontleft_depth_pub.publish(frontleft_image_msg)
+        self.frontright_depth_pub.publish(frontright_image_msg)
+        self.left_depth_pub.publish(left_image_msg)
+        self.right_depth_pub.publish(right_image_msg)
+        self.back_depth_pub.publish(back_image_msg)
+
+        self.frontleft_depth_info_pub.publish(frontleft_camera_info)
+        self.frontright_depth_info_pub.publish(frontright_camera_info)
+        self.left_depth_info_pub.publish(left_camera_info)
+        self.right_depth_info_pub.publish(right_camera_info)
+        self.back_depth_info_pub.publish(back_camera_info)
+
+        self.populate_camera_static_transforms(image_bundle.frontleft)
+        self.populate_camera_static_transforms(image_bundle.frontright)
+        self.populate_camera_static_transforms(image_bundle.left)
+        self.populate_camera_static_transforms(image_bundle.right)
+        self.populate_camera_static_transforms(image_bundle.back)
+
+    def publish_depth_registered_images_callback(self):
+        image_bundle = self.spot_wrapper.get_depth_registered_images()
+        frontleft_image_msg, frontleft_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+            image_bundle.frontleft, self.spot_wrapper
+        )
+        frontright_image_msg, frontright_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+            image_bundle.frontright, self.spot_wrapper
+        )
+        left_image_msg, left_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+            image_bundle.left, self.spot_wrapper
+        )
+        right_image_msg, right_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+            image_bundle.right, self.spot_wrapper
+        )
+        back_image_msg, back_camera_info = bosdyn_data_to_image_and_camera_info_msgs(
+            image_bundle.back, self.spot_wrapper
+        )
+
+        self.frontleft_depth_registered_pub.publish(frontleft_image_msg)
+        self.frontright_depth_registered_pub.publish(frontright_image_msg)
+        self.left_depth_registered_pub.publish(left_image_msg)
+        self.right_depth_registered_pub.publish(right_image_msg)
+        self.back_depth_registered_pub.publish(back_image_msg)
+
+        self.frontleft_depth_registered_info_pub.publish(frontleft_camera_info)
+        self.frontright_depth_registered_info_pub.publish(frontright_camera_info)
+        self.left_depth_registered_info_pub.publish(left_camera_info)
+        self.right_depth_registered_info_pub.publish(right_camera_info)
+        self.back_depth_registered_info_pub.publish(back_camera_info)
+
+        self.populate_camera_static_transforms(image_bundle.frontleft)
+        self.populate_camera_static_transforms(image_bundle.frontright)
+        self.populate_camera_static_transforms(image_bundle.left)
+        self.populate_camera_static_transforms(image_bundle.right)
+        self.populate_camera_static_transforms(image_bundle.back)
 
     def service_wrapper(self, name, handler, request, response):
         if self.spot_wrapper is None:
@@ -823,7 +916,7 @@ class SpotROS():
                 continue
 
             transform = image_data.shot.transforms_snapshot.child_to_parent_edge_map.get(frame_name)
-            local_time = self.spot_wrapper.robotToLocalTime(image_data.shot.acquisition_time)
+            local_time = self.spot_wrapper.robot_to_local_time(image_data.shot.acquisition_time)
             tf_time = Time(sec=local_time.seconds, nanosec=local_time.nanos)
             static_tf = populateTransformStamped(tf_time, transform.parent_frame_name, frame_name,
                                                  transform.parent_tform_child, frame_prefix)
@@ -885,8 +978,8 @@ class SpotROS():
             self.mobility_params_pub.publish(mobility_params_msg)
             self.node_rate.sleep()
 
-def main(args=None):
 
+def main(args=None):
     COLOR_END    = '\33[0m'
     COLOR_RED    = '\33[31m'
     COLOR_GREEN  = '\33[32m'
@@ -896,12 +989,18 @@ def main(args=None):
 
     spot_ros = SpotROS()
     rclpy.init(args=args)
-    """Main function for the SpotROS class.  Gets config from ROS and initializes the wrapper.  Holds lease from wrapper and updates all async tasks at the ROS rate"""
+    """
+    Main function for the SpotROS class.  Gets config from ROS and initializes the wrapper.  Holds lease from wrapper
+     and updates all async tasks at the ROS rate
+    """
 
     node = rclpy.create_node('spot_ros2')
 
     spot_ros.node = node
     spot_ros.group = ReentrantCallbackGroup()
+    spot_ros.rgb_callback_group = MutuallyExclusiveCallbackGroup()
+    spot_ros.depth_callback_group = MutuallyExclusiveCallbackGroup()
+    spot_ros.depth_registered_callback_group = MutuallyExclusiveCallbackGroup()
     rate = node.create_rate(100)
     spot_ros.node_rate = rate
 
@@ -922,6 +1021,9 @@ def main(args=None):
     node.declare_parameter('deadzone', 0.05)
     node.declare_parameter('estop_timeout', 9.0)
     node.declare_parameter('start_estop', False)
+    node.declare_parameter('publish_rgb', True)
+    node.declare_parameter('publish_depth', True)
+    node.declare_parameter('publish_depth_registered', False)
     node.declare_parameter('spot_name', '')
 
     spot_ros.auto_claim = node.get_parameter('auto_claim')
@@ -929,11 +1031,14 @@ def main(args=None):
     spot_ros.auto_stand = node.get_parameter('auto_stand')
     spot_ros.start_estop = node.get_parameter('start_estop')
 
+    spot_ros.publish_rgb = node.get_parameter('publish_rgb')
+    spot_ros.publish_depth = node.get_parameter('publish_depth')
+    spot_ros.publish_depth_registered = node.get_parameter('publish_depth_registered')
+
     # This is only done from parameter because it should be passed by the launch file
     spot_ros.name = node.get_parameter('spot_name').value
     if not spot_ros.name:
         spot_ros.name = None
-
 
     spot_ros.motion_deadzone = node.get_parameter('deadzone')
     spot_ros.estop_timeout = node.get_parameter('estop_timeout')
@@ -986,6 +1091,71 @@ def main(args=None):
         spot_ros.spot_wrapper = None
     # spot_ros.spot_wrapper = spot_wrapper
     if spot_ros.spot_wrapper is None or spot_ros.spot_wrapper.is_valid:
+        if spot_ros.publish_rgb.value:
+            # Images #
+            spot_ros.back_image_pub = node.create_publisher(Image, 'camera/back/image', 1)
+            spot_ros.frontleft_image_pub = node.create_publisher(Image, 'camera/frontleft/image', 1)
+            spot_ros.frontright_image_pub = node.create_publisher(Image, 'camera/frontright/image', 1)
+            spot_ros.left_image_pub = node.create_publisher(Image, 'camera/left/image', 1)
+            spot_ros.right_image_pub = node.create_publisher(Image, 'camera/right/image', 1)
+            # Image Camera Info #
+            spot_ros.back_image_info_pub = node.create_publisher(CameraInfo, 'camera/back/camera_info', 1)
+            spot_ros.frontleft_image_info_pub = node.create_publisher(CameraInfo, 'camera/frontleft/camera_info', 1)
+            spot_ros.frontright_image_info_pub = node.create_publisher(CameraInfo, 'camera/frontright/camera_info', 1)
+            spot_ros.left_image_info_pub = node.create_publisher(CameraInfo, 'camera/left/camera_info', 1)
+            spot_ros.right_image_info_pub = node.create_publisher(CameraInfo, 'camera/right/camera_info', 1)
+
+            node.create_timer(
+                1 / spot_ros.rates['front_image'],
+                spot_ros.publish_camera_images_callback,
+                callback_group=spot_ros.rgb_callback_group,
+            )
+
+        if spot_ros.publish_depth.value:
+            # Depth #
+            spot_ros.back_depth_pub = node.create_publisher(Image, 'depth/back/image', 1)
+            spot_ros.frontleft_depth_pub = node.create_publisher(Image, 'depth/frontleft/image', 1)
+            spot_ros.frontright_depth_pub = node.create_publisher(Image, 'depth/frontright/image', 1)
+            spot_ros.left_depth_pub = node.create_publisher(Image, 'depth/left/image', 1)
+            spot_ros.right_depth_pub = node.create_publisher(Image, 'depth/right/image', 1)
+            # Depth Camera Info #
+            spot_ros.back_depth_info_pub = node.create_publisher(CameraInfo, 'depth/back/camera_info', 1)
+            spot_ros.frontleft_depth_info_pub = node.create_publisher(CameraInfo, 'depth/frontleft/camera_info', 1)
+            spot_ros.frontright_depth_info_pub = node.create_publisher(CameraInfo, 'depth/frontright/camera_info', 1)
+            spot_ros.left_depth_info_pub = node.create_publisher(CameraInfo, 'depth/left/camera_info', 1)
+            spot_ros.right_depth_info_pub = node.create_publisher(CameraInfo, 'depth/right/camera_info', 1)
+
+            node.create_timer(
+                1 / spot_ros.rates['front_image'],
+                spot_ros.publish_depth_images_callback,
+                callback_group=spot_ros.depth_callback_group,
+            )
+
+        if spot_ros.publish_depth_registered.value:
+            # Depth Registered #
+            spot_ros.back_depth_registered_pub = node.create_publisher(Image, 'depth_registered/back/image', 1)
+            spot_ros.frontleft_depth_registered_pub = node.create_publisher(Image, 'depth_registered/frontleft/image', 1)
+            spot_ros.frontright_depth_registered_pub = node.create_publisher(Image, 'depth_registered/frontright/image', 1)
+            spot_ros.left_depth_registered_pub = node.create_publisher(Image, 'depth_registered/left/image', 1)
+            spot_ros.right_depth_registered_pub = node.create_publisher(Image, 'depth_registered/right/image', 1)
+            # Depth Registered Camera Info #
+            spot_ros.back_depth_registered_info_pub = \
+                node.create_publisher(CameraInfo, 'depth_registered/back/camera_info', 1)
+            spot_ros.frontleft_depth_registered_info_pub = \
+                node.create_publisher(CameraInfo, 'depth_registered/frontleft/camera_info', 1)
+            spot_ros.frontright_depth_registered_info_pub = \
+                node.create_publisher(CameraInfo, 'depth_registered/frontright/camera_info', 1)
+            spot_ros.left_depth_registered_info_pub = \
+                node.create_publisher(CameraInfo, 'depth_registered/left/camera_info', 1)
+            spot_ros.right_depth_registered_info_pub = \
+                node.create_publisher(CameraInfo, 'depth_registered/right/camera_info', 1)
+
+            node.create_timer(
+                1 / spot_ros.rates['front_image'],
+                spot_ros.publish_depth_registered_images_callback,
+                callback_group=spot_ros.depth_registered_callback_group,
+            )
+
         # Status Publishers #
         spot_ros.joint_state_pub = node.create_publisher(JointState, 'joint_states', 1)
         spot_ros.dynamic_broadcaster = tf2_ros.TransformBroadcaster(node)

--- a/spot_driver/spot_driver/spot_wrapper.py
+++ b/spot_driver/spot_driver/spot_wrapper.py
@@ -484,7 +484,7 @@ class SpotWrapper:
         """
         self._mobility_params = RobotCommandBuilder.mobility_params()
 
-    def robot_to_local_time(self, timestamp):
+    def robotToLocalTime(self, timestamp):
         """Takes a timestamp and an estimated skew and return seconds and nano seconds in local time
 
         Args:

--- a/spot_driver/spot_driver/spot_wrapper.py
+++ b/spot_driver/spot_driver/spot_wrapper.py
@@ -288,11 +288,11 @@ class SpotWrapper():
 
         # Depth
         for source in front_image_sources_depth:
-            self._side_image_requests.append(build_image_request(
+            self._front_image_requests.append(build_image_request(
                 source, image_format=image_pb2.Image.FORMAT_RAW, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16))
 
         for source in side_image_sources_depth:
-            self._rear_image_requests.append(build_image_request(
+            self._side_image_requests.append(build_image_request(
                 source, image_format=image_pb2.Image.FORMAT_RAW, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16))
 
         for source in rear_image_sources_depth:

--- a/spot_driver/spot_driver/spot_wrapper.py
+++ b/spot_driver/spot_driver/spot_wrapper.py
@@ -4,6 +4,8 @@ import traceback
 from collections import namedtuple
 from typing import Optional
 
+import cv2
+import numpy as np
 from bosdyn.client import create_standard_sdk, ResponseError, RpcError
 from bosdyn.client.async_tasks import AsyncPeriodicQuery, AsyncTasks
 
@@ -298,19 +300,22 @@ class SpotWrapper:
         self._camera_image_requests = []
         for camera_source in CAMERA_IMAGE_SOURCES:
             self._camera_image_requests.append(build_image_request(
-                camera_source, pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8, quality_percent=50
+                camera_source,
+                image_format=image_pb2.Image.FORMAT_JPEG,
+                pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8,
+                quality_percent=50,
             ))
 
         self._depth_image_requests = []
         for camera_source in DEPTH_IMAGE_SOURCES:
             self._depth_image_requests.append(build_image_request(
-                camera_source, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16, quality_percent=50
+                camera_source, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16
             ))
 
         self._depth_registered_image_requests = []
         for camera_source in DEPTH_REGISTERED_IMAGE_SOURCES:
             self._depth_registered_image_requests.append(build_image_request(
-                camera_source, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16, quality_percent=50
+                camera_source, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16
             ))
 
         try:

--- a/spot_driver/spot_driver/spot_wrapper.py
+++ b/spot_driver/spot_driver/spot_wrapper.py
@@ -276,28 +276,28 @@ class SpotWrapper():
         # RGB
         for source in front_image_sources_rgb:
             self._front_image_requests.append(build_image_request(
-                source, image_format=image_pb2.Image.FORMAT_RAW, pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8))
+                source, image_format=image_pb2.Image.FORMAT_RAW)) #, pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8))
 
         for source in side_image_sources_rgb:
             self._side_image_requests.append(build_image_request(
-                source, image_format=image_pb2.Image.FORMAT_RAW, pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8))
+                source, image_format=image_pb2.Image.FORMAT_RAW)) #, pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8))
 
         for source in rear_image_sources_rgb:
             self._rear_image_requests.append(build_image_request(
-                source, image_format=image_pb2.Image.FORMAT_RAW, pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8))
+                source, image_format=image_pb2.Image.FORMAT_RAW)) #, pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8))
 
         # Depth
         for source in front_image_sources_depth:
             self._front_image_requests.append(build_image_request(
-                source, image_format=image_pb2.Image.FORMAT_RAW, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16))
+                source, image_format=image_pb2.Image.FORMAT_RAW)) #, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16))
 
         for source in side_image_sources_depth:
             self._side_image_requests.append(build_image_request(
-                source, image_format=image_pb2.Image.FORMAT_RAW, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16))
+                source, image_format=image_pb2.Image.FORMAT_RAW)) #, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16))
 
         for source in rear_image_sources_depth:
             self._rear_image_requests.append(build_image_request(
-                source, image_format=image_pb2.Image.FORMAT_RAW, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16))
+                source, image_format=image_pb2.Image.FORMAT_RAW)) #, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16))
 
         try:
             self._sdk = create_standard_sdk('ros_spot')

--- a/spot_driver/spot_driver/spot_wrapper.py
+++ b/spot_driver/spot_driver/spot_wrapper.py
@@ -1,10 +1,11 @@
 import math
 import time
 import traceback
+from collections import namedtuple
+from typing import Optional
 
 from bosdyn.client import create_standard_sdk, ResponseError, RpcError
 from bosdyn.client.async_tasks import AsyncPeriodicQuery, AsyncTasks
-from bosdyn.geometry import EulerZXY
 
 from bosdyn.client.robot_state import RobotStateClient
 from bosdyn.client.robot_command import RobotCommandClient, RobotCommandBuilder
@@ -12,17 +13,15 @@ from bosdyn.client.graph_nav import GraphNavClient
 from bosdyn.client.frame_helpers import get_odom_tform_body
 from bosdyn.client.power import safe_power_off, PowerClient, power_on
 from bosdyn.client.lease import LeaseClient, LeaseKeepAlive
-from bosdyn.client.image import ImageClient, build_image_request
+from bosdyn.client.image import ImageClient, build_image_request, UnsupportedPixelFormatRequestedError
 from bosdyn.api import image_pb2
 from bosdyn.api.graph_nav import graph_nav_pb2
 from bosdyn.api.graph_nav import map_pb2
 from bosdyn.api.graph_nav import nav_pb2
 from bosdyn.client.estop import EstopClient, EstopEndpoint, EstopKeepAlive, MotorsOnError
-from bosdyn.client import power
 from bosdyn.client import frame_helpers
 from bosdyn.client import math_helpers
 from bosdyn.client.world_object import WorldObjectClient
-from bosdyn.client.exceptions import InternalServerError
 
 MAX_COMMAND_DURATION = 1e5
 
@@ -31,9 +30,32 @@ from . import graph_nav_util
 ### Debug
 # import graph_nav_util
 
-import bosdyn.api.robot_state_pb2 as robot_state_proto
 from bosdyn.api import basic_command_pb2
 from google.protobuf.timestamp_pb2 import Timestamp
+
+# TODO: Missing Hand images
+CAMERA_IMAGE_SOURCES = [
+    "frontleft_fisheye_image",
+    "frontright_fisheye_image",
+    "left_fisheye_image",
+    "right_fisheye_image",
+    "back_fisheye_image"
+]
+DEPTH_IMAGE_SOURCES = [
+    "frontleft_depth",
+    "frontright_depth",
+    "left_depth",
+    "right_depth",
+    "back_depth",
+]
+DEPTH_REGISTERED_IMAGE_SOURCES = [
+    "frontleft_depth_in_visual_frame",
+    "frontright_depth_in_visual_frame",
+    "right_depth_in_visual_frame",
+    "left_depth_in_visual_frame",
+    "back_depth_in_visual_frame",
+]
+ImageBundle = namedtuple("ImageBundle", ["frontleft", "frontright", "left", "right", "back"])
 
 
 class AsyncRobotState(AsyncPeriodicQuery):
@@ -45,9 +67,10 @@ class AsyncRobotState(AsyncPeriodicQuery):
             rate: Rate (Hz) to trigger the query
             callback: Callback function to call when the results of the query are available
     """
+
     def __init__(self, client, logger, rate, callback):
         super(AsyncRobotState, self).__init__("robot-state", client, logger,
-                                           period_sec=1.0/max(rate, 1.0))
+                                              period_sec=1.0 / max(rate, 1.0))
         self._callback = None
         if rate > 0.0:
             self._callback = callback
@@ -58,6 +81,7 @@ class AsyncRobotState(AsyncPeriodicQuery):
             callback_future.add_done_callback(self._callback)
             return callback_future
 
+
 class AsyncMetrics(AsyncPeriodicQuery):
     """Class to get robot metrics at regular intervals.  get_robot_metrics_async query sent to the robot at every tick.  Callback registered to defined callback function.
 
@@ -67,9 +91,10 @@ class AsyncMetrics(AsyncPeriodicQuery):
             rate: Rate (Hz) to trigger the query
             callback: Callback function to call when the results of the query are available
     """
+
     def __init__(self, client, logger, rate, callback):
         super(AsyncMetrics, self).__init__("robot-metrics", client, logger,
-                                           period_sec=1.0/max(rate, 1.0))
+                                           period_sec=1.0 / max(rate, 1.0))
         self._callback = None
         if rate > 0.0:
             self._callback = callback
@@ -80,6 +105,7 @@ class AsyncMetrics(AsyncPeriodicQuery):
             callback_future.add_done_callback(self._callback)
             return callback_future
 
+
 class AsyncLease(AsyncPeriodicQuery):
     """Class to get lease state at regular intervals.  list_leases_async query sent to the robot at every tick.  Callback registered to defined callback function.
 
@@ -89,9 +115,10 @@ class AsyncLease(AsyncPeriodicQuery):
             rate: Rate (Hz) to trigger the query
             callback: Callback function to call when the results of the query are available
     """
+
     def __init__(self, client, logger, rate, callback):
         super(AsyncLease, self).__init__("lease", client, logger,
-                                           period_sec=1.0/max(rate, 1.0))
+                                         period_sec=1.0 / max(rate, 1.0))
         self._callback = None
         if rate > 0.0:
             self._callback = callback
@@ -102,6 +129,7 @@ class AsyncLease(AsyncPeriodicQuery):
             callback_future.add_done_callback(self._callback)
             return callback_future
 
+
 class AsyncImageService(AsyncPeriodicQuery):
     """Class to get images at regular intervals.  get_image_from_sources_async query sent to the robot at every tick.  Callback registered to defined callback function.
 
@@ -111,9 +139,10 @@ class AsyncImageService(AsyncPeriodicQuery):
             rate: Rate (Hz) to trigger the query
             callback: Callback function to call when the results of the query are available
     """
+
     def __init__(self, client, logger, rate, callback, image_requests):
         super(AsyncImageService, self).__init__("robot_image_service", client, logger,
-                                           period_sec=1.0/max(rate, 1.0))
+                                                period_sec=1.0 / max(rate, 1.0))
         self._callback = None
         if rate > 0.0:
             self._callback = callback
@@ -125,6 +154,7 @@ class AsyncImageService(AsyncPeriodicQuery):
             callback_future.add_done_callback(self._callback)
             return callback_future
 
+
 class AsyncIdle(AsyncPeriodicQuery):
     """Class to check if the robot is moving, and if not, command a stand with the set mobility parameters
 
@@ -134,9 +164,10 @@ class AsyncIdle(AsyncPeriodicQuery):
             rate: Rate (Hz) to trigger the query
             spot_wrapper: A handle to the wrapper library
     """
+
     def __init__(self, client, logger, rate, spot_wrapper):
         super(AsyncIdle, self).__init__("idle", client, logger,
-                                           period_sec=1.0/rate)
+                                        period_sec=1.0 / rate)
 
         self._spot_wrapper = spot_wrapper
 
@@ -184,8 +215,8 @@ class AsyncIdle(AsyncPeriodicQuery):
                 # STATUS_AT_GOAL always means that the robot reached the goal. If the trajectory command did not
                 # request precise positioning, then STATUS_NEAR_GOAL also counts as reaching the goal
                 if status == basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_AT_GOAL or \
-                    (status == basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_NEAR_GOAL and
-                     not self._spot_wrapper._last_trajectory_command_precise):
+                        (status == basic_command_pb2.SE2TrajectoryCommand.Feedback.STATUS_NEAR_GOAL and
+                         not self._spot_wrapper._last_trajectory_command_precise):
                     self._spot_wrapper._at_goal = True
                     # Clear the command once at the goal
                     self._spot_wrapper._last_trajectory_command = None
@@ -202,6 +233,7 @@ class AsyncIdle(AsyncPeriodicQuery):
 
         self._spot_wrapper._is_moving = is_moving
 
+
 class AsyncWorldObjects(AsyncPeriodicQuery):
     """Class to get world objects.  list_world_objects_async query sent to the robot at every tick.  Callback registered to defined callback function.
 
@@ -211,8 +243,9 @@ class AsyncWorldObjects(AsyncPeriodicQuery):
             rate: Rate (Hz) to trigger the query
             callback: Callback function to call when the results of the query are available
     """
+
     def __init__(self, client, logger, rate, callback):
-        super(AsyncWorldObjects, self).__init__("world-objects", client, logger, period_sec=1.0/max(rate, 1.0))
+        super(AsyncWorldObjects, self).__init__("world-objects", client, logger, period_sec=1.0 / max(rate, 1.0))
         self._callback = None
         if rate > 0.0:
             self._callback = callback
@@ -223,10 +256,12 @@ class AsyncWorldObjects(AsyncPeriodicQuery):
             callback_future.add_done_callback(self._callback)
             return callback_future
 
-class SpotWrapper():
+
+class SpotWrapper:
     """Generic wrapper class to encompass release 1.1.4 API features as well as maintaining leases automatically"""
+
     def __init__(self, username, password, hostname, robot_name, logger, start_estop, estop_timeout=9.0,
-                 rates = None, callbacks = None):
+                 rates=None, callbacks=None):
         self._username = username
         self._password = password
         self._hostname = hostname
@@ -259,6 +294,24 @@ class SpotWrapper():
         self._last_trajectory_command_precise = None
         self._last_velocity_command_time = None
         self._last_robot_command = None
+
+        self._camera_image_requests = []
+        for camera_source in CAMERA_IMAGE_SOURCES:
+            self._camera_image_requests.append(build_image_request(
+                camera_source, pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8, quality_percent=50
+            ))
+
+        self._depth_image_requests = []
+        for camera_source in DEPTH_IMAGE_SOURCES:
+            self._depth_image_requests.append(build_image_request(
+                camera_source, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16, quality_percent=50
+            ))
+
+        self._depth_registered_image_requests = []
+        for camera_source in DEPTH_REGISTERED_IMAGE_SOURCES:
+            self._depth_registered_image_requests.append(build_image_request(
+                camera_source, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16, quality_percent=50
+            ))
 
         try:
             self._sdk = create_standard_sdk('ros_spot')
@@ -299,15 +352,20 @@ class SpotWrapper():
 
             # Store the most recent knowledge of the state of the robot based on rpc calls.
             self._current_graph = None
-            self._current_edges = dict()  #maps to_waypoint to list(from_waypoint)
+            self._current_edges = dict()  # maps to_waypoint to list(from_waypoint)
             self._current_waypoint_snapshots = dict()  # maps id to waypoint snapshot
             self._current_edge_snapshots = dict()  # maps id to edge snapshot
             self._current_annotation_name_to_wp_id = dict()
 
             # Async Tasks
-            self._robot_state_task = AsyncRobotState(self._robot_state_client, self._logger, max(0.0, self._rates.get("robot_state", 0.0)), self._callbacks.get("robot_state", None))
-            self._robot_metrics_task = AsyncMetrics(self._robot_state_client, self._logger, max(0.0, self._rates.get("metrics", 0.0)), self._callbacks.get("metrics", None))
-            self._lease_task = AsyncLease(self._lease_client, self._logger, max(0.0, self._rates.get("lease", 0.0)), self._callbacks.get("lease", None))
+            self._robot_state_task = AsyncRobotState(self._robot_state_client, self._logger,
+                                                     max(0.0, self._rates.get("robot_state", 0.0)),
+                                                     self._callbacks.get("robot_state", None))
+            self._robot_metrics_task = AsyncMetrics(self._robot_state_client, self._logger,
+                                                    max(0.0, self._rates.get("metrics", 0.0)),
+                                                    self._callbacks.get("metrics", None))
+            self._lease_task = AsyncLease(self._lease_client, self._logger, max(0.0, self._rates.get("lease", 0.0)),
+                                          self._callbacks.get("lease", None))
             self._idle_task = AsyncIdle(self._robot_command_client, self._logger, 10.0, self)
             self._world_objects_task = AsyncWorldObjects(self._world_objects_client, self._logger, 10.0,
                                                          self._callbacks.get("world_objects", None))
@@ -421,7 +479,7 @@ class SpotWrapper():
         """
         self._mobility_params = RobotCommandBuilder.mobility_params()
 
-    def robotToLocalTime(self, timestamp):
+    def robot_to_local_time(self, timestamp):
         """Takes a timestamp and an estimated skew and return seconds and nano seconds in local time
 
         Args:
@@ -495,7 +553,6 @@ class SpotWrapper():
         except:
             return False, "Error"
 
-
     def releaseEStop(self):
         """Stop eStop keepalive"""
         if self._estop_keepalive:
@@ -539,7 +596,9 @@ class SpotWrapper():
             timesync_endpoint: (optional) Time sync endpoint
         """
         try:
-            id = self._robot_command_client.robot_command(lease=None, command=command_proto, end_time_secs=end_time_secs, timesync_endpoint=timesync_endpoint)
+            id = self._robot_command_client.robot_command(lease=None, command=command_proto,
+                                                          end_time_secs=end_time_secs,
+                                                          timesync_endpoint=timesync_endpoint)
             return True, "Success", id
         except Exception as e:
             self._logger.error("Unable to execute robot command, exception was" + str(e))
@@ -586,7 +645,7 @@ class SpotWrapper():
             return response
         if self._is_sitting:
             response = self._robot_command(
-                RobotCommandBuilder.battery_change_pose_command(1)) # 1: Rightside
+                RobotCommandBuilder.battery_change_pose_command(1))  # 1: Rightside
             return response[0], response[1]
         return False, 'Call /sit first'
 
@@ -638,7 +697,6 @@ class SpotWrapper():
     def list_world_objects(self, object_types, time_start_point):
         return self._world_objects_client.list_world_objects(object_types, time_start_point)
 
-
     def velocity_cmd(self, v_x, v_y, v_rot, cmd_duration=0.125):
         """Send a velocity motion command to the robot.
 
@@ -648,10 +706,10 @@ class SpotWrapper():
             v_rot: Angular velocity around the Z axis in radians
             cmd_duration: (optional) Time-to-live for the command in seconds.  Default is 125ms (assuming 10Hz command rate).
         """
-        end_time=time.time() + cmd_duration
+        end_time = time.time() + cmd_duration
         response = self._robot_command(RobotCommandBuilder.synchro_velocity_command(
-                                      v_x=v_x, v_y=v_y, v_rot=v_rot, params=self._mobility_params),
-                                      end_time_secs=end_time, timesync_endpoint=self._robot.time_sync.endpoint)
+            v_x=v_x, v_y=v_y, v_rot=v_rot, params=self._mobility_params),
+            end_time_secs=end_time, timesync_endpoint=self._robot.time_sync.endpoint)
         self._last_velocity_command_time = end_time
         return response[0], response[1]
 
@@ -675,35 +733,37 @@ class SpotWrapper():
         self._near_goal = False
         self._last_trajectory_command_precise = precise_position
         self._logger.info("got command duration of {}".format(cmd_duration))
-        end_time=time.time() + cmd_duration
+        end_time = time.time() + cmd_duration
         if frame_name == 'vision':
             vision_tform_body = frame_helpers.get_vision_tform_body(
-                    self._robot_state_client.get_robot_state().kinematic_state.transforms_snapshot)
-            body_tform_goal = math_helpers.SE3Pose(x=goal_x, y=goal_y, z=0, rot=math_helpers.Quat.from_yaw(goal_heading))
+                self._robot_state_client.get_robot_state().kinematic_state.transforms_snapshot)
+            body_tform_goal = math_helpers.SE3Pose(x=goal_x, y=goal_y, z=0,
+                                                   rot=math_helpers.Quat.from_yaw(goal_heading))
             vision_tform_goal = vision_tform_body * body_tform_goal
             response = self._robot_command(
-                            RobotCommandBuilder.synchro_se2_trajectory_point_command(
-                                goal_x=vision_tform_goal.x,
-                                goal_y=vision_tform_goal.y,
-                                goal_heading=vision_tform_goal.rot.to_yaw(),
-                                frame_name=frame_helpers.VISION_FRAME_NAME,
-                                params=mobility_params),
-                            end_time_secs=end_time
-                            )
+                RobotCommandBuilder.synchro_se2_trajectory_point_command(
+                    goal_x=vision_tform_goal.x,
+                    goal_y=vision_tform_goal.y,
+                    goal_heading=vision_tform_goal.rot.to_yaw(),
+                    frame_name=frame_helpers.VISION_FRAME_NAME,
+                    params=mobility_params),
+                end_time_secs=end_time
+            )
         elif frame_name == 'odom':
             odom_tform_body = frame_helpers.get_odom_tform_body(
-                    self._robot_state_client.get_robot_state().kinematic_state.transforms_snapshot)
-            body_tform_goal = math_helpers.SE3Pose(x=goal_x, y=goal_y, z=0, rot=math_helpers.Quat.from_yaw(goal_heading))
+                self._robot_state_client.get_robot_state().kinematic_state.transforms_snapshot)
+            body_tform_goal = math_helpers.SE3Pose(x=goal_x, y=goal_y, z=0,
+                                                   rot=math_helpers.Quat.from_yaw(goal_heading))
             odom_tform_goal = odom_tform_body * body_tform_goal
             response = self._robot_command(
-                            RobotCommandBuilder.synchro_se2_trajectory_point_command(
-                                goal_x=odom_tform_goal.x,
-                                goal_y=odom_tform_goal.y,
-                                goal_heading=odom_tform_goal.rot.to_yaw(),
-                                frame_name=frame_helpers.ODOM_FRAME_NAME,
-                                params=mobility_params),
-                            end_time_secs=end_time
-                            )
+                RobotCommandBuilder.synchro_se2_trajectory_point_command(
+                    goal_x=odom_tform_goal.x,
+                    goal_y=odom_tform_goal.y,
+                    goal_heading=odom_tform_goal.rot.to_yaw(),
+                    frame_name=frame_helpers.ODOM_FRAME_NAME,
+                    params=mobility_params),
+                end_time_secs=end_time
+            )
         else:
             raise ValueError('frame_name must be \'vision\' or \'odom\'')
         if response[0]:
@@ -712,7 +772,8 @@ class SpotWrapper():
 
     def robot_command(self, robot_command):
         end_time = time.time() + MAX_COMMAND_DURATION
-        return self._robot_command(robot_command, end_time_secs=end_time, timesync_endpoint=self._robot.time_sync.endpoint)
+        return self._robot_command(robot_command, end_time_secs=end_time,
+                                   timesync_endpoint=self._robot.time_sync.endpoint)
 
     def get_robot_command_feedback(self, cmd_id):
         return self._robot_command_client.robot_command_feedback(cmd_id)
@@ -724,7 +785,7 @@ class SpotWrapper():
         """
         ids, eds = self._list_graph_waypoint_and_edge_ids()
         # skip waypoint_ for v2.2.1, skip waypiont for < v2.2
-        return [v for k, v in sorted(ids.items(), key=lambda id : int(id[0].replace('waypoint_','')))]
+        return [v for k, v in sorted(ids.items(), key=lambda id: int(id[0].replace('waypoint_', '')))]
 
     def navigate_to(self, upload_path,
                     navigate_to,
@@ -808,8 +869,8 @@ class SpotWrapper():
         self._graph_nav_client.set_localization(
             initial_guess_localization=localization,
             # It's hard to get the pose perfect, search +/-20 deg and +/-20cm (0.2m).
-            max_distance = 0.2,
-            max_yaw = 20.0 * math.pi / 180.0,
+            max_distance=0.2,
+            max_yaw=20.0 * math.pi / 180.0,
             fiducial_init=graph_nav_pb2.SetLocalizationRequest.FIDUCIAL_INIT_NO_FIDUCIAL,
             ko_tform_body=current_odom_tform_body)
 
@@ -829,7 +890,6 @@ class SpotWrapper():
         self._current_annotation_name_to_wp_id, self._current_edges = graph_nav_util.update_waypoints_and_edges(
             graph, localization_id, self._logger)
         return self._current_annotation_name_to_wp_id, self._current_edges
-
 
     def _upload_graph_and_snapshots(self, upload_filepath):
         """Upload the graph and snapshots to the robot."""
@@ -874,8 +934,8 @@ class SpotWrapper():
         if not localization_state.localization.waypoint_id:
             # The robot is not localized to the newly uploaded graph.
             self._logger.info(
-                   "Upload complete! The robot is currently not localized to the map; please localize", \
-                   "the robot using commands (2) or (3) before attempting a navigation command.")
+                "Upload complete! The robot is currently not localized to the map; please localize", \
+                "the robot using commands (2) or (3) before attempting a navigation command.")
 
     def _navigate_to(self, *args):
         """Navigate to a specific waypoint."""
@@ -1010,7 +1070,7 @@ class SpotWrapper():
             motors_on = False
             while not motors_on:
                 future = self._robot_state_client.get_robot_state_async()
-                state_response = future.result(timeout=10) # 10 second timeout for waiting for the state response.
+                state_response = future.result(timeout=10)  # 10 second timeout for waiting for the state response.
                 if state_response.power_state.motor_power_state == robot_state_pb2.PowerState.STATE_ON:
                     motors_on = True
                 else:
@@ -1067,3 +1127,60 @@ class SpotWrapper():
                     # This edge matches the pair of waypoints! Add it the edge list and continue.
                     return map_pb2.Edge.Id(from_waypoint=waypoint1, to_waypoint=waypoint2)
         return None
+
+    def get_frontleft_rgb_image(self):
+        try:
+            return self._image_client.get_image([build_image_request(
+                "frontleft_fisheye_image", pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8, quality_percent=50)])[0]
+        except UnsupportedPixelFormatRequestedError as e:
+            return None
+
+    def get_frontright_rgb_image(self):
+        try:
+            return self._image_client.get_image([build_image_request(
+                "frontright_fisheye_image", pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8, quality_percent=50)])[0]
+        except UnsupportedPixelFormatRequestedError as e:
+            return None
+
+    def get_left_rgb_image(self):
+        try:
+            return self._image_client.get_image([build_image_request(
+                "left_fisheye_image", pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8, quality_percent=50)])[0]
+        except UnsupportedPixelFormatRequestedError as e:
+            return None
+
+    def get_right_rgb_image(self):
+        try:
+            return self._image_client.get_image([build_image_request(
+                "right_fisheye_image", pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8, quality_percent=50)])[0]
+        except UnsupportedPixelFormatRequestedError as e:
+            return None
+
+    def get_back_rgb_image(self):
+        try:
+            return self._image_client.get_image([build_image_request(
+                "back_fisheye_image", pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8, quality_percent=50)])[0]
+        except UnsupportedPixelFormatRequestedError as e:
+            return None
+
+    def get_images(self, image_requests: list[image_pb2.ImageRequest]) -> Optional[ImageBundle]:
+        try:
+            image_responses = self._image_client.get_image(image_requests)
+        except UnsupportedPixelFormatRequestedError as e:
+            return None
+        return ImageBundle(
+            frontleft=image_responses[0],
+            frontright=image_responses[1],
+            left=image_responses[2],
+            right=image_responses[3],
+            back=image_responses[4],
+        )
+
+    def get_camera_images(self) -> ImageBundle:
+        return self.get_images(self._camera_image_requests)
+
+    def get_depth_images(self) -> ImageBundle:
+        return self.get_images(self._depth_image_requests)
+
+    def get_depth_registered_images(self) -> ImageBundle:
+        return self.get_images(self._depth_registered_image_requests)

--- a/spot_driver/spot_driver/spot_wrapper.py
+++ b/spot_driver/spot_driver/spot_wrapper.py
@@ -36,13 +36,13 @@ from bosdyn.api import basic_command_pb2
 from google.protobuf.timestamp_pb2 import Timestamp
 
 front_image_sources_rgb = ['frontleft_fisheye_image', 'frontright_fisheye_image']
-front_image_sources_depth = ['frontleft_depth', 'frontright_depth']
+front_image_sources_depth = ['frontleft_depth', 'frontright_depth', 'frontleft_depth_in_visual_frame', 'frontright_depth_in_visual_frame']
 """List of image sources for front image periodic query"""
 side_image_sources_rgb = ['left_fisheye_image', 'right_fisheye_image']
-side_image_sources_depth = ['left_depth', 'right_depth']
+side_image_sources_depth = ['left_depth', 'right_depth', 'right_depth_in_visual_frame', 'left_depth_in_visual_frame']
 """List of image sources for side image periodic query"""
 rear_image_sources_rgb = ['back_fisheye_image']
-rear_image_sources_depth = ['back_depth']
+rear_image_sources_depth = ['back_depth', 'back_depth_in_visual_frame']
 """List of image sources for rear image periodic query"""
 
 class AsyncRobotState(AsyncPeriodicQuery):

--- a/spot_driver/spot_driver/spot_wrapper.py
+++ b/spot_driver/spot_driver/spot_wrapper.py
@@ -35,11 +35,14 @@ import bosdyn.api.robot_state_pb2 as robot_state_proto
 from bosdyn.api import basic_command_pb2
 from google.protobuf.timestamp_pb2 import Timestamp
 
-front_image_sources = ['frontleft_fisheye_image', 'frontright_fisheye_image', 'frontleft_depth', 'frontright_depth']
+front_image_sources_rgb = ['frontleft_fisheye_image', 'frontright_fisheye_image']
+front_image_sources_depth = ['frontleft_depth', 'frontright_depth']
 """List of image sources for front image periodic query"""
-side_image_sources = ['left_fisheye_image', 'right_fisheye_image', 'left_depth', 'right_depth']
+side_image_sources_rgb = ['left_fisheye_image', 'right_fisheye_image']
+side_image_sources_depth = ['left_depth', 'right_depth']
 """List of image sources for side image periodic query"""
-rear_image_sources = ['back_fisheye_image', 'back_depth']
+rear_image_sources_rgb = ['back_fisheye_image']
+rear_image_sources_depth = ['back_depth']
 """List of image sources for rear image periodic query"""
 
 class AsyncRobotState(AsyncPeriodicQuery):
@@ -267,16 +270,34 @@ class SpotWrapper():
         self._last_robot_command = None
 
         self._front_image_requests = []
-        for source in front_image_sources:
-            self._front_image_requests.append(build_image_request(source, image_format=image_pb2.Image.FORMAT_RAW))
-
         self._side_image_requests = []
-        for source in side_image_sources:
-            self._side_image_requests.append(build_image_request(source, image_format=image_pb2.Image.FORMAT_RAW))
-
         self._rear_image_requests = []
-        for source in rear_image_sources:
-            self._rear_image_requests.append(build_image_request(source, image_format=image_pb2.Image.FORMAT_RAW))
+
+        # RGB
+        for source in front_image_sources_rgb:
+            self._front_image_requests.append(build_image_request(
+                source, image_format=image_pb2.Image.FORMAT_RAW, pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8))
+
+        for source in side_image_sources_rgb:
+            self._side_image_requests.append(build_image_request(
+                source, image_format=image_pb2.Image.FORMAT_RAW, pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8))
+
+        for source in rear_image_sources_rgb:
+            self._rear_image_requests.append(build_image_request(
+                source, image_format=image_pb2.Image.FORMAT_RAW, pixel_format=image_pb2.Image.PIXEL_FORMAT_RGB_U8))
+
+        # Depth
+        for source in front_image_sources_depth:
+            self._side_image_requests.append(build_image_request(
+                source, image_format=image_pb2.Image.FORMAT_RAW, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16))
+
+        for source in side_image_sources_depth:
+            self._rear_image_requests.append(build_image_request(
+                source, image_format=image_pb2.Image.FORMAT_RAW, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16))
+
+        for source in rear_image_sources_depth:
+            self._rear_image_requests.append(build_image_request(
+                source, image_format=image_pb2.Image.FORMAT_RAW, pixel_format=image_pb2.Image.PIXEL_FORMAT_DEPTH_U16))
 
         try:
             self._sdk = create_standard_sdk('ros_spot')

--- a/spot_driver/spot_driver/spot_wrapper.py
+++ b/spot_driver/spot_driver/spot_wrapper.py
@@ -36,13 +36,16 @@ from bosdyn.api import basic_command_pb2
 from google.protobuf.timestamp_pb2 import Timestamp
 
 front_image_sources_rgb = ['frontleft_fisheye_image', 'frontright_fisheye_image']
-front_image_sources_depth = ['frontleft_depth', 'frontright_depth', 'frontleft_depth_in_visual_frame', 'frontright_depth_in_visual_frame']
+# front_image_sources_depth = ['frontleft_depth', 'frontright_depth', 'frontleft_depth_in_visual_frame', 'frontright_depth_in_visual_frame']
+front_image_sources_depth = ['frontleft_depth', 'frontright_depth']
 """List of image sources for front image periodic query"""
 side_image_sources_rgb = ['left_fisheye_image', 'right_fisheye_image']
-side_image_sources_depth = ['left_depth', 'right_depth', 'right_depth_in_visual_frame', 'left_depth_in_visual_frame']
+# side_image_sources_depth = ['left_depth', 'right_depth', 'right_depth_in_visual_frame', 'left_depth_in_visual_frame']
+side_image_sources_depth = ['left_depth', 'right_depth']
 """List of image sources for side image periodic query"""
 rear_image_sources_rgb = ['back_fisheye_image']
-rear_image_sources_depth = ['back_depth', 'back_depth_in_visual_frame']
+# rear_image_sources_depth = ['back_depth', 'back_depth_in_visual_frame']
+rear_image_sources_depth = ['back_depth']
 """List of image sources for rear image periodic query"""
 
 class AsyncRobotState(AsyncPeriodicQuery):


### PR DESCRIPTION
The current publisher for RGB and depth images is slow. I have made the following improvements
- Added publishing the correct scoped frame_id for images
- Removed image publishing from spot_ros2.py and created a separate node to publish rgb, depth, or depth_registered
- Added arguments to publish depth_registered or depth aligned with the rgb frame