### PR TITLE
Declares hostname as a launch argument

### DIFF
--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -38,10 +38,18 @@ def generate_launch_description():
         default_value="false",
     )
 
+    hostname = LaunchConfiguration("hostname")
+    hostname_arg = DeclareLaunchArgument(
+        "hostname",
+        description="The IP address of the spot. This value is overriden by the SPOT_IP environment variable",
+        default_value="10.0.0.3",
+    )
+
     driver_params = {
         'publish_rgb': publish_rgb,
         'publish_depth': publish_depth,
-        'publish_depth_registered': publish_depth_registered
+        'publish_depth_registered': publish_depth_registered,
+        'hostname': hostname,
     }
     spot_driver_node = launch_ros.actions.Node(
         package='spot_driver',
@@ -62,6 +70,7 @@ def generate_launch_description():
         publish_rgb_arg,
         publish_depth_arg,
         publish_depth_registered_arg,
+        hostname_arg,
         config_file_arg,
         spot_driver_node,
         robot_state_publisher,

--- a/spot_driver/launch/spot_driver_with_namespace.launch.py
+++ b/spot_driver/launch/spot_driver_with_namespace.launch.py
@@ -41,11 +41,19 @@ def generate_launch_description():
         default_value="false",
     )
 
+    hostname = LaunchConfiguration("hostname")
+    hostname_arg = DeclareLaunchArgument(
+        "hostname",
+        description="The IP address of the spot. This value is overriden by the SPOT_IP environment variable",
+        default_value="10.0.0.3",
+    )
+
     driver_params = {
         'spot_name': spot_name,
         'publish_rgb': publish_rgb,
         'publish_depth': publish_depth,
         'publish_depth_registered': publish_depth_registered,
+        'hostname': hostname,
     }
     spot_driver_node = launch_ros.actions.Node(
         package='spot_driver',
@@ -69,6 +77,7 @@ def generate_launch_description():
         publish_depth_arg,
         publish_depth_registered_arg,
         spot_name_arg,
+        hostname_arg,
         config_file_arg,
         spot_driver_node,
         robot_state_publisher,


### PR DESCRIPTION
This allows the hostname to be specified via an argument to the launch command, or via a child launch file that includes the spot driver with IncludeLaunchDescription. The `SPOT_IP` environment variable will override the argument if both are specified.