### PR TITLE
Move spot_wrapper to bdaiinstitute repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "spot_wrapper"]
 	path = spot_wrapper
-	url = git@github.com:heuristicus/spot_wrapper
+	url = git@github.com:bdaiinstitute/spot_wrapper


### PR DESCRIPTION
This fixes the submodule pointing to the wrong repository and includes the most recent commit in the bdaiinstitute repo.