### PR TITLE
Use https submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "spot_wrapper"]
 	path = spot_wrapper
-	url = git@github.com:bdaiinstitute/spot_wrapper
+	url = https://github.com/bdaiinstitute/spot_wrapper.git
 [submodule "ros_utilities"]
 	path = ros_utilities
 	url = https://github.com/bdaiinstitute/ros_utilities.git

--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -2,7 +2,7 @@ ROS_DISTRO=humble  # only humble is currently supported by install script
 # Install BD API
 pip3 install bosdyn-client bosdyn-mission bosdyn-api bosdyn-core
 # Install ROS dependencies
-sudo apt install ros-$ROS_DISTRO-joint-state-publisher-gui ros-$ROS_DISTRO-tf-transformations ros-$ROS_DISTRO-xacro ros-$ROS_DISTRO-depth-image-proc
+sudo apt install -y ros-$ROS_DISTRO-joint-state-publisher-gui ros-$ROS_DISTRO-tf-transformations ros-$ROS_DISTRO-xacro ros-$ROS_DISTRO-depth-image-proc
 # Install bosdyn_msgs - automatic conversions of BD protobufs to ROS messages
 wget -q -O /tmp/ros-humble-bosdyn-msgs_0.0.0-0jammy_amd64.deb https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/v0.0.0-humble/ros-humble-bosdyn-msgs_0.0.0-0jammy_amd64.deb
 sudo dpkg -i /tmp/ros-humble-bosdyn-msgs_0.0.0-0jammy_amd64.deb


### PR DESCRIPTION
HTTPS submodules are preferred for public distribution because they don't require additional setup and SSH may be blocked on some networks.

I also added `-y` to the `apt install` command to make things smoother e.g. when running in a Docker build.