### PR TITLE
Fixed has_arm

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1209,7 +1209,7 @@ def main(args=None):
                 callback_group=spot_ros.depth_registered_callback_group,
             )
 
-            node.declare_parameter("has_arm", has_arm)
+        node.declare_parameter("has_arm", has_arm)
 
         # Status Publishers #
         spot_ros.joint_state_pub = node.create_publisher(JointState, 'joint_states', 1)


### PR DESCRIPTION
The `has_arm` parameter was hidden under a conditional and wasn't accessible unless you were publishing `depth_registered` images. Unindented and now we can access this parameter. 