### PR TITLE
Fix publish_depth_registered overwritten in spot_ros2

### DIFF
--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -49,7 +49,7 @@ def generate_launch_description():
         executable='spot_ros2',
         name='spot_ros2',
         output='screen',
-        parameters=[config_file, driver_params]
+        parameters=[config_file]
     )
 
     params = {'robot_description': robot_desc}

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -39,11 +39,6 @@ def generate_launch_description():
         default_value="false",
     )
 
-    driver_params = {
-        'publish_rgb': publish_rgb,
-        'publish_depth': publish_depth,
-        'publish_depth_registered': publish_depth_registered
-    }
     spot_driver_node = launch_ros.actions.Node(
         package='spot_driver',
         executable='spot_ros2',

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -18,27 +18,6 @@ def generate_launch_description():
     doc = xacro.process_file(xacro_file)
     robot_desc = doc.toprettyxml(indent='  ')
 
-    publish_rgb = LaunchConfiguration("publish_rgb", default="true")
-    publish_rgb_arg = DeclareLaunchArgument(
-        "publish_rgb",
-        description="Start publishing all RGB channels on Spot cameras",
-        default_value="true",
-    )
-
-    publish_depth = LaunchConfiguration("publish_depth", default="true")
-    publish_depth_arg = DeclareLaunchArgument(
-        "publish_depth",
-        description="Start publishing all depth channels on Spot cameras",
-        default_value="true",
-    )
-
-    publish_depth_registered = LaunchConfiguration("publish_depth_registered", default="false")
-    publish_depth_registered_arg = DeclareLaunchArgument(
-        "publish_depth_registered",
-        description="Start publishing all depth_registered channels on Spot cameras",
-        default_value="false",
-    )
-
     spot_driver_node = launch_ros.actions.Node(
         package='spot_driver',
         executable='spot_ros2',
@@ -55,9 +34,6 @@ def generate_launch_description():
         parameters=[params])
 
     return launch.LaunchDescription([
-        publish_rgb_arg,
-        publish_depth_arg,
-        publish_depth_registered_arg,
         config_file_arg,
         spot_driver_node,
         robot_state_publisher,

--- a/spot_driver/launch/spot_driver_with_namespace.launch.py
+++ b/spot_driver/launch/spot_driver_with_namespace.launch.py
@@ -41,12 +41,6 @@ def generate_launch_description():
         default_value="false",
     )
 
-    driver_params = {
-        'spot_name': spot_name,
-        'publish_rgb': publish_rgb,
-        'publish_depth': publish_depth,
-        'publish_depth_registered': publish_depth_registered,
-    }
     spot_driver_node = launch_ros.actions.Node(
         package='spot_driver',
         executable='spot_ros2',

--- a/spot_driver/launch/spot_driver_with_namespace.launch.py
+++ b/spot_driver/launch/spot_driver_with_namespace.launch.py
@@ -53,7 +53,7 @@ def generate_launch_description():
         name='spot_ros2',
         output='screen',
         namespace=spot_name,
-        parameters=[config_file, driver_params]
+        parameters=[config_file]
     )
 
     params = {'robot_description': robot_desc, 'frame_prefix': PathJoinSubstitution([spot_name, ''])}

--- a/spot_driver/launch/spot_driver_with_namespace.launch.py
+++ b/spot_driver/launch/spot_driver_with_namespace.launch.py
@@ -47,7 +47,7 @@ def generate_launch_description():
         name='spot_ros2',
         output='screen',
         namespace=spot_name,
-        parameters=[config_file]
+        parameters=[config_file, {'spot_name': spot_name}]
     )
 
     params = {'robot_description': robot_desc, 'frame_prefix': PathJoinSubstitution([spot_name, ''])}

--- a/spot_driver/launch/spot_driver_with_namespace.launch.py
+++ b/spot_driver/launch/spot_driver_with_namespace.launch.py
@@ -20,27 +20,6 @@ def generate_launch_description():
     doc = xacro.process_file(xacro_file)
     robot_desc = doc.toprettyxml(indent='  ')
 
-    publish_rgb = LaunchConfiguration("publish_rgb", default="true")
-    publish_rgb_arg = DeclareLaunchArgument(
-        "publish_rgb",
-        description="Start publishing all RGB channels on Spot cameras",
-        default_value="true",
-    )
-
-    publish_depth = LaunchConfiguration("publish_depth", default="true")
-    publish_depth_arg = DeclareLaunchArgument(
-        "publish_depth",
-        description="Start publishing all depth channels on Spot cameras",
-        default_value="true",
-    )
-
-    publish_depth_registered = LaunchConfiguration("publish_depth_registered", default="false")
-    publish_depth_registered_arg = DeclareLaunchArgument(
-        "publish_depth_registered",
-        description="Start publishing all depth_registered channels on Spot cameras",
-        default_value="false",
-    )
-
     spot_driver_node = launch_ros.actions.Node(
         package='spot_driver',
         executable='spot_ros2',
@@ -59,9 +38,6 @@ def generate_launch_description():
         parameters=[params])
 
     return launch.LaunchDescription([
-        publish_rgb_arg,
-        publish_depth_arg,
-        publish_depth_registered_arg,
         spot_name_arg,
         config_file_arg,
         spot_driver_node,


### PR DESCRIPTION
## Issue Description

When I add publish_depth_registered: True in spot_ros.yaml, this parameter on spot_ros2 is still False. 
```
$ ros2 param get /Gosu/spot_ros2 publish_depth_registered
Boolean value is: False
```
I tried adding a print statement inside spot_ros2, and indeed, I get False for `publish_depth_registered`.

However, for some other parameters, like `auto_claim`, auto_stand, I am able to change their values in spot_ros.yaml file and have them reflected in the spot_ros2 node.

 Similarly, I tried adding a print statement inside spot_ros2 to test for auto_stand and it works.


## Cause

In `spot_driver_with_namespace.launch.py` and `spot_driver.launch.py`, the default value of the parameter `publish_depth_registered` (False) overwrites the parameter set in the YAML configuration file.


## Solution

Remove `drivers_params` entirely, including the declared arguments. Enforce the configuration of `publish_x_args` through configuration file.  Exception is made for `spot_name` in  `spot_driver_with_namespace.launch.py`.

The general reason, I believe, is that in ROS, we should separate out parameters we want to be defined through the command line vs. defined through the configuration file.  In the case of spot_ros2,   `spot_name` should be declared on the command line (for quick change), and the rest go into the configuration file (potentially more stable).  This adds clarity to how to configure for spot_ros2 as well. 