### PR TITLE
[SW-143] Add Spot name to the wrapper logger name 

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1009,8 +1009,12 @@ def main(args=None):
                                 + frame_prefix + '"vision".')
         return
 
-    # logger
-    spot_ros.wrapper_logger = rcutils_logger.RcutilsLogger(name=f"{spot_ros.name}.spot_wrapper")
+    # logger for spot wrapper
+    name_with_dot = ''
+    if spot_ros.name is not None:
+        name_with_dot = spot_ros.name + "."
+    spot_ros.wrapper_logger = rcutils_logger.RcutilsLogger(name=f"{name_with_dot}spot_wrapper")
+
     name_str = ''
     if spot_ros.name is not None:
         name_str = ' for ' + spot_ros.name

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1010,7 +1010,7 @@ def main(args=None):
         return
 
     # logger
-    spot_ros.wrapper_logger = rcutils_logger.RcutilsLogger(name="spot_wrapper")
+    spot_ros.wrapper_logger = rcutils_logger.RcutilsLogger(name=f"{spot_ros.name}.spot_wrapper")
     name_str = ''
     if spot_ros.name is not None:
         name_str = ' for ' + spot_ros.name


### PR DESCRIPTION
Extremely simple fix to make spot_wrapper log robot-specific too.


Now that logging within spot_wrapper is working, you get logs like:
```
[spot_ros2-1] [INFO] [1683750769.364323221] [Gosu.spot_ros2]: Starting ROS driver for Spot for Gosu
[spot_ros2-1] [INFO] [1683750769.365105183] [spot_wrapper]: Initialising robot at 10.17.30.31
[spot_ros2-1] [INFO] [1683750769.365348574] [spot_wrapper]: Trying to authenticate with robot...
[spot_ros2-1] [INFO] [1683750770.994341303] [spot_wrapper]: Successfully authenticated.
[spot_ros2-1] [INFO] [1683750770.995229933] [spot_wrapper]: Creating clients...
[spot_ros2-1] [INFO] [1683750770.998374009] [spot_wrapper]: No point cloud services are available.
 ```

The hope of this PR is to also add robot name to the [spot_wrapper] so that this works better for a multi-robot system.  

After this PR, you get,
```
[spot_ros2-1] [INFO] [1683751379.813513637] [Gosu.spot_ros2]: Starting ROS driver for Spot for Gosu
[spot_ros2-1] [INFO] [1683751379.814412255] [Gosu.spot_wrapper]: Initialising robot at 10.17.30.31
[spot_ros2-1] [INFO] [1683751379.814673813] [Gosu.spot_wrapper]: Trying to authenticate with robot...
[spot_ros2-1] [INFO] [1683751380.557309995] [Gosu.spot_wrapper]: Successfully authenticated.
[spot_ros2-1] [INFO] [1683751380.866416768] [Gosu.spot_wrapper]: Creating clients...
[spot_ros2-1] [INFO] [1683751380.903602770] [Gosu.spot_wrapper]: No point cloud services are available.
```