### PR TITLE
[SW-138] Adding graph_nav_upload_graph service handler

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -748,7 +748,9 @@ class SpotROS:
             response.success = True
             response.message = "Success"
         except Exception as e:
-            self.node.get_logger().error(f"Exception Error:{e}; \n {traceback.format_exc()}")
+            self.node.get_logger().error(f"Error:{e}; \n {traceback.format_exc()}")
+            response.success = False
+            response.message = f"Error:{e}"
         return response
 
     def handle_list_graph(self, request, response):

--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -55,6 +55,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/SetLocomotion.srv"
   "srv/SetVelocity.srv"
   "srv/ClearBehaviorFault.srv"
+  "srv/GraphNavUploadGraph.srv"
   "action/NavigateTo.action"
   "action/RobotCommand.action"
   "action/Trajectory.action"

--- a/spot_msgs/srv/GraphNavUploadGraph.srv
+++ b/spot_msgs/srv/GraphNavUploadGraph.srv
@@ -1,0 +1,6 @@
+# Loads the GraphNav map from 'upload_filepath' and
+# uploads it to the GraphNav server using UploadGraph rpc.
+string upload_filepath
+---
+bool success
+string message


### PR DESCRIPTION
This PR is for part of SW-138.  Adds a service for upload graph, given a file path. This PR goes together with one in bdai and one in spot_wrapper. The test is in bdai.

* https://github.com/bdaiinstitute/spot_ros2/pull/55
* https://github.com/bdaiinstitute/spot_wrapper/pull/12

When the service handler is called, the following driver log happens:
```
[spot_ros2-1] [INFO] [1683815953.577940734] [Gosu.spot_ros2]: Uploading GraphNav map: /workspaces/bdai/ws/src/spot_maps/maps/bdai5picasso
[spot_ros2-1] [INFO] [1683815953.579430977] [spot_wrapper]: Loading the graph from disk into local storage...
[spot_ros2-1] [INFO] [1683815953.580826267] [spot_wrapper]: Loaded graph has 23 waypoints and 26 edges
[spot_ros2-1] [INFO] [1683815953.587187860] [spot_wrapper]: Uploading the graph and snapshots to the robot...
[spot_ros2-1] [INFO] [1683815953.877267127] [spot_wrapper]: Uploaded snapshot_edgy-egg-xQaSq54VuWCgFsWe5ByY9g==
[spot_ros2-1] [INFO] [1683815954.112413740] [spot_wrapper]: Uploaded snapshot_fuggy-kelp-oOq99bWbMLTEWBJRRv7xPw==
...
[spot_ros2-1] [INFO] [1683815958.734839673] [Gosu.spot_ros2]: Uploaded
```

For context, "upload graph" corresponds to a RPC call [in Spot SDK](https://dev.bostondynamics.com/_modules/bosdyn/client/graph_nav#GraphNavClient.upload_graph:~:text=%5Bdocs%5D-,def%20upload_graph,-(self%2C)) that uploads a map file to the GraphNav server running on Spot.