### PR TITLE
[N/A] Fixing typo in depth registered info pub creation

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1062,7 +1062,7 @@ def main(args=None):
         if spot_ros.publish_depth_registered.value:
             for camera_name in spot_ros.cameras_used.value:
                 setattr(spot_ros, f"{camera_name}_depth_registered_pub", node.create_publisher(Image, f"depth_registered/{camera_name}/image", 1))
-                setattr(spot_ros, f"{camera_name}_depth_registered_pub", node.create_publisher(CameraInfo, f"depth_registered/{camera_name}/camera_info", 1))
+                setattr(spot_ros, f"{camera_name}_depth_registered_info_pub", node.create_publisher(CameraInfo, f"depth_registered/{camera_name}/camera_info", 1))
 
             node.create_timer(
                 1 / spot_ros.rates['front_image'],


### PR DESCRIPTION
There is a typo when initializing the camera info publisher for registered depth images. This caused the `publish_depth_registered_images_callback` callback to fail due to exception. After fixing this typo, the callback works. I can receive registered depth images at around 1-3hz.