### PR TITLE
[SW-174] Allow camera setting for point cloud streaming; fixing RGB cloud streaming

### DIFF
--- a/spot_driver/launch/point_cloud_xyz.launch.py
+++ b/spot_driver/launch/point_cloud_xyz.launch.py
@@ -45,117 +45,35 @@ def generate_launch_description():
     spot_name = LaunchConfiguration('spot_name')
     spot_name_arg = DeclareLaunchArgument('spot_name', description='Name of spot')
 
-    return LaunchDescription([
-        spot_name_arg,
+    camera = LaunchConfiguration('camera')
+    camera_arg = DeclareLaunchArgument('camera', description='Name of camera')
 
-        # launch plugin through rclcpp_components container
-        launch_ros.actions.ComposableNodeContainer(
-            name='frontleft_container',
-            namespace=spot_name,
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                # Driver itself
-                launch_ros.descriptions.ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzNode',
-                    name='point_cloud_xyz_frontleft',
-                    remappings=[
-                        ('image_rect', PathJoinSubstitution([spot_name, "depth/frontleft/image"])),
-                        ('camera_info', PathJoinSubstitution([spot_name, "depth/frontleft/camera_info"])),
-                        ('image', PathJoinSubstitution([spot_name, "depth/frontleft/image"])),
-                        ('points', PathJoinSubstitution([spot_name, "depth/frontleft/points"]))
-                    ]
-                ),
-            ],
-            output='screen',
-        ),
-        
-        launch_ros.actions.ComposableNodeContainer(
-            name='frontright_container',
-            namespace=spot_name,
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                # Driver itself
-                launch_ros.descriptions.ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzNode',
-                    name='point_cloud_xyz_frontright',
-                    remappings=[
-                        ('image_rect', PathJoinSubstitution([spot_name, "depth/frontright/image"])),
-                        ('camera_info', PathJoinSubstitution([spot_name, "depth/frontright/camera_info"])),
-                        ('image', PathJoinSubstitution([spot_name, "depth/frontright/image"])),
-                        ('points', PathJoinSubstitution([spot_name, "depth/frontright/points"]))
-                    ]
-                ),
-            ],
-            output='screen',
-        ),
-
-        launch_ros.actions.ComposableNodeContainer(
-            name='back_container',
-            namespace=spot_name,
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                # Driver itself
-                launch_ros.descriptions.ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzNode',
-                    name='point_cloud_xyz_back',
-                    remappings=[
-                        ('image_rect', PathJoinSubstitution([spot_name, "depth/back/image"])),
-                        ('camera_info', PathJoinSubstitution([spot_name, "depth/back/camera_info"])),
-                        ('image', PathJoinSubstitution([spot_name, "depth/back/image"])),
-                        ('points', PathJoinSubstitution([spot_name, "depth/back/points"]))
-                    ]
-                ),
-            ],
-            output='screen',
-        ),
-        
-        launch_ros.actions.ComposableNodeContainer(
-            name='left_container',
-            namespace=spot_name,
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                # Driver itself
-                launch_ros.descriptions.ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzNode',
-                    name='point_cloud_xyz_left',
-                    remappings=[
-                        ('image_rect', PathJoinSubstitution([spot_name, "depth/left/image"])),
-                        ('camera_info', PathJoinSubstitution([spot_name, "depth/left/camera_info"])),
-                        ('image', PathJoinSubstitution([spot_name, "depth/left/image"])),
-                        ('points', PathJoinSubstitution([spot_name, "depth/left/points"]))
-                    ]
-                ),
-            ],
-            output='screen',
-        ),
-
-        launch_ros.actions.ComposableNodeContainer(
-            name='right_container',
-            namespace=spot_name,
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                # Driver itself
-                launch_ros.descriptions.ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzNode',
-                    name='point_cloud_xyz_right',
-                    remappings=[
-                        ('image_rect', PathJoinSubstitution([spot_name, "depth/right/image"])),
-                        ('camera_info', PathJoinSubstitution([spot_name, "depth/right/camera_info"])),
-                        ('image', PathJoinSubstitution([spot_name, "depth/right/image"])),
-                        ('points', PathJoinSubstitution([spot_name, "depth/right/points"]))
-                    ]
-                ),
-            ],
-            output='screen',
-        ),
-    ])
+    ld = LaunchDescription(
+        [
+            spot_name_arg,
+            camera_arg,
+            # launch plugin through rclcpp_components container
+            launch_ros.actions.ComposableNodeContainer(
+                name=(camera, '_container'),
+                namespace=spot_name,
+                package='rclcpp_components',
+                executable='component_container',
+                composable_node_descriptions=[
+                    # Driver itself
+                    launch_ros.descriptions.ComposableNode(
+                        package='depth_image_proc',
+                        plugin='depth_image_proc::PointCloudXyzNode',
+                        name=('point_cloud_xyz_', camera),
+                        remappings=[
+                            ('image_rect', PathJoinSubstitution([spot_name, "depth", camera, "image"])),
+                            ('camera_info', PathJoinSubstitution([spot_name, "depth", camera, "camera_info"])),
+                            ('image', PathJoinSubstitution([spot_name, "depth", camera, "image"])),
+                            ('points', PathJoinSubstitution([spot_name, "depth", camera, "points"]))
+                        ]
+                    ),
+                ],
+                output='screen',
+            ),
+        ]
+    )
+    return ld

--- a/spot_driver/launch/point_cloud_xyzrgb.launch.py
+++ b/spot_driver/launch/point_cloud_xyzrgb.launch.py
@@ -45,126 +45,35 @@ def generate_launch_description():
     spot_name = LaunchConfiguration('spot_name')
     spot_name_arg = DeclareLaunchArgument('spot_name', description='Name of spot')
 
-    return LaunchDescription([
-        spot_name_arg,
+    camera = LaunchConfiguration('camera')
+    camera_arg = DeclareLaunchArgument('camera', description='Name of camera')
 
-        # launch plugin through rclcpp_components container
-        launch_ros.actions.ComposableNodeContainer(
-            name='frontleft_container',
-            namespace=spot_name,
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                # Driver itself
-                launch_ros.descriptions.ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzNode',
-                    name='point_cloud_xyz_frontleft',
-                    remappings=[
-                        ('image_rect', PathJoinSubstitution([spot_name, "depth/frontleft/image"])),
-                        ('camera_info', PathJoinSubstitution([spot_name, "depth/frontleft/camera_info"])),
-                        ('image', PathJoinSubstitution([spot_name, "depth/frontleft/image"])),
-                        ('points', PathJoinSubstitution([spot_name, "depth/frontleft/points"]))
-                    ]
-                ),
-            ],
-            output='screen',
-        ),
-        
-        launch_ros.actions.ComposableNodeContainer(
-            name='frontright_container',
-            namespace=spot_name,
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                # Driver itself
-                launch_ros.descriptions.ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzNode',
-                    name='point_cloud_xyz_frontright',
-                    remappings=[
-                        ('image_rect', PathJoinSubstitution([spot_name, "depth/frontright/image"])),
-                        ('camera_info', PathJoinSubstitution([spot_name, "depth/frontright/camera_info"])),
-                        ('image', PathJoinSubstitution([spot_name, "depth/frontright/image"])),
-                        ('points', PathJoinSubstitution([spot_name, "depth/frontright/points"]))
-                    ]
-                ),
-            ],
-            output='screen',
-        ),
-
-        launch_ros.actions.ComposableNodeContainer(
-            name='back_container',
-            namespace=spot_name,
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                launch_ros.descriptions.ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzrgbNode',
-                    name='point_cloud_xyzrgb_node',
-                    remappings=[('rgb/camera_info', '/camera/color/camera_info'),
-                                ('rgb/image_rect_color', '/camera/color/image_raw'),
-                                ('depth_registered/image_rect', '/camera/aligned_depth_to_color/image_raw'),
-                                ('points', '/camera/depth_registered/points')]
-                ),
-                # Driver itself
-                launch_ros.descriptions.ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzNode',
-                    name='point_cloud_xyz_back',
-                    remappings=[
-                        ('rgb/camera_info', PathJoinSubstitution([spot_name, "depth/back/image"])),
-                        ('rgb/image_rect_color', PathJoinSubstitution([spot_name, "depth/back/camera_info"])),
-                        ('depth_registered/image_rect', PathJoinSubstitution([spot_name, "depth/back/image"])),
-                        ('points', PathJoinSubstitution([spot_name, "depth/back/points"]))
-                    ]
-                ),
-            ],
-            output='screen',
-        ),
-        
-        launch_ros.actions.ComposableNodeContainer(
-            name='left_container',
-            namespace=spot_name,
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                # Driver itself
-                launch_ros.descriptions.ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzNode',
-                    name='point_cloud_xyz_left',
-                    remappings=[
-                        ('image_rect', PathJoinSubstitution([spot_name, "depth/left/image"])),
-                        ('camera_info', PathJoinSubstitution([spot_name, "depth/left/camera_info"])),
-                        ('image', PathJoinSubstitution([spot_name, "depth/left/image"])),
-                        ('points', PathJoinSubstitution([spot_name, "depth/left/points"]))
-                    ]
-                ),
-            ],
-            output='screen',
-        ),
-
-        launch_ros.actions.ComposableNodeContainer(
-            name='right_container',
-            namespace=spot_name,
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                # Driver itself
-                launch_ros.descriptions.ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzNode',
-                    name='point_cloud_xyz_right',
-                    remappings=[
-                        ('image_rect', PathJoinSubstitution([spot_name, "depth/right/image"])),
-                        ('camera_info', PathJoinSubstitution([spot_name, "depth/right/camera_info"])),
-                        ('image', PathJoinSubstitution([spot_name, "depth/right/image"])),
-                        ('points', PathJoinSubstitution([spot_name, "depth/right/points"]))
-                    ]
-                ),
-            ],
-            output='screen',
-        ),
-    ])
+    ld = LaunchDescription(
+        [
+            spot_name_arg,
+            camera_arg,
+            # launch plugin through rclcpp_components container
+            launch_ros.actions.ComposableNodeContainer(
+                name=(camera, '_container'),
+                namespace=spot_name,
+                package='rclcpp_components',
+                executable='component_container',
+                composable_node_descriptions=[
+                    # Driver itself
+                    launch_ros.descriptions.ComposableNode(
+                        package='depth_image_proc',
+                        plugin='depth_image_proc::PointCloudXyzrgbNode',
+                        name=('point_cloud_xyzrgb_', camera),
+                        remappings=[
+                            ('rgb/camera_info', PathJoinSubstitution([spot_name, "camera", camera, "camera_info"])),
+                            ('rgb/image_rect_color', PathJoinSubstitution([spot_name, "camera", camera, "image"])),
+                            ('depth_registered/image_rect', PathJoinSubstitution([spot_name, "depth_registered", camera, "image"])),
+                            ('points', PathJoinSubstitution([spot_name, "depth_registered", camera, "points"]))
+                        ]
+                    ),
+                ],
+                output='screen',
+            ),
+        ]
+    )
+    return ld

--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -154,7 +154,7 @@ def _create_image_msg(data: image_pb2.ImageResponse, robot_to_local_time: Callab
     # JPEG format
     if data.shot.image.format == image_pb2.Image.FORMAT_JPEG:
         cv2_image = cv2.imdecode(np.frombuffer(data.shot.image.data, dtype=np.uint8), -1)
-        image_msg = cv_bridge.cv2_to_imgmsg(cv2_image, encoding='passthrough')
+        image_msg = cv_bridge.cv2_to_imgmsg(cv2_image, encoding='rgb8')
         image_msg.header.stamp = stamp
         image_msg.header.frame_id = frame_id
 


### PR DESCRIPTION
This PR modifies the point_cloud_xyz.launch.py and point_cloud_xyzrgb.launch.py in spot_ros2 to take in a parameter for the camera used for streaming..  It would be straightforward to ‘include’ multiple such launch files if one wants to stream point clouds from different cameras.

This PR also fixes the colored point cloud streaming. To do this, the encoding for JPEG had to be changed to rgb8 because otherwise, the encoding of the image messages is 8UC3 which is not recognized by cv_bridge and causes
```
[component_container-1] terminate called after throwing an instance of 'cv_bridge::Exception'
[component_container-1]   what():  [8UC3] is not a color format. but [rgb8] is. The conversion does not make sense
```

See results in the following screenshots:

(Mono color)
![image-20230601-220325](https://github.com/bdaiinstitute/spot_ros2/assets/125413689/8459e0ed-a869-4337-832c-4c13f1226fec)


(RGB)
![image-20230601-223941](https://github.com/bdaiinstitute/spot_ros2/assets/125413689/1f3622cb-586f-42de-809e-c9d4dbdfdbf6)


