### PR TITLE
remove a magic number being multiplied to cmd_duration_secs in handle…

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1560,7 +1560,7 @@ class SpotROS(Node):
                 # check for timeout
                 com_dur = self.get_clock().now() - command_start_time
 
-                if com_dur.nanoseconds / 1e9 > (cmd_duration_secs * 10.3):
+                if com_dur.nanoseconds / 1e9 > cmd_duration_secs:
                     # timeout, quit with failure
                     self.get_logger().error("TIMEOUT")
                     feedback = Trajectory.Feedback()


### PR DESCRIPTION
…_trajectory

suppose we give a target with duration of 5 seconds, if spot doesn't reach it in 5 seconds, this action continues to run for 51 (5*10.3), fix it

I'm not sure if was intended for something else