### PR TITLE
[OC-4] Added new wrappers for choreography

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -356,12 +356,13 @@ class SpotROS:
     
     def handle_list_all_moves(self, request, response):
         """ROS service handler for getting list of already uploaded moves."""
-        response.success, response.message, response.dances = self.spot_wrapper.list_all_moves()
+        response.success, response.message, response.moves = self.spot_wrapper.list_all_moves()
         return response 
 
     def handle_upload_animation(self, request, response):
         """ROS service handler for uploading an animation."""
-        response.success, response.message = self.spot_wrapper.upload_animation(request.animation_file_content)
+        response.success, response.message = self.spot_wrapper.upload_animation(request.animation_name,
+                                                                                request.animation_file_content)
         return response
 
     def handle_stair_mode(self, request, response):

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -41,6 +41,7 @@ from spot_msgs.srv import SetLocomotion
 from spot_msgs.srv import ClearBehaviorFault
 from spot_msgs.srv import SetVelocity
 from spot_msgs.srv import ExecuteDance
+from spot_msgs.srv import UploadAnimation
 from spot_msgs.srv import GraphNavUploadGraph, GraphNavClearGraph, GraphNavSetLocalization, GraphNavGetLocalizationPose
 
 #####DEBUG/RELEASE: RELATIVE PATH NOT WORKING IN DEBUG
@@ -343,8 +344,13 @@ class SpotROS:
     
     def handle_execute_dance(self, request, response):
         """ROS service handler for uploading and executing dance."""
-        response.success, response.message = self.spot_wrapper.execute_dance(request.upload_filepath)
+        response.success, response.message = self.spot_wrapper.execute_dance(request.choreo_file_content)
         return response 
+
+    def handle_upload_animation(self, request, response):
+        """ROS service handler for uploading an animation."""
+        response.success, response.messsage = self.spot_wrapper.upload_animation(request.animation_file_content)
+        return response
 
     def handle_stair_mode(self, request, response):
         """ROS service handler to set a stair mode to the robot."""
@@ -1380,6 +1386,11 @@ def main(args=None):
                                                                spot_ros.handle_execute_dance, 
                                                                request, response),
             callback_group=spot_ros.group)
+        node.create_service(
+            UploadAnimation, "upload_animation",
+            lambda request, response: spot_ros.service_wrapper('upload_animation',
+                                                               spot_ros.handle_upload_animation,
+                                                               request, response),
         node.create_service(
             ListGraph, "list_graph",
             lambda request, response: spot_ros.service_wrapper('list_graph', spot_ros.handle_list_graph,

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -361,7 +361,7 @@ class SpotROS:
 
     def handle_upload_animation(self, request, response):
         """ROS service handler for uploading an animation."""
-        response.success, response.messsage = self.spot_wrapper.upload_animation(request.animation_file_content)
+        response.success, response.message = self.spot_wrapper.upload_animation(request.animation_file_content)
         return response
 
     def handle_stair_mode(self, request, response):

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -41,12 +41,9 @@ from spot_msgs.srv import SetLocomotion
 from spot_msgs.srv import ClearBehaviorFault
 from spot_msgs.srv import SetVelocity
 from spot_msgs.srv import ExecuteDance
-<<<<<<< HEAD
 from spot_msgs.srv import UploadAnimation
-=======
 from spot_msgs.srv import ListAllDances
 from spot_msgs.srv import ListAllMoves
->>>>>>> e5799d51a05a606d703e7818183b759ad14ac448
 from spot_msgs.srv import GraphNavUploadGraph, GraphNavClearGraph, GraphNavSetLocalization, GraphNavGetLocalizationPose
 
 #####DEBUG/RELEASE: RELATIVE PATH NOT WORKING IN DEBUG
@@ -349,10 +346,7 @@ class SpotROS:
     
     def handle_execute_dance(self, request, response):
         """ROS service handler for uploading and executing dance."""
-<<<<<<< HEAD
         response.success, response.message = self.spot_wrapper.execute_dance(request.choreo_file_content)
-=======
-        response.success, response.message = self.spot_wrapper.execute_dance(request.data)
         return response 
     
     def handle_list_all_dances(self, request, response):
@@ -363,7 +357,6 @@ class SpotROS:
     def handle_list_all_moves(self, request, response):
         """ROS service handler for getting list of already uploaded moves."""
         response.success, response.message, response.dances = self.spot_wrapper.list_all_moves()
->>>>>>> e5799d51a05a606d703e7818183b759ad14ac448
         return response 
 
     def handle_upload_animation(self, request, response):
@@ -1406,12 +1399,12 @@ def main(args=None):
                                                                request, response),
             callback_group=spot_ros.group)
         node.create_service(
-<<<<<<< HEAD
             UploadAnimation, "upload_animation",
             lambda request, response: spot_ros.service_wrapper('upload_animation',
                                                                spot_ros.handle_upload_animation,
                                                                request, response),
-=======
+            callback_group=spot_ros.group)
+        node.create_service(
             ListAllDances, "list_all_dances",
             lambda request, response: spot_ros.service_wrapper('list_all_dances', 
                                                                spot_ros.handle_list_all_dances, 
@@ -1423,7 +1416,6 @@ def main(args=None):
                                                                spot_ros.handle_list_all_moves, 
                                                                request, response),
             callback_group=spot_ros.group)
->>>>>>> e5799d51a05a606d703e7818183b759ad14ac448
         node.create_service(
             ListGraph, "list_graph",
             lambda request, response: spot_ros.service_wrapper('list_graph', spot_ros.handle_list_graph,

--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -54,6 +54,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/ListWorldObjects.srv"
   "srv/SetLocomotion.srv"
   "srv/SetVelocity.srv"
+  "srv/ExecuteDance.srv"
   "srv/ClearBehaviorFault.srv"
   "srv/GraphNavUploadGraph.srv"
   "srv/GraphNavClearGraph.srv"

--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -57,6 +57,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/ExecuteDance.srv"
   "srv/ListAllDances.srv"
   "srv/ListAllMoves.srv"
+  "srv/UploadAnimation.srv"
   "srv/ClearBehaviorFault.srv"
   "srv/GraphNavUploadGraph.srv"
   "srv/GraphNavClearGraph.srv"

--- a/spot_msgs/srv/ExecuteDance.srv
+++ b/spot_msgs/srv/ExecuteDance.srv
@@ -1,0 +1,4 @@
+string upload_filepath
+---
+bool success 
+string message

--- a/spot_msgs/srv/ExecuteDance.srv
+++ b/spot_msgs/srv/ExecuteDance.srv
@@ -1,4 +1,4 @@
-string upload_filepath
+string choreo_file_content
 ---
 bool success 
 string message

--- a/spot_msgs/srv/ListAllDances.srv
+++ b/spot_msgs/srv/ListAllDances.srv
@@ -1,4 +1,4 @@
 ---
 bool success 
-str message
+string message
 string[] dances

--- a/spot_msgs/srv/ListAllMoves.srv
+++ b/spot_msgs/srv/ListAllMoves.srv
@@ -1,4 +1,4 @@
 ---
 bool success 
-str moves
+string message
 string[] moves

--- a/spot_msgs/srv/UploadAnimation.srv
+++ b/spot_msgs/srv/UploadAnimation.srv
@@ -1,0 +1,4 @@
+string animation_file_content
+---
+bool success 
+string message

--- a/spot_msgs/srv/UploadAnimation.srv
+++ b/spot_msgs/srv/UploadAnimation.srv
@@ -1,3 +1,4 @@
+string animation_name
 string animation_file_content
 ---
 bool success 


### PR DESCRIPTION
Added ROS2 wrappers for:
1) uploading new animation files (i.e. dance moves in .cha format)
2) fetching the list of animated moves on a robot
3) fetching the list of all choreographs on a robot (same issue as above)
4) changed the implementation of upload_dance to upload the choreography file contents, instead of the file paths. This allows for uploading dance with the driver on a remote computer. 

## Notes
- Created three new types of services: ListAllMoves, ListAllDances, and UploadAnimation
- These new wrappers allow for the execution of a more diverse set of choreographs