### PR TITLE
Fix setuptools future deprecation in setup.cfg file

### DIFF
--- a/spot_driver/setup.cfg
+++ b/spot_driver/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/spot_driver
+script_dir=$base/lib/spot_driver
 [install]
-install-scripts=$base/lib/spot_driver
+install_scripts=$base/lib/spot_driver


### PR DESCRIPTION
When running `colcon` you'll get a warning about a `script-dir` and `install-scripts` will not be supported in future versions and to use the underscored versions. Small fix just to cut down on warnings that pop up during building the package.