### PR TITLE
[SW-232] Fixed conversions for map values which was submsgs from the protobuf

### DIFF
--- a/spot_driver/spot_driver/conversions.py
+++ b/spot_driver/spot_driver/conversions.py
@@ -5649,10 +5649,10 @@ def convert_bosdyn_msgs_frame_tree_snapshot_parent_edge_to_proto(ros_msg: "bosdy
 
 
 def convert_proto_to_bosdyn_msgs_frame_tree_snapshot(proto: "bosdyn.api.geometry_pb2.FrameTreeSnapshot", ros_msg: "bosdyn_msgs.msgs.FrameTreeSnapshot") -> None:
-    from bosdyn_msgs.msg import KeyStringValueBosdynMsgsParentEdge
+    from bosdyn_msgs.msg import KeyStringValueBosdynMsgsFrameTreeSnapshotParentEdge
     ros_msg.child_to_parent_edge_map = []
     for _item in proto.child_to_parent_edge_map:
-        ros_msg.child_to_parent_edge_map.append(KeyStringValueBosdynMsgsParentEdge())
+        ros_msg.child_to_parent_edge_map.append(KeyStringValueBosdynMsgsFrameTreeSnapshotParentEdge())
         ros_msg.child_to_parent_edge_map[-1].key = _item
         convert_proto_to_bosdyn_msgs_frame_tree_snapshot_parent_edge(proto.child_to_parent_edge_map[_item], ros_msg.child_to_parent_edge_map[-1].value)
 


### PR DESCRIPTION
This fixes a bug from the proto2ros conversion. 

protobufs allow submessages e.g.
```
message Outside
{
  message Inside
  {
    ...
  }
}
```

whereas ros msgs do not. When we generate the ros msgs we concatenate the message names, so the inner message would make a ros msg file for `OutsideInside`. protobuf also allows for `map`s whereas ros msgs do not, so we create a `Key<key-type>Value<value-type>` ros msg file. Previous proto2ros was not using the concatenated name for the import when converting a type that contained a map. It now does and this is the result. This specifically is need to use some of the manipulation API
