### PR TITLE
SW-276-fix-the-ros-walk-forward-example

### DIFF
--- a/examples/simple_arm_motion/README.md
+++ b/examples/simple_arm_motion/README.md
@@ -17,14 +17,19 @@ This is a simple example of using ROS2 to move the arm up and down and open and 
 ```bash
 ros2 launch spot_driver spot_driver.launch.py
 ```
+If you want to launch with a namespace,
+```bash
+ros2 launch spot_driver_with_namespace.launch.py spot_name:=<spot_name> 
+```
 
 5.  Run the example:
 ```bash
 ros2 run simple_arm_motion arm_simple
 ```
-
-The robot should move its arm up and down.
-
+If you launched the spot_ros2 driver with a namespace, use the following command instead:
+```bash
+ros2 run simple_arm_motion arm_simple --robot <spot_name>
+```
 
 ## Converting Direct API Calls to ROS2
 

--- a/examples/simple_arm_motion/simple_arm_motion/arm_simple.py
+++ b/examples/simple_arm_motion/simple_arm_motion/arm_simple.py
@@ -1,4 +1,7 @@
+import argparse
 import rclpy
+from typing import Optional
+
 from bdai_ros2_wrappers.action_client import ActionClientWrapper
 from bosdyn.api import geometry_pb2
 from bosdyn.client import math_helpers
@@ -12,13 +15,21 @@ import spot_driver.conversions as conv
 from spot_msgs.action import RobotCommand  # type: ignore
 
 
-def hello_arm() -> bool:
+def hello_arm(robot: Optional[str]) -> bool:
     # Set up basic ROS2 utilities for communicating with the driver
     node = Node("arm_simple")
-    tf_listener = TFListenerWrapper("arm_simple_tf", wait_for_transform=[ODOM_FRAME_NAME, GRAV_ALIGNED_BODY_FRAME_NAME])
+    name = ""
+    namespace = ""
+    if robot is not None:
+        name = robot + "/"
+        namespace = robot
+    tf_listener = TFListenerWrapper(
+        "arm_simple_tf", wait_for_transform=[name + ODOM_FRAME_NAME, name + GRAV_ALIGNED_BODY_FRAME_NAME]
+    )
 
-    robot = SimpleSpotCommander()
-    robot_command_client = ActionClientWrapper(RobotCommand, "robot_command", "arm_simple_action_node")
+    robot = SimpleSpotCommander(namespace)
+    robot_command_client = ActionClientWrapper(
+        RobotCommand, "robot_command", "arm_simple_action_node", namespace=namespace)
 
     # Claim robot
     node.get_logger().info("Claiming robot")
@@ -59,7 +70,9 @@ def hello_arm() -> bool:
 
     flat_body_T_hand = geometry_pb2.SE3Pose(position=hand_ewrt_flat_body, rotation=flat_body_Q_hand)
 
-    odom_T_flat_body = tf_listener.lookup_a_tform_b(ODOM_FRAME_NAME, GRAV_ALIGNED_BODY_FRAME_NAME)
+    odom_T_flat_body = tf_listener.lookup_a_tform_b(
+        name + ODOM_FRAME_NAME, name + GRAV_ALIGNED_BODY_FRAME_NAME
+    )
 
     odom_T_hand = odom_T_flat_body * math_helpers.SE3Pose.from_obj(flat_body_T_hand)
 
@@ -134,7 +147,10 @@ def hello_arm() -> bool:
 
 def main() -> None:
     rclpy.init()
-    hello_arm()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--robot", type=str, default=None)
+    args = parser.parse_args()
+    hello_arm(args.robot)
 
 
 if __name__ == "__main__":

--- a/examples/simple_arm_motion/simple_arm_motion/arm_simple.py
+++ b/examples/simple_arm_motion/simple_arm_motion/arm_simple.py
@@ -1,7 +1,7 @@
 import argparse
-import rclpy
 from typing import Optional
 
+import rclpy
 from bdai_ros2_wrappers.action_client import ActionClientWrapper
 from bosdyn.api import geometry_pb2
 from bosdyn.client import math_helpers
@@ -15,21 +15,22 @@ import spot_driver.conversions as conv
 from spot_msgs.action import RobotCommand  # type: ignore
 
 
-def hello_arm(robot: Optional[str]) -> bool:
+def hello_arm(robot_name: Optional[str]) -> bool:
     # Set up basic ROS2 utilities for communicating with the driver
     node = Node("arm_simple")
     name = ""
     namespace = ""
-    if robot is not None:
-        name = robot + "/"
-        namespace = robot
+    if robot_name is not None:
+        name = robot_name + "/"
+        namespace = robot_name
     tf_listener = TFListenerWrapper(
         "arm_simple_tf", wait_for_transform=[name + ODOM_FRAME_NAME, name + GRAV_ALIGNED_BODY_FRAME_NAME]
     )
 
     robot = SimpleSpotCommander(namespace)
     robot_command_client = ActionClientWrapper(
-        RobotCommand, "robot_command", "arm_simple_action_node", namespace=namespace)
+        RobotCommand, "robot_command", "arm_simple_action_node", namespace=namespace
+    )
 
     # Claim robot
     node.get_logger().info("Claiming robot")
@@ -70,9 +71,7 @@ def hello_arm(robot: Optional[str]) -> bool:
 
     flat_body_T_hand = geometry_pb2.SE3Pose(position=hand_ewrt_flat_body, rotation=flat_body_Q_hand)
 
-    odom_T_flat_body = tf_listener.lookup_a_tform_b(
-        name + ODOM_FRAME_NAME, name + GRAV_ALIGNED_BODY_FRAME_NAME
-    )
+    odom_T_flat_body = tf_listener.lookup_a_tform_b(name + ODOM_FRAME_NAME, name + GRAV_ALIGNED_BODY_FRAME_NAME)
 
     odom_T_hand = odom_T_flat_body * math_helpers.SE3Pose.from_obj(flat_body_T_hand)
 

--- a/examples/simple_walk_forward/README.md
+++ b/examples/simple_walk_forward/README.md
@@ -19,7 +19,7 @@ ros2 launch spot_driver spot_driver.launch.py
 
 5.  Run the example:
 ```bash
-ros2 run simple_walk_forward walk_forward
+ros2 run simple_walk_forward walk_forward --robot <spot_name>
 ```
 
 The robot should walk forward.

--- a/examples/simple_walk_forward/README.md
+++ b/examples/simple_walk_forward/README.md
@@ -16,12 +16,19 @@ This is a simple example of using ROS2 to make the robot walk 1m forward.
 ```bash
 ros2 launch spot_driver spot_driver.launch.py
 ```
+If you want to launch with a namespace,
+```bash
+ros2 launch spot_driver_with_namespace.launch.py spot_name:=<spot_name> 
+```
 
 5.  Run the example:
 ```bash
+ros2 run simple_walk_forward walk_forward
+```
+If you are launching spot_ros2 with a namespace, use the following command instead:
+```bash
 ros2 run simple_walk_forward walk_forward --robot <spot_name>
 ```
-
 The robot should walk forward.
 
 ## Understanding the Code

--- a/examples/simple_walk_forward/simple_walk_forward/walk_forward.py
+++ b/examples/simple_walk_forward/simple_walk_forward/walk_forward.py
@@ -25,7 +25,7 @@ class WalkForward(Node):
 
         self._tf_listener = TFListenerWrapper(
             "walk_forward_tf",
-            wait_for_transform=[self._name + "/" + BODY_FRAME_NAME, self._name + "/" + VISION_FRAME_NAME]
+            wait_for_transform=[self._name + "/" + BODY_FRAME_NAME, self._name + "/" + VISION_FRAME_NAME],
         )
         self._robot = SimpleSpotCommander(self._name)
         self._robot_command_client = ActionClientWrapper(

--- a/examples/simple_walk_forward/simple_walk_forward/walk_forward.py
+++ b/examples/simple_walk_forward/simple_walk_forward/walk_forward.py
@@ -21,18 +21,27 @@ ROBOT_T_GOAL = SE2Pose(1.0, 0.0, 0.0)
 class WalkForward(Node):
     def __init__(self, name) -> None:
         super().__init__("walk_forward")
-        self._name = name
+        # Include the option to have a namespae or not
+        if name is not None:
+            self._name = name + "/"
+            self._namespace = name
+        else:
+            self._name = ""
+            self._namespace = ""
+        
 
         self._tf_listener = TFListenerWrapper(
             "walk_forward_tf",
-            wait_for_transform=[self._name + "/" + BODY_FRAME_NAME, self._name + "/" + VISION_FRAME_NAME],
+            wait_for_transform=[self._name + BODY_FRAME_NAME, self._name + VISION_FRAME_NAME],
         )
-        self._robot = SimpleSpotCommander(self._name)
+
+        self._robot = SimpleSpotCommander(self._namespace)
         self._robot_command_client = ActionClientWrapper(
-            RobotCommand, "robot_command", "walk_forward_action_node", namespace=self._name
+            RobotCommand, "robot_command", "walk_forward_action_node", namespace=self._namespace
         )
 
     def initialize_robot(self) -> bool:
+        self.get_logger().info("Robot name: " + self._name)
         self.get_logger().info("Claiming robot")
         result = self._robot.command("claim")
         if not result.success:
@@ -57,7 +66,7 @@ class WalkForward(Node):
     def walk_forward_with_world_frame_goal(self) -> None:
         self.get_logger().info("Walking forward")
         world_t_robot = self._tf_listener.lookup_a_tform_b(
-            self._name + "/" + VISION_FRAME_NAME, self._name + "/" + BODY_FRAME_NAME
+            self._name + VISION_FRAME_NAME, self._name + BODY_FRAME_NAME
         ).get_closest_se2_transform()
         world_t_goal = world_t_robot * ROBOT_T_GOAL
         proto_goal = RobotCommandBuilder.synchro_se2_trajectory_point_command(
@@ -75,7 +84,7 @@ class WalkForward(Node):
 def main() -> int:
     rclpy.init()
     parser = argparse.ArgumentParser()
-    parser.add_argument("--robot")
+    parser.add_argument("--robot", type=str, default=None)
     args = parser.parse_args()
     goto = WalkForward(args.robot)
     goto.initialize_robot()

--- a/examples/simple_walk_forward/simple_walk_forward/walk_forward.py
+++ b/examples/simple_walk_forward/simple_walk_forward/walk_forward.py
@@ -1,8 +1,7 @@
 import argparse
-
+from typing import Optional
 
 import rclpy
-
 from bdai_ros2_wrappers.action_client import ActionClientWrapper
 from bosdyn.client.frame_helpers import BODY_FRAME_NAME, VISION_FRAME_NAME
 from bosdyn.client.math_helpers import SE2Pose
@@ -19,7 +18,7 @@ ROBOT_T_GOAL = SE2Pose(1.0, 0.0, 0.0)
 
 
 class WalkForward(Node):
-    def __init__(self, name) -> None:
+    def __init__(self, name: Optional[str]) -> None:
         super().__init__("walk_forward")
         # Include the option to have a namespae or not
         if name is not None:
@@ -28,7 +27,6 @@ class WalkForward(Node):
         else:
             self._name = ""
             self._namespace = ""
-        
 
         self._tf_listener = TFListenerWrapper(
             "walk_forward_tf",
@@ -95,4 +93,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     exit(main())
-

--- a/examples/simple_walk_forward/simple_walk_forward/walk_forward.py
+++ b/examples/simple_walk_forward/simple_walk_forward/walk_forward.py
@@ -1,4 +1,6 @@
 import argparse
+
+
 import rclpy
 
 from bdai_ros2_wrappers.action_client import ActionClientWrapper
@@ -22,16 +24,13 @@ class WalkForward(Node):
         self._name = name
 
         self._tf_listener = TFListenerWrapper(
-            "walk_forward_tf", wait_for_transform=[self._name + 
-"/" + BODY_FRAME_NAME, self._name + "/" + VISION_FRAME_NAME]
+            "walk_forward_tf",
+            wait_for_transform=[self._name + "/" + BODY_FRAME_NAME, self._name + "/" + VISION_FRAME_NAME]
         )
         self._robot = SimpleSpotCommander(self._name)
         self._robot_command_client = ActionClientWrapper(
-            RobotCommand, 
-            "robot_command", 
-            "walk_forward_action_node",
-            namespace=self._name
-            )
+            RobotCommand, "robot_command", "walk_forward_action_node", namespace=self._name
+        )
 
     def initialize_robot(self) -> bool:
         self.get_logger().info("Claiming robot")


### PR DESCRIPTION
The namespace for the robot wasn't included, causing an error where it wouldn't find the ROS topic it was supposed to publish to. I've added it to the example as a command line argument to pass in and updated the README