### PR TITLE
[SW-265] Spot Ros2 slight refactor for testability and unit testing

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1847,7 +1847,7 @@ class SpotROS(Node):
 
     def body_pose_callback(self, data: Pose) -> None:
         """Callback for cmd_vel command"""
-        if not self.spot_wrapper:
+        if self.spot_wrapper is None:
             self.get_logger().info("Mock mode, received command vel " + str(data))
             return
         q = Quaternion()
@@ -2158,7 +2158,7 @@ class SpotROS(Node):
                 self.spot_wrapper.updateTasks()  # Testing with Robot
             self.get_logger().debug("UPDATE TASKS")
             feedback_msg = Feedback()
-            if self.spot_wrapper:
+            if self.spot_wrapper is not None:
                 feedback_msg.standing = self.spot_wrapper.is_standing
                 feedback_msg.sitting = self.spot_wrapper.is_sitting
                 feedback_msg.moving = self.spot_wrapper.is_moving
@@ -2173,34 +2173,35 @@ class SpotROS(Node):
                     pass
             self.feedback_pub.publish(feedback_msg)
             mobility_params_msg = MobilityParams()
-            try:
-                mobility_params = self.spot_wrapper.get_mobility_params()
-                mobility_params_msg.body_control.position.x = (
-                    mobility_params.body_control.base_offset_rt_footprint.points[0].pose.position.x
-                )
-                mobility_params_msg.body_control.position.y = (
-                    mobility_params.body_control.base_offset_rt_footprint.points[0].pose.position.y
-                )
-                mobility_params_msg.body_control.position.z = (
-                    mobility_params.body_control.base_offset_rt_footprint.points[0].pose.position.z
-                )
-                mobility_params_msg.body_control.orientation.x = (
-                    mobility_params.body_control.base_offset_rt_footprint.points[0].pose.rotation.x
-                )
-                mobility_params_msg.body_control.orientation.y = (
-                    mobility_params.body_control.base_offset_rt_footprint.points[0].pose.rotation.y
-                )
-                mobility_params_msg.body_control.orientation.z = (
-                    mobility_params.body_control.base_offset_rt_footprint.points[0].pose.rotation.z
-                )
-                mobility_params_msg.body_control.orientation.w = (
-                    mobility_params.body_control.base_offset_rt_footprint.points[0].pose.rotation.w
-                )
-                mobility_params_msg.locomotion_hint = mobility_params.locomotion_hint
-                mobility_params_msg.stair_hint = mobility_params.stair_hint
-            except Exception as e:
-                self.get_logger().error("Error:{}".format(e))
-                pass
+            if self.spot_wrapper is not None:
+                try:
+                    mobility_params = self.spot_wrapper.get_mobility_params()
+                    mobility_params_msg.body_control.position.x = (
+                        mobility_params.body_control.base_offset_rt_footprint.points[0].pose.position.x
+                    )
+                    mobility_params_msg.body_control.position.y = (
+                        mobility_params.body_control.base_offset_rt_footprint.points[0].pose.position.y
+                    )
+                    mobility_params_msg.body_control.position.z = (
+                        mobility_params.body_control.base_offset_rt_footprint.points[0].pose.position.z
+                    )
+                    mobility_params_msg.body_control.orientation.x = (
+                        mobility_params.body_control.base_offset_rt_footprint.points[0].pose.rotation.x
+                    )
+                    mobility_params_msg.body_control.orientation.y = (
+                        mobility_params.body_control.base_offset_rt_footprint.points[0].pose.rotation.y
+                    )
+                    mobility_params_msg.body_control.orientation.z = (
+                        mobility_params.body_control.base_offset_rt_footprint.points[0].pose.rotation.z
+                    )
+                    mobility_params_msg.body_control.orientation.w = (
+                        mobility_params.body_control.base_offset_rt_footprint.points[0].pose.rotation.w
+                    )
+                    mobility_params_msg.locomotion_hint = mobility_params.locomotion_hint
+                    mobility_params_msg.stair_hint = mobility_params.stair_hint
+                except Exception as e:
+                    self.get_logger().error("Error:{}".format(e))
+                    pass
             self.mobility_params_pub.publish(mobility_params_msg)
 
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -153,6 +153,10 @@ class WaitForGoal(object):
             time.sleep(0.05)
         self._at_goal = True
 
+class SpotImageType(str, Enum):
+    RGB = 'visual'
+    Depth = 'depth'
+    RegDepth = 'depth_registered'
 
 class SpotROS(Node):
     """Parent class for using the wrapper.  Defines all callbacks and keeps the wrapper alive"""

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -5,9 +5,9 @@ import threading
 import time
 import traceback
 import typing
-from functools import partial
 from dataclasses import dataclass
 from enum import Enum
+from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import builtin_interfaces.msg
@@ -155,10 +155,12 @@ class WaitForGoal(object):
             time.sleep(0.05)
         self._at_goal = True
 
+
 class SpotImageType(str, Enum):
-    RGB = 'visual'
-    Depth = 'depth'
-    RegDepth = 'depth_registered'
+    RGB = "visual"
+    Depth = "depth"
+    RegDepth = "depth_registered"
+
 
 class SpotROS(Node):
     """Parent class for using the wrapper.  Defines all callbacks and keeps the wrapper alive"""
@@ -460,9 +462,7 @@ class SpotROS(Node):
         self.create_service(
             Trigger,
             "power_off",
-            lambda request, response: self.service_wrapper(
-                "power_off", self.handle_safe_power_off, request, response
-            ),
+            lambda request, response: self.service_wrapper("power_off", self.handle_safe_power_off, request, response),
             callback_group=self.group,
         )
         self.create_service(
@@ -474,9 +474,7 @@ class SpotROS(Node):
         self.create_service(
             Trigger,
             "estop/gentle",
-            lambda request, response: self.service_wrapper(
-                "estop/gentle", self.handle_estop_soft, request, response
-            ),
+            lambda request, response: self.service_wrapper("estop/gentle", self.handle_estop_soft, request, response),
             callback_group=self.group,
         )
         self.create_service(
@@ -557,9 +555,7 @@ class SpotROS(Node):
         self.create_service(
             ListSounds,
             "list_sounds",
-            lambda request, response: self.service_wrapper(
-                "list_sounds", self.handle_list_sounds, request, response
-            ),
+            lambda request, response: self.service_wrapper("list_sounds", self.handle_list_sounds, request, response),
             callback_group=self.group,
         )
         self.create_service(
@@ -577,9 +573,7 @@ class SpotROS(Node):
         self.create_service(
             DeleteSound,
             "delete_sound",
-            lambda request, response: self.service_wrapper(
-                "delete_sound", self.handle_delete_sound, request, response
-            ),
+            lambda request, response: self.service_wrapper("delete_sound", self.handle_delete_sound, request, response),
             callback_group=self.group,
         )
         self.create_service(
@@ -882,7 +876,9 @@ class SpotROS(Node):
     def create_image_publisher(self, image_type: SpotImageType, callback_group: CallbackGroup) -> None:
         for camera_name in self.cameras_used.value:
             setattr(
-                self, f"{camera_name}_{image_type}_pub", self.create_publisher(Image, f"{image_type}/{camera_name}/image", 1)
+                self,
+                f"{camera_name}_{image_type}_pub",
+                self.create_publisher(Image, f"{image_type}/{camera_name}/image", 1),
             )
             setattr(
                 self,

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -4,6 +4,7 @@ import sys
 import threading
 import time
 import traceback
+import typing
 from functools import partial
 from dataclasses import dataclass
 from enum import Enum
@@ -162,7 +163,7 @@ class SpotImageType(str, Enum):
 class SpotROS(Node):
     """Parent class for using the wrapper.  Defines all callbacks and keeps the wrapper alive"""
 
-    def __init__(self, parameter_list: Optional[list[Parameter]] = None) -> None:
+    def __init__(self, parameter_list: Optional[typing.List[Parameter]] = None) -> None:
         """
         Main function for the SpotROS class.  Gets config from ROS and initializes the wrapper.
         Holds lease from wrapper and updates all async tasks at the ROS rate

--- a/spot_driver/test/test_spot_driver.py
+++ b/spot_driver/test/test_spot_driver.py
@@ -1,0 +1,124 @@
+import multiprocessing
+import threading
+import time
+import unittest
+from threading import Thread
+from typing import Optional, Any
+
+import rclpy
+from rclpy import Context
+from rclpy.callback_groups import ReentrantCallbackGroup, CallbackGroup
+from rclpy.executors import MultiThreadedExecutor, SingleThreadedExecutor, ExternalShutdownException
+
+import spot_driver.spot_ros2
+from spot_msgs.srv import Dock
+from std_srvs.srv import Trigger
+from rclpy.task import Future
+
+
+def spin_thread(executor: MultiThreadedExecutor) -> None:
+    if executor is not None:
+        try:
+            executor.spin()
+        except (ExternalShutdownException, KeyboardInterrupt):
+            pass
+
+
+def call_trigger_client(client: rclpy.node.Client, executor: MultiThreadedExecutor, request: Any = Trigger.Request()) -> spot_driver.spot_ros2.Response:
+    req = request
+    future = client.call_async(req)
+    executor.spin_until_future_complete(future)
+    resp = future.result()
+    return resp
+
+class SpotDriverTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.context: Optional[Context] = Context()
+        rclpy.init()
+
+        # create and run spot ros2 servers
+        mock_param = rclpy.parameter.Parameter("spot_name", rclpy.Parameter.Type.STRING, "Mock_spot")
+        self.spot_ros2 = spot_driver.spot_ros2.SpotROS(parameter_list=[mock_param])
+        # set mock
+        self.spot_ros2_exec = MultiThreadedExecutor(num_threads=8)
+        self.spot_ros2_exec.add_node(self.spot_ros2)
+        self.spot_ros2_thread: Thread = Thread(target=spin_thread, args=(self.spot_ros2_exec,))
+        self.spot_ros2_thread.start()
+        self.group: CallbackGroup = ReentrantCallbackGroup()
+
+        # clients
+        self.client_node = rclpy.node.Node(node_name="client_tester")
+        self.command_exec: MultiThreadedExecutor = MultiThreadedExecutor(num_threads=8)
+        self.command_exec.add_node(self.client_node)
+        self.claim_client: rclpy.node.Client = self.client_node.create_client(Trigger, "claim", callback_group=self.group)
+        self.release_client: rclpy.node.Client = self.client_node.create_client(Trigger, "release", callback_group=self.group)
+        self.power_on_client: rclpy.node.Client = self.client_node.create_client(Trigger, "power_on", callback_group=self.group)
+        self.power_off_client: rclpy.node.Client = self.client_node.create_client(Trigger, "power_off", callback_group=self.group)
+        self.sit_client: rclpy.node.Client = self.client_node.create_client(Trigger, "sit", callback_group=self.group)
+        self.stand_client: rclpy.node.Client = self.client_node.create_client(Trigger, "stand", callback_group=self.group)
+        self.estop_gentle: rclpy.node.Client = self.client_node.create_client(Trigger, "estop/gentle", callback_group=self.group)
+        self.estop_hard: rclpy.node.Client = self.client_node.create_client(Trigger, "estop/hard", callback_group=self.group)
+        self.estop_release: rclpy.node.Client = self.client_node.create_client(Trigger, "estop/release",
+                                                                            callback_group=self.group)
+        self.undock_client: rclpy.node.Client = self.client_node.create_client(Trigger, "undock",
+                                                                            callback_group=self.group)
+        self.dock_client: rclpy.node.Client = self.client_node.create_client(Dock, "dock",
+                                                                            callback_group=self.group)
+
+        # # create and run commander
+        # self.commander: spot_driver.command_spot_driver.CommandSpotDriver = spot_driver.command_spot_driver.CommandSpotDriver("command_spot_driver")
+        # self.command_exec: MultiThreadedExecutor = MultiThreadedExecutor(num_threads=8)
+        # self.command_exec.add_node(self.commander)
+        # self.commander_thread: Thread = Thread(target=spin_thread, args=(self.command_exec,))
+        # self.commander_thread.start()
+
+
+
+    def tearDown(self) -> None:
+        # shutdown and kill any nodes and threads
+        if self.command_exec is not None:
+            self.command_exec.shutdown()
+            self.command_exec.remove_node(self.client_node)
+            self.client_node.destroy_node()
+
+        if self.spot_ros2_exec is not None:
+            self.spot_ros2_exec.shutdown()
+            self.spot_ros2_exec.remove_node(self.spot_ros2)
+            self.spot_ros2_thread.join()
+            self.spot_ros2.destroy_node()
+
+        rclpy.shutdown()
+        self.context = None
+
+    def test_wrapped_commands(self):
+        """
+        Spot Ros2 driver has multiple commands that are wrapped in a service wrapper.
+        When no spot_wrapper is present they return true, but this test at least tests
+        communications and APIs.
+        """
+        resp = call_trigger_client(self.claim_client, self.command_exec)
+        self.assertEqual(resp.success, True)
+        resp = call_trigger_client(self.release_client, self.command_exec)
+        self.assertEqual(resp.success, True)
+        resp = call_trigger_client(self.power_on_client, self.command_exec)
+        self.assertEqual(resp.success, True)
+        resp = call_trigger_client(self.power_off_client, self.command_exec)
+        self.assertEqual(resp.success, True)
+        resp = call_trigger_client(self.sit_client, self.command_exec)
+        self.assertEqual(resp.success, True)
+        resp = call_trigger_client(self.stand_client, self.command_exec)
+        self.assertEqual(resp.success, True)
+        resp = call_trigger_client(self.estop_hard, self.command_exec)
+        self.assertEqual(resp.success, True)
+        resp = call_trigger_client(self.estop_gentle, self.command_exec)
+        self.assertEqual(resp.success, True)
+        resp = call_trigger_client(self.estop_release, self.command_exec)
+        self.assertEqual(resp.success, True)
+        resp = call_trigger_client(self.undock_client, self.command_exec)
+        self.assertEqual(resp.success, True)
+        resp = call_trigger_client(self.dock_client, self.command_exec, request=Dock.Request())
+        self.assertEqual(resp.success, True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spot_driver/test/test_spot_driver.py
+++ b/spot_driver/test/test_spot_driver.py
@@ -1,21 +1,17 @@
-import multiprocessing
-import threading
-import time
 import unittest
 from threading import Thread
-from typing import Optional, Any
+from typing import Any, Optional
 
 import rclpy
 from rclpy import Context
-from rclpy.callback_groups import ReentrantCallbackGroup, CallbackGroup
-from rclpy.executors import MultiThreadedExecutor, SingleThreadedExecutor, ExternalShutdownException
+from rclpy.callback_groups import CallbackGroup, ReentrantCallbackGroup
+from rclpy.executors import ExternalShutdownException, MultiThreadedExecutor
+from std_srvs.srv import Trigger
 
 import spot_driver.spot_ros2
 from spot_msgs.srv import (  # type: ignore
     Dock,
 )
-from std_srvs.srv import Trigger
-from rclpy.task import Future
 
 
 def spin_thread(executor: MultiThreadedExecutor) -> None:
@@ -26,7 +22,9 @@ def spin_thread(executor: MultiThreadedExecutor) -> None:
             pass
 
 
-def call_trigger_client(client: rclpy.node.Client, executor: MultiThreadedExecutor, request: Any = Trigger.Request()) -> spot_driver.spot_ros2.Response:
+def call_trigger_client(
+    client: rclpy.node.Client, executor: MultiThreadedExecutor, request: Any = Trigger.Request()
+) -> spot_driver.spot_ros2.Response:
     req = request
     future = client.call_async(req)
     executor.spin_until_future_complete(future)
@@ -53,28 +51,35 @@ class SpotDriverTest(unittest.TestCase):
         self.client_node = rclpy.node.Node(node_name="client_tester")
         self.command_exec: MultiThreadedExecutor = MultiThreadedExecutor(num_threads=8)
         self.command_exec.add_node(self.client_node)
-        self.claim_client: rclpy.node.Client = self.client_node.create_client(Trigger, "claim",
-                                                                              callback_group=self.group)
-        self.release_client: rclpy.node.Client = self.client_node.create_client(Trigger, "release",
-                                                                                callback_group=self.group)
-        self.power_on_client: rclpy.node.Client = self.client_node.create_client(Trigger, "power_on",
-                                                                                 callback_group=self.group)
-        self.power_off_client: rclpy.node.Client = self.client_node.create_client(Trigger, "power_off",
-                                                                                  callback_group=self.group)
-        self.sit_client: rclpy.node.Client = self.client_node.create_client(Trigger, "sit",
-                                                                            callback_group=self.group)
-        self.stand_client: rclpy.node.Client = self.client_node.create_client(Trigger, "stand",
-                                                                              callback_group=self.group)
-        self.estop_gentle: rclpy.node.Client = self.client_node.create_client(Trigger, "estop/gentle",
-                                                                              callback_group=self.group)
-        self.estop_hard: rclpy.node.Client = self.client_node.create_client(Trigger, "estop/hard",
-                                                                            callback_group=self.group)
-        self.estop_release: rclpy.node.Client = self.client_node.create_client(Trigger, "estop/release",
-                                                                            callback_group=self.group)
-        self.undock_client: rclpy.node.Client = self.client_node.create_client(Trigger, "undock",
-                                                                            callback_group=self.group)
-        self.dock_client: rclpy.node.Client = self.client_node.create_client(Dock, "dock",
-                                                                            callback_group=self.group)
+        self.claim_client: rclpy.node.Client = self.client_node.create_client(
+            Trigger, "claim", callback_group=self.group
+        )
+        self.release_client: rclpy.node.Client = self.client_node.create_client(
+            Trigger, "release", callback_group=self.group
+        )
+        self.power_on_client: rclpy.node.Client = self.client_node.create_client(
+            Trigger, "power_on", callback_group=self.group
+        )
+        self.power_off_client: rclpy.node.Client = self.client_node.create_client(
+            Trigger, "power_off", callback_group=self.group
+        )
+        self.sit_client: rclpy.node.Client = self.client_node.create_client(Trigger, "sit", callback_group=self.group)
+        self.stand_client: rclpy.node.Client = self.client_node.create_client(
+            Trigger, "stand", callback_group=self.group
+        )
+        self.estop_gentle: rclpy.node.Client = self.client_node.create_client(
+            Trigger, "estop/gentle", callback_group=self.group
+        )
+        self.estop_hard: rclpy.node.Client = self.client_node.create_client(
+            Trigger, "estop/hard", callback_group=self.group
+        )
+        self.estop_release: rclpy.node.Client = self.client_node.create_client(
+            Trigger, "estop/release", callback_group=self.group
+        )
+        self.undock_client: rclpy.node.Client = self.client_node.create_client(
+            Trigger, "undock", callback_group=self.group
+        )
+        self.dock_client: rclpy.node.Client = self.client_node.create_client(Dock, "dock", callback_group=self.group)
 
     def tearDown(self) -> None:
         # shutdown and kill any nodes and threads

--- a/spot_driver/test/test_spot_driver.py
+++ b/spot_driver/test/test_spot_driver.py
@@ -11,7 +11,9 @@ from rclpy.callback_groups import ReentrantCallbackGroup, CallbackGroup
 from rclpy.executors import MultiThreadedExecutor, SingleThreadedExecutor, ExternalShutdownException
 
 import spot_driver.spot_ros2
-from spot_msgs.srv import Dock
+from spot_msgs.srv import (  # type: ignore
+    Dock,
+)
 from std_srvs.srv import Trigger
 from rclpy.task import Future
 
@@ -30,6 +32,7 @@ def call_trigger_client(client: rclpy.node.Client, executor: MultiThreadedExecut
     executor.spin_until_future_complete(future)
     resp = future.result()
     return resp
+
 
 class SpotDriverTest(unittest.TestCase):
     def setUp(self) -> None:
@@ -50,29 +53,28 @@ class SpotDriverTest(unittest.TestCase):
         self.client_node = rclpy.node.Node(node_name="client_tester")
         self.command_exec: MultiThreadedExecutor = MultiThreadedExecutor(num_threads=8)
         self.command_exec.add_node(self.client_node)
-        self.claim_client: rclpy.node.Client = self.client_node.create_client(Trigger, "claim", callback_group=self.group)
-        self.release_client: rclpy.node.Client = self.client_node.create_client(Trigger, "release", callback_group=self.group)
-        self.power_on_client: rclpy.node.Client = self.client_node.create_client(Trigger, "power_on", callback_group=self.group)
-        self.power_off_client: rclpy.node.Client = self.client_node.create_client(Trigger, "power_off", callback_group=self.group)
-        self.sit_client: rclpy.node.Client = self.client_node.create_client(Trigger, "sit", callback_group=self.group)
-        self.stand_client: rclpy.node.Client = self.client_node.create_client(Trigger, "stand", callback_group=self.group)
-        self.estop_gentle: rclpy.node.Client = self.client_node.create_client(Trigger, "estop/gentle", callback_group=self.group)
-        self.estop_hard: rclpy.node.Client = self.client_node.create_client(Trigger, "estop/hard", callback_group=self.group)
+        self.claim_client: rclpy.node.Client = self.client_node.create_client(Trigger, "claim",
+                                                                              callback_group=self.group)
+        self.release_client: rclpy.node.Client = self.client_node.create_client(Trigger, "release",
+                                                                                callback_group=self.group)
+        self.power_on_client: rclpy.node.Client = self.client_node.create_client(Trigger, "power_on",
+                                                                                 callback_group=self.group)
+        self.power_off_client: rclpy.node.Client = self.client_node.create_client(Trigger, "power_off",
+                                                                                  callback_group=self.group)
+        self.sit_client: rclpy.node.Client = self.client_node.create_client(Trigger, "sit",
+                                                                            callback_group=self.group)
+        self.stand_client: rclpy.node.Client = self.client_node.create_client(Trigger, "stand",
+                                                                              callback_group=self.group)
+        self.estop_gentle: rclpy.node.Client = self.client_node.create_client(Trigger, "estop/gentle",
+                                                                              callback_group=self.group)
+        self.estop_hard: rclpy.node.Client = self.client_node.create_client(Trigger, "estop/hard",
+                                                                            callback_group=self.group)
         self.estop_release: rclpy.node.Client = self.client_node.create_client(Trigger, "estop/release",
                                                                             callback_group=self.group)
         self.undock_client: rclpy.node.Client = self.client_node.create_client(Trigger, "undock",
                                                                             callback_group=self.group)
         self.dock_client: rclpy.node.Client = self.client_node.create_client(Dock, "dock",
                                                                             callback_group=self.group)
-
-        # # create and run commander
-        # self.commander: spot_driver.command_spot_driver.CommandSpotDriver = spot_driver.command_spot_driver.CommandSpotDriver("command_spot_driver")
-        # self.command_exec: MultiThreadedExecutor = MultiThreadedExecutor(num_threads=8)
-        # self.command_exec.add_node(self.commander)
-        # self.commander_thread: Thread = Thread(target=spin_thread, args=(self.command_exec,))
-        # self.commander_thread.start()
-
-
 
     def tearDown(self) -> None:
         # shutdown and kill any nodes and threads
@@ -90,7 +92,7 @@ class SpotDriverTest(unittest.TestCase):
         rclpy.shutdown()
         self.context = None
 
-    def test_wrapped_commands(self):
+    def test_wrapped_commands(self) -> None:
         """
         Spot Ros2 driver has multiple commands that are wrapped in a service wrapper.
         When no spot_wrapper is present they return true, but this test at least tests


### PR DESCRIPTION
Tickets: SW-265, SW-255
Changes:
- Made Spot Ros 2 "Mock_spot" actually work as intended allowing services to be created (they already had checks for mock)
- Added unit tests and changes to spot_ros2.py to allow for that testing without a launch file
- To fix dependency issues, __init__.py needed moving into the tests folder so that it could properly find modules
- Cleaned up redundant code of the camera publishing using a partial and the common naming scheme (this does potentially change the topic name on the rgb camera images. Its cleaner if the spot_wrapper image name and the topic name match, but if it's a deal breaker I'm happy to put a check in to swap just that one to be "camera/..." instead of "visual/.." again)

Tests run:
- Ran on a spot testing out normal functionality as well as tested the unit tests
- Viewed images in Rviz2 to make sure they were publishing