### PR TITLE
[SW-220] Publish non-static hand camera transform on image update

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -923,7 +923,7 @@ class SpotROS(Node):
             image_info_pub = getattr(self, f"{image_entry.camera_name}_image_info_pub")
             image_pub.publish(image_msg)
             image_info_pub.publish(camera_info)
-            self.populate_camera_static_transforms(image_entry.image_response)
+            self.populate_camera_transforms(image_entry.image_response)
 
     def publish_depth_images_callback(self) -> None:
         if self.spot_wrapper is None:
@@ -940,7 +940,7 @@ class SpotROS(Node):
             depth_info_pub = getattr(self, f"{image_entry.camera_name}_depth_info_pub")
             depth_pub.publish(image_msg)
             depth_info_pub.publish(camera_info)
-            self.populate_camera_static_transforms(image_entry.image_response)
+            self.populate_camera_transforms(image_entry.image_response)
 
     def publish_depth_registered_images_callback(self) -> None:
         if self.spot_wrapper is None:
@@ -957,7 +957,7 @@ class SpotROS(Node):
             depth_registered_info_pub = getattr(self, f"{image_entry.camera_name}_depth_registered_info_pub")
             depth_registered_pub.publish(image_msg)
             depth_registered_info_pub.publish(camera_info)
-            self.populate_camera_static_transforms(image_entry.image_response)
+            self.populate_camera_transforms(image_entry.image_response)
 
     def service_wrapper(
         self,
@@ -2120,11 +2120,19 @@ class SpotROS(Node):
 
         return result
 
-    def populate_camera_static_transforms(self, image_data: image_pb2.Image) -> None:
+    def populate_camera_transforms(self, image_data: image_pb2.Image) -> None:
         """Check data received from one of the image tasks and use the transform snapshot to extract the camera frame
-        transforms. This is the transforms from body->frontleft->frontleft_fisheye, for example. These transforms
-        never change, but they may be calibrated slightly differently for each robot, so we need to generate the
-        transforms at runtime.
+        transforms. This is the transforms from body->frontleft->frontleft_fisheye, for example.
+
+        In most cases, these transforms never change, but they may be calibrated slightly differently for each robot,
+        so we need to generate and publish the static transforms once.
+
+        The only (known) exception to this is the transforms for the hand/arm mounted cameras, which must publish
+        a dynamic update for the arm's base link relative to the body. This frame/link "arm0.link_wr1" in the image
+        response's transform snapshot tree does now follow the same naming convention ("link_wr1") as reported in the
+        robot state / dynamic tf publisher logic elsewhere. We don't want to alias/hack this as it is used by
+        other pipelines such as manipulation - so we special case and publish the dynamic arm link here instead.
+
         Args:
         image_data: Image protobuf data from the wrapper
         """
@@ -2136,18 +2144,27 @@ class SpotROS(Node):
             frame_prefix = self.spot_wrapper.frame_prefix
         excluded_frames = [self.tf_name_vision_odom.value, self.tf_name_kinematic_odom.value, frame_prefix + "body"]
         excluded_frames = [f[f.rfind("/") + 1 :] for f in excluded_frames]
+
+        # We assume all frames are static, except for a special case/naming convention used by the transform tree
+        # snapshot returned in the spot image callbacks for arm/hand cameras.
+        dynamic_frames = []
+        if self.spot_wrapper and self.spot_wrapper.has_arm():
+            dynamic_frames = ["arm0.link_wr1"]
+
         for frame_name in image_data.shot.transforms_snapshot.child_to_parent_edge_map:
             if frame_name in excluded_frames:
                 continue
             parent_frame = image_data.shot.transforms_snapshot.child_to_parent_edge_map.get(
                 frame_name
             ).parent_frame_name
-            existing_transforms = [
-                (transform.header.frame_id, transform.child_frame_id) for transform in self.camera_static_transforms
-            ]
-            if (frame_prefix + parent_frame, frame_prefix + frame_name) in existing_transforms:
-                # We already extracted this transform
-                continue
+
+            if frame_name not in dynamic_frames:
+                existing_static_transforms = [
+                    (transform.header.frame_id, transform.child_frame_id) for transform in self.camera_static_transforms
+                ]
+                if (frame_prefix + parent_frame, frame_prefix + frame_name) in existing_static_transforms:
+                    # We already extracted this static transform
+                    continue
 
             transform = image_data.shot.transforms_snapshot.child_to_parent_edge_map.get(frame_name)
             if self.spot_wrapper is not None:
@@ -2155,11 +2172,15 @@ class SpotROS(Node):
             else:
                 local_time = Timestamp()
             tf_time = builtin_interfaces.msg.Time(sec=local_time.seconds, nanosec=local_time.nanos)
-            static_tf = populate_transform_stamped(
+            tf = populate_transform_stamped(
                 tf_time, transform.parent_frame_name, frame_name, transform.parent_tform_child, frame_prefix
             )
-            self.camera_static_transforms.append(static_tf)
-            self.camera_static_transform_broadcaster.sendTransform(self.camera_static_transforms)
+
+            if frame_name in dynamic_frames:
+                self.dynamic_broadcaster.sendTransform(tf)
+            else:
+                self.camera_static_transforms.append(tf)
+                self.camera_static_transform_broadcaster.sendTransform(self.camera_static_transforms)
 
     def shutdown(self, sig: Optional[Any] = None, frame: Optional[str] = None) -> None:
         self.get_logger().info("Shutting down ROS driver for Spot")


### PR DESCRIPTION
## Overview
On any image callback, the `spot_driver` would call `populate_camera_static_transforms` to ensure all individual spot camera's calibration-specific static transforms were published. This assumed that all cameras are statically mounted (e.g. rigidly fixed to the body), but this is not true for arm/hand cameras.

Without this patch, the hand camera frames would be fixed to their first static transform (e.g. stowed position), and this would not update as the arm was unstowed or moved. This patch ensures that if an arm is present, the single dynamic transform (`arm0.link_wrl -> body`) is published dynamically on image callback, ensuring the rest of the kinematic chain for image frames are updated appropriately.

## Additional Detail
The normal robot state callback publishes dynamic transforms at robot state frequency, but this does not fix the problem due to a mismatch between the naming conventions reported in the transform snapshot trees for robot state and image response. The link of interest on the arm is reported as `link_wr1` by the snapshot tree received by robot state and `arm0.link_wr1` by the snapshot tree bundled in image response.

## Limitations
The hand camera frames will only update at the rate images are received, which is currently much slower than robot state callback. We could modify the robot state callback to dynamically alias/publish `link_wr1` as `arm0.link_wr1`, but this seems to be a workaround at a higher level out of camera-specific code and would no longer accurately reflect the bundled arm state at image capture time.

## Steps to Reproduce / Verification of Behavior

- launch `rviz2` `ros2 run rviz2 rviz2` (with correct spot configuration file)
- visualize any of the `hand_camera` frames
- unstow and move the arm, observe the behavior and position of the frame in relation to the end effector

Broken Behavior Before (hand camera frame does not update from initial stowed position)

https://github.com/bdaiinstitute/spot_ros2/assets/137219344/1adec765-de88-4ffd-a56f-7aff82b0d83e

Correct Behavior After Patch (hand camera frame updates and camera image rate)

https://github.com/bdaiinstitute/spot_ros2/assets/137219344/8e7454d0-ccda-45cb-bafc-969b4d720bf0