### PR TITLE
[SW-328] Better handling of arm0.link_wr1 for hand camera transforms

### DIFF
--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -466,29 +466,6 @@ def get_tf_from_state(
                         tf_time, frame_name, transform.parent_frame_name, geo_tform_inversed, spot_wrapper.frame_prefix
                     )
                 else:
-                    # Arm specific workaround for bug/discrepancy between link names in the transform tree snapshot
-                    # bundled with hand camera image result callbacks and the link names in robot state callbacks.
-                    #
-                    # On image callback, we publish static transforms for each camera frame's kinematic chain just
-                    # once on the first callback received. This sets the initial, fixed position of the frame, but
-                    # the hand cameras move on the arm independent of the body frame, which necessitates dynamic tf
-                    # updates. Unfortunately the hand camera transform snapshot trees refer to a link "arm0.link_wr1",
-                    # which is not used anywhere else - in fact it is just "link_wr1" in robot state callbacks.
-                    #
-                    # This special case code simply generates a duplicate transform for "link_wr1" aliased to
-                    # "arm0.link_wr1" for hand camera use cases. We leave the original transform alone for other
-                    # pipelines such as manipulation and avoid the RPC call to "has_arm()" on the SpotWrapper
-                    # as this link will not exist on arm-less spots.
-                    if frame_name == "link_wr1":
-                        alias_tf = populate_transform_stamped(
-                            tf_time,
-                            transform.parent_frame_name,
-                            "arm0.link_wr1",
-                            transform.parent_tform_child,
-                            spot_wrapper.frame_prefix,
-                        )
-                        tf_msg.transforms.append(alias_tf)
-
                     new_tf = populate_transform_stamped(
                         tf_time,
                         transform.parent_frame_name,

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -922,7 +922,7 @@ class SpotROS(Node):
             image_info_pub = getattr(self, f"{image_entry.camera_name}_{publisher_name}_info_pub")
             image_pub.publish(image_msg)
             image_info_pub.publish(camera_info)
-            self.populate_camera_transforms(image_entry.image_response)
+            self.populate_camera_static_transforms(image_entry.image_response)
 
     def service_wrapper(
         self,
@@ -2085,19 +2085,11 @@ class SpotROS(Node):
 
         return result
 
-    def populate_camera_transforms(self, image_data: image_pb2.Image) -> None:
+    def populate_camera_static_transforms(self, image_data: image_pb2.Image) -> None:
         """Check data received from one of the image tasks and use the transform snapshot to extract the camera frame
-        transforms. This is the transforms from body->frontleft->frontleft_fisheye, for example.
-
-        In most cases, these transforms never change, but they may be calibrated slightly differently for each robot,
-        so we need to generate and publish the static transforms once.
-
-        The only (known) exception to this is the transforms for the hand/arm mounted cameras, which must publish
-        a dynamic update for the arm's base link relative to the body. This frame/link "arm0.link_wr1" in the image
-        response's transform snapshot tree does now follow the same naming convention ("link_wr1") as reported in the
-        robot state / dynamic tf publisher logic elsewhere. We don't want to alias/hack this as it is used by
-        other pipelines such as manipulation - so we special case and publish the dynamic arm link here instead.
-
+        transforms. This is the transforms from body->frontleft->frontleft_fisheye, for example. These transforms
+        never change, but they may be calibrated slightly differently for each robot, so we need to generate the
+        transforms at runtime.
         Args:
         image_data: Image protobuf data from the wrapper
         """
@@ -2109,27 +2101,18 @@ class SpotROS(Node):
             frame_prefix = self.spot_wrapper.frame_prefix
         excluded_frames = [self.tf_name_vision_odom.value, self.tf_name_kinematic_odom.value, frame_prefix + "body"]
         excluded_frames = [f[f.rfind("/") + 1 :] for f in excluded_frames]
-
-        # We assume all frames are static, except for a special case/naming convention used by the transform tree
-        # snapshot returned in the spot image callbacks for arm/hand cameras.
-        dynamic_frames = []
-        if self.spot_wrapper and self.spot_wrapper.has_arm():
-            dynamic_frames = ["arm0.link_wr1"]
-
         for frame_name in image_data.shot.transforms_snapshot.child_to_parent_edge_map:
             if frame_name in excluded_frames:
                 continue
             parent_frame = image_data.shot.transforms_snapshot.child_to_parent_edge_map.get(
                 frame_name
             ).parent_frame_name
-
-            if frame_name not in dynamic_frames:
-                existing_static_transforms = [
-                    (transform.header.frame_id, transform.child_frame_id) for transform in self.camera_static_transforms
-                ]
-                if (frame_prefix + parent_frame, frame_prefix + frame_name) in existing_static_transforms:
-                    # We already extracted this static transform
-                    continue
+            existing_transforms = [
+                (transform.header.frame_id, transform.child_frame_id) for transform in self.camera_static_transforms
+            ]
+            if (frame_prefix + parent_frame, frame_prefix + frame_name) in existing_transforms:
+                # We already extracted this transform
+                continue
 
             transform = image_data.shot.transforms_snapshot.child_to_parent_edge_map.get(frame_name)
             if self.spot_wrapper is not None:
@@ -2137,15 +2120,11 @@ class SpotROS(Node):
             else:
                 local_time = Timestamp()
             tf_time = builtin_interfaces.msg.Time(sec=local_time.seconds, nanosec=local_time.nanos)
-            tf = populate_transform_stamped(
+            static_tf = populate_transform_stamped(
                 tf_time, transform.parent_frame_name, frame_name, transform.parent_tform_child, frame_prefix
             )
-
-            if frame_name in dynamic_frames:
-                self.dynamic_broadcaster.sendTransform(tf)
-            else:
-                self.camera_static_transforms.append(tf)
-                self.camera_static_transform_broadcaster.sendTransform(self.camera_static_transforms)
+            self.camera_static_transforms.append(static_tf)
+            self.camera_static_transform_broadcaster.sendTransform(self.camera_static_transforms)
 
     def shutdown(self, sig: Optional[Any] = None, frame: Optional[str] = None) -> None:
         self.get_logger().info("Shutting down ROS driver for Spot")

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2120,9 +2120,9 @@ class SpotROS(Node):
         for frame_name in image_data.shot.transforms_snapshot.child_to_parent_edge_map:
             if frame_name in excluded_frames:
                 continue
-            parent_frame = image_data.shot.transforms_snapshot.child_to_parent_edge_map.get(
-                frame_name
-            ).parent_frame_name
+
+            transform = image_data.shot.transforms_snapshot.child_to_parent_edge_map.get(frame_name)
+            parent_frame = transform.parent_frame_name
 
             # special case handling of parent frame to sync with robot state naming, see above
             if parent_frame == "arm0.link_wr1":
@@ -2135,14 +2135,13 @@ class SpotROS(Node):
                 # We already extracted this transform
                 continue
 
-            transform = image_data.shot.transforms_snapshot.child_to_parent_edge_map.get(frame_name)
             if self.spot_wrapper is not None:
                 local_time = self.spot_wrapper.robotToLocalTime(image_data.shot.acquisition_time)
             else:
                 local_time = Timestamp()
             tf_time = builtin_interfaces.msg.Time(sec=local_time.seconds, nanosec=local_time.nanos)
             static_tf = populate_transform_stamped(
-                tf_time, transform.parent_frame_name, frame_name, transform.parent_tform_child, frame_prefix
+                tf_time, parent_frame, frame_name, transform.parent_tform_child, frame_prefix
             )
             self.camera_static_transforms.append(static_tf)
             self.camera_static_transform_broadcaster.sendTransform(self.camera_static_transforms)


### PR DESCRIPTION
## Overview
This patch rolls back the changes made in #107 (see description for problem notes) in favor of a cleaner and simpler approach to handling `arm0.link_wr1` in hand camera image callbacks - with special case code to:

- avoid publishing a static transform for `arm0.link_wr1` at all as it is not static
- rename parent `arm0.link_wr1` to `link_wr1` in any static transforms for proper connectivity to robot state updates
- rely on robot state publication to handle all necessary dynamic tfs in a single place

This change will have no impact on spot configurations without an arm and will not break anything in the future if the naming discrepancy is fixed by Boston Dynamics.

Relying on robot state has the added benefit of much higher frequency tf updates, eliminating the choppy behavior seen when relying on only image callback timing.

In addition, this elimates `TF_OLD_DATA` warnings that were observed due to the currently serial nature of our image pipeline callbacks. For example:

- a batch of depth image callbacks for some timestamp window [0, n] arrive
- each callback publishes its tf snapshot at reported capture timestamp
- a batch of rgb image callbacks arrive next for an overlapping window [0, n + 1]
- any attempts to publish within the overlapping window (- some delta) are refused with warning, they're too old

## Testing
updated behavior, smooth updates at robot state (see #107 for older behavior)

https://github.com/bdaiinstitute/spot_ros2/assets/137219344/f522e4b9-c6b0-44b1-b437-cbef129dac38