### PR TITLE
[SW-341] Remove aggressive (non-)error printing in handle_list_graph

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1996,11 +1996,10 @@ class SpotROS(Node):
             return response
 
         try:
-            self.get_logger().error(f"handle_list_graph: {request}")
+            self.get_logger().info(f"Listing graph for: {request.upload_filepath}")
             self.spot_wrapper._clear_graph()
             self.spot_wrapper._upload_graph_and_snapshots(request.upload_filepath)
             response.waypoint_ids = self.spot_wrapper.list_graph(request.upload_filepath)
-            self.get_logger().error(f"handle_list_graph RESPONSE: {response}")
         except Exception as e:
             self.get_logger().error("Exception Error:{}".format(e))
         return response


### PR DESCRIPTION
Fix logging in `handle_list_graph` for request/response that would appear as very large red errors in the console, but are not actually. Change the request printing to just the human readable part of the request rather than the entire object.