### PR TITLE
Update SpotImagePublisher image request rate to 15Hz and log the effective callback rate

### DIFF
--- a/spot_driver/launch/spot_image_publishers.launch.py
+++ b/spot_driver/launch/spot_image_publishers.launch.py
@@ -15,7 +15,7 @@ def generate_launch_description() -> launch.LaunchDescription:
     image_publish_rate_arg = DeclareLaunchArgument(
         "image_publish_rate",
         description="Rate in (hz) of image publishing",
-        default_value="10",
+        default_value="15",
     )
 
     rgb_cameras = LaunchConfiguration("rgb_cameras", default="true")
@@ -56,6 +56,7 @@ def generate_launch_description() -> launch.LaunchDescription:
     ]
     camera_types = ["camera", "depth", "depth_registered"]
     publish_camera_types = [publish_rgb, publish_depth, publish_depth_registered]
+
     for camera_type, publish_camera_type in zip(camera_types, publish_camera_types):
         camera_node = launch_ros.actions.Node(
             package="spot_driver",


### PR DESCRIPTION
This PR adds some new logging functionality to the standalone Spot image publisher node:

- The Spot body cameras can be queried at a maximum rate of 15Hz, so this updates the default rate which is used to configure the timer callback from 10Hz to 15Hz,
- Adds a rolling-average measurement for the actual rate at which the timer callbacks are being handled.
  - Since the timer callbacks which are responsible for requesting images from the Spot SDK and publishing them to ROS are handled by a single-threaded executor, each callback blocks subsequent callbacks from being handled until it finishes. This means that if each callback cannot handle all its work in less than `1/15` seconds, then the actual rate at which images are published will be slower than the requested 15Hz query rate.
- Use the ROS logger to print log messages, and log the time deltas with 3 decimal places of precision for readability.