### PR TITLE
[SW-341] Fix list_graph after graphnav modularization update

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2004,11 +2004,10 @@ class SpotROS(Node):
             return response
 
         try:
-            self.get_logger().error(f"handle_list_graph: {request}")
+            self.get_logger().info(f"Listing graph for: {request.upload_filepath}")
             self.spot_wrapper.spot_graph_nav.clear_graph()
             self.spot_wrapper.spot_graph_nav.upload_graph(request.upload_filepath)
-            response.waypoint_ids = self.spot_wrapper.spot_graph_nav.list_graph(request.upload_filepath)
-            self.get_logger().error(f"handle_list_graph RESPONSE: {response}")
+            response.waypoint_ids = self.spot_wrapper.spot_graph_nav.list_graph()
         except Exception as e:
             self.get_logger().error("Exception Error:{}".format(e))
         return response


### PR DESCRIPTION
Fix `list_graph` after the recent `spot_wrapper` modularization - it no longer takes an (unused) argument for the graph - which must be uploaded prior. This patch also removes some excessive error level logging that would appear as errors when everything was working as intended.