### PR TITLE
Fix missing use of frame_prefix when creating CameraInfo messages

### DIFF
--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -289,7 +289,7 @@ def bosdyn_data_to_image_and_camera_info_msgs(
     camera_info_msg.p[11] = 0
     local_time = robot_to_local_time(data.shot.acquisition_time)
     camera_info_msg.header.stamp = Time(sec=local_time.seconds, nanosec=local_time.nanos)
-    camera_info_msg.header.frame_id = data.shot.frame_name_image_sensor
+    camera_info_msg.header.frame_id = frame_prefix + data.shot.frame_name_image_sensor
     camera_info_msg.height = data.shot.image.rows
     camera_info_msg.width = data.shot.image.cols
 


### PR DESCRIPTION
## Description

When the driver node is publishing camera images and camera info, the `frame_id` field in the CameraInfo message is missing the prefix which describes the robot name. The causes these messages to contain mismatched values of `frame_id` when running the spot_ros2 driver node with a prefix, which subsequently causes problems when using some perception processing tools that use the frame ID in the CameraInfo header to perform TF lookups.

This PR fixes this problem by making the frame ID of the image header match the frame ID of the CameraInfo header set at [this line](https://github.com/bdaiinstitute/spot_ros2/blob/3d7224cc6d8bcc6724d3cb387b60e93125b205ce/spot_driver/spot_driver/ros_helpers.py#L187).

## How to Test

(note: I'm connected to a robot using a direct Ethernet connection, so the robot's namespace is `Ethernet1`)

Echo an image topic: `ros2 topic echo --no-arr /Ethernet1/depth/back/image`

The output should look like this:

```
header:
  stamp:
    sec: 1692306918
    nanosec: 568113870
  frame_id: Ethernet1/back
height: 240
width: 424
encoding: 16UC1
is_bigendian: 0
step: 848
data: '<sequence type: uint8, length: 203520>'
```

Echo a camera info topic: `ros2 topic echo --no-arr /Ethernet1/depth/back/camera_info`

Output looks like this:

```
header:
  stamp:
    sec: 1692306925
    nanosec: 503100110
  frame_id: Ethernet1/back
height: 240
width: 424
distortion_model: plumb_bob
d: '<sequence type: double, length: 5>'
k: '<array type: double[9]>'
r: '<array type: double[9]>'
p: '<array type: double[12]>'
binning_x: 0
binning_y: 0
roi:
  x_offset: 0
  y_offset: 0
  height: 0
  width: 0
  do_rectify: false
```
Verify that the value of `header.frame_id` matches between both messages.
