### PR TITLE
[SW-440] Fixed the goals by passing a name to them

### DIFF
--- a/examples/simple_arm_motion/simple_arm_motion/arm_simple.py
+++ b/examples/simple_arm_motion/simple_arm_motion/arm_simple.py
@@ -101,7 +101,7 @@ def hello_arm(robot_name: Optional[str]) -> bool:
     conv.convert_proto_to_bosdyn_msgs_robot_command(command, action_goal.command)
     # Send the request and wait until the arm arrives at the goal
     node.get_logger().info("Moving arm to position 1.")
-    robot_command_client.send_goal_and_wait(action_goal)
+    robot_command_client.send_goal_and_wait("arm_move_one", action_goal)
 
     # Move the arm to a different position
     hand_ewrt_flat_body.z = 0
@@ -137,7 +137,7 @@ def hello_arm(robot_name: Optional[str]) -> bool:
     conv.convert_proto_to_bosdyn_msgs_robot_command(command, action_goal.command)
     # Send the request and wait until the arm arrives at the goal
     node.get_logger().info("Moving arm to position 2.")
-    robot_command_client.send_goal_and_wait(action_goal)
+    robot_command_client.send_goal_and_wait("arm_move_two", action_goal)
 
     tf_listener.shutdown()
 

--- a/examples/simple_walk_forward/simple_walk_forward/walk_forward.py
+++ b/examples/simple_walk_forward/simple_walk_forward/walk_forward.py
@@ -72,7 +72,7 @@ class WalkForward(Node):
         )
         action_goal = RobotCommand.Goal()
         conv.convert_proto_to_bosdyn_msgs_robot_command(proto_goal, action_goal.command)
-        self._robot_command_client.send_goal_and_wait(action_goal)
+        self._robot_command_client.send_goal_and_wait("walk_forward", action_goal)
         self.get_logger().info("Successfully walked forward")
 
     def shutdown(self) -> None:


### PR DESCRIPTION
The examples would fail originally due to the ActionClientWrapper refactor requiring an action name and a goal. The previous examples only sent a goal. Added an action name for the `walk_forward` and `arm_simple` examples.