### PR TITLE
[SW-443] spot_ros2 does not tell the spot-sdk to cancel when an action is cancelled

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1615,6 +1615,9 @@ class SpotROS(Node):
             result.success = False
             result.message = "Cancelled"
             goal_handle.canceled()
+            if self.spot_wrapper is not None:
+                _, stop_message = self.spot_wrapper.stop()
+                self.get_logger().info(f"Stop attempt due to cancellation: {stop_message}")
         elif not goal_handle.is_active:
             result.success = False
             result.message = "Cancelled"
@@ -1732,6 +1735,9 @@ class SpotROS(Node):
             result.success = False
             result.message = "Cancelled"
             goal_handle.canceled()
+            if self.spot_wrapper is not None:
+                _, stop_message = self.spot_wrapper.stop()
+                self.get_logger().info(f"Stop attempt due to cancellation: {stop_message}")
         elif not goal_handle.is_active:
             result.success = False
             result.message = "Cancelled"


### PR DESCRIPTION
Want to double check: in the case that the robot has aborted a goal, do we also want to check and stop the robot from doing anything? 