### PR TITLE
Add ROS services for Get and Set Gripper Camera Param messages

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -32,14 +32,29 @@ from bosdyn.api.geometry_pb2 import Quaternion, SE2VelocityLimit
 from bosdyn.api.spot import robot_command_pb2 as spot_command_pb2
 from bosdyn.client import math_helpers
 from bosdyn.client.exceptions import InternalServerError
-from bosdyn_msgs.msg import ManipulationApiFeedbackResponse, ManipulatorState, RobotCommandFeedback
-from geometry_msgs.msg import Pose, PoseStamped, TransformStamped, Twist, TwistWithCovarianceStamped, Vector3Stamped
+from bosdyn_msgs.msg import (
+    ManipulationApiFeedbackResponse,
+    ManipulatorState,
+    RobotCommandFeedback,
+)
+from geometry_msgs.msg import (
+    Pose,
+    PoseStamped,
+    TransformStamped,
+    Twist,
+    TwistWithCovarianceStamped,
+    Vector3Stamped,
+)
 from google.protobuf.timestamp_pb2 import Timestamp
 from nav_msgs.msg import Odometry
 from rclpy import Parameter
 from rclpy.action import ActionServer
 from rclpy.action.server import ServerGoalHandle
-from rclpy.callback_groups import CallbackGroup, MutuallyExclusiveCallbackGroup, ReentrantCallbackGroup
+from rclpy.callback_groups import (
+    CallbackGroup,
+    MutuallyExclusiveCallbackGroup,
+    ReentrantCallbackGroup,
+)
 from rclpy.clock import Clock
 from rclpy.executors import ExternalShutdownException, MultiThreadedExecutor
 from rclpy.impl import rcutils_logger
@@ -141,7 +156,12 @@ class GoalResponse(Enum):
 
 
 class WaitForGoal(object):
-    def __init__(self, clock: Clock, _time: Union[float, rclpy.time.Time], callback: Optional[Callable] = None) -> None:
+    def __init__(
+        self,
+        clock: Clock,
+        _time: Union[float, rclpy.time.Time],
+        callback: Optional[Callable] = None,
+    ) -> None:
         self._at_goal: bool = False
         self._callback: Optional[Callable] = callback
         self._clock: Clock = clock
@@ -528,7 +548,10 @@ class SpotROS(Node):
             ClearBehaviorFault,
             "clear_behavior_fault",
             lambda request, response: self.service_wrapper(
-                "clear_behavior_fault", self.handle_clear_behavior_fault, request, response
+                "clear_behavior_fault",
+                self.handle_clear_behavior_fault,
+                request,
+                response,
             ),
             callback_group=self.group,
         )
@@ -659,12 +682,20 @@ class SpotROS(Node):
         )
 
         self.navigate_as = ActionServer(
-            self, NavigateTo, "navigate_to", self.handle_navigate_to, callback_group=self.group
+            self,
+            NavigateTo,
+            "navigate_to",
+            self.handle_navigate_to,
+            callback_group=self.group,
         )
         # spot_ros.navigate_as.start() # As is online
 
         self.trajectory_server = ActionServer(
-            self, Trajectory, "trajectory", self.handle_trajectory, callback_group=self.group
+            self,
+            Trajectory,
+            "trajectory",
+            self.handle_trajectory,
+            callback_group=self.group,
         )
         # spot_ros.trajectory_server.start()
 
@@ -873,7 +904,9 @@ class SpotROS(Node):
         if world_objects:
             # TF
             tf_msg = get_tf_from_world_objects(
-                world_objects.world_objects, self.spot_wrapper, self.preferred_odom_frame.value
+                world_objects.world_objects,
+                self.spot_wrapper,
+                self.preferred_odom_frame.value,
             )
             if len(tf_msg.transforms) > 0:
                 self.dynamic_broadcaster.sendTransform(tf_msg.transforms)
@@ -889,7 +922,10 @@ class SpotROS(Node):
                 self.get_logger().warning("Robot is not localized; Please upload graph and localize.")
                 return
 
-            seed_t_body_msg, seed_t_body_trans_msg = conv.bosdyn_localization_to_pose_msg(
+            (
+                seed_t_body_msg,
+                seed_t_body_trans_msg,
+            ) = conv.bosdyn_localization_to_pose_msg(
                 state.localization,
                 self.spot_wrapper.robotToLocalTime,
                 in_seed_frame=True,
@@ -944,7 +980,9 @@ class SpotROS(Node):
         )
         for image_entry in result:
             image_msg, camera_info = bosdyn_data_to_image_and_camera_info_msgs(
-                image_entry.image_response, self.spot_wrapper.robotToLocalTime, self.spot_wrapper.frame_prefix
+                image_entry.image_response,
+                self.spot_wrapper.robotToLocalTime,
+                self.spot_wrapper.frame_prefix,
             )
             image_pub = getattr(self, f"{image_entry.camera_name}_{publisher_name}_pub")
             image_info_pub = getattr(self, f"{image_entry.camera_name}_{publisher_name}_info_pub")
@@ -1113,7 +1151,11 @@ class SpotROS(Node):
             response.success = False
             response.message = "Spot wrapper is undefined"
             return response
-        response.success, response.message, response.dances = self.spot_wrapper.list_all_dances()
+        (
+            response.success,
+            response.message,
+            response.dances,
+        ) = self.spot_wrapper.list_all_dances()
         return response
 
     def handle_list_all_moves(
@@ -1124,7 +1166,11 @@ class SpotROS(Node):
             response.success = False
             response.message = "Spot wrapper is undefined"
             return response
-        response.success, response.message, response.moves = self.spot_wrapper.list_all_moves()
+        (
+            response.success,
+            response.message,
+            response.moves,
+        ) = self.spot_wrapper.list_all_moves()
         return response
 
     def handle_upload_animation(
@@ -1587,7 +1633,8 @@ class SpotROS(Node):
         else:
             if self.spot_wrapper is not None:
                 conv.convert_proto_to_bosdyn_msgs_robot_command_feedback(
-                    self.spot_wrapper.get_robot_command_feedback(goal_id).feedback, feedback
+                    self.spot_wrapper.get_robot_command_feedback(goal_id).feedback,
+                    feedback,
                 )
         return feedback
 
@@ -1917,7 +1964,9 @@ class SpotROS(Node):
         self.spot_wrapper.set_mobility_params(mobility_params)
 
     def handle_graph_nav_get_localization_pose(
-        self, request: GraphNavGetLocalizationPose.Response, response: GraphNavGetLocalizationPose.Response
+        self,
+        request: GraphNavGetLocalizationPose.Response,
+        response: GraphNavGetLocalizationPose.Response,
     ) -> GraphNavGetLocalizationPose.Response:
         if self.spot_wrapper is None:
             self.get_logger().error("Spot wrapper is None")
@@ -1953,7 +2002,9 @@ class SpotROS(Node):
         return response
 
     def handle_graph_nav_set_localization(
-        self, request: GraphNavSetLocalization.Request, response: GraphNavSetLocalization.Response
+        self,
+        request: GraphNavSetLocalization.Request,
+        response: GraphNavSetLocalization.Response,
     ) -> GraphNavSetLocalization.Response:
         if self.spot_wrapper is None:
             self.get_logger().error("Spot wrapper is None")
@@ -1983,7 +2034,9 @@ class SpotROS(Node):
         return response
 
     def handle_graph_nav_upload_graph(
-        self, request: GraphNavUploadGraph.Request, response: GraphNavUploadGraph.Response
+        self,
+        request: GraphNavUploadGraph.Request,
+        response: GraphNavUploadGraph.Response,
     ) -> GraphNavUploadGraph.Response:
         if self.spot_wrapper is None:
             self.get_logger().error("Spot wrapper is None")
@@ -2140,7 +2193,11 @@ class SpotROS(Node):
         frame_prefix = MOCK_HOSTNAME + "/"
         if self.spot_wrapper is not None:
             frame_prefix = self.spot_wrapper.frame_prefix
-        excluded_frames = [self.tf_name_vision_odom.value, self.tf_name_kinematic_odom.value, frame_prefix + "body"]
+        excluded_frames = [
+            self.tf_name_vision_odom.value,
+            self.tf_name_kinematic_odom.value,
+            frame_prefix + "body",
+        ]
         excluded_frames = [f[f.rfind("/") + 1 :] for f in excluded_frames]
 
         # Special case handling for hand camera frames that reference the link "arm0.link_wr1" in their
@@ -2172,7 +2229,10 @@ class SpotROS(Node):
             existing_transforms = [
                 (transform.header.frame_id, transform.child_frame_id) for transform in self.camera_static_transforms
             ]
-            if (frame_prefix + parent_frame, frame_prefix + frame_name) in existing_transforms:
+            if (
+                frame_prefix + parent_frame,
+                frame_prefix + frame_name,
+            ) in existing_transforms:
                 # We already extracted this transform
                 continue
 
@@ -2182,7 +2242,11 @@ class SpotROS(Node):
                 local_time = Timestamp()
             tf_time = builtin_interfaces.msg.Time(sec=local_time.seconds, nanosec=local_time.nanos)
             static_tf = populate_transform_stamped(
-                tf_time, parent_frame, frame_name, transform.parent_tform_child, frame_prefix
+                tf_time,
+                parent_frame,
+                frame_name,
+                transform.parent_tform_child,
+                frame_prefix,
             )
             self.camera_static_transforms.append(static_tf)
             self.camera_static_transform_broadcaster.sendTransform(self.camera_static_transforms)
@@ -2254,16 +2318,22 @@ class SpotROS(Node):
             self.mobility_params_pub.publish(mobility_params_msg)
 
     def handle_get_gripper_camera_parameters(
-        self, request: GetGripperCameraParameters.Request
+        self,
+        request: GetGripperCameraParameters.Request,
+        response: GetGripperCameraParameters.Response,
     ) -> GetGripperCameraParameters.Response:
         if self.cam_wrapper is not None:
-            return self.cam_wrapper.gripper.get_params(request)
+            response = self.cam_wrapper.gripper.get_params(request)
+        return response
 
     def handle_set_gripper_camera_parameters(
-        self, request: SetGripperCameraParameters.Request
+        self,
+        request: SetGripperCameraParameters.Request,
+        response: SetGripperCameraParameters.Response,
     ) -> SetGripperCameraParameters.Response:
         if self.cam_wrapper is not None:
-            return self.cam_wrapper.gripper.set_params(request)
+            response = self.cam_wrapper.gripper.set_params(request)
+        return response
 
 
 def main(args: Optional[List[str]] = None) -> None:

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -22,6 +22,7 @@ from bdai_ros2_wrappers.single_goal_multiple_action_servers import (
 )
 from bosdyn.api import (
     geometry_pb2,
+    gripper_camera_param_pb2,
     image_pb2,
     manipulation_api_pb2,
     robot_command_pb2,
@@ -2193,25 +2194,17 @@ class SpotROS(Node):
         response: GetGripperCameraParameters.Response,
     ) -> GetGripperCameraParameters.Response:
         if self.spot_wrapper is None:
-            # response.success = False
-            # response.message = "Spot wrapper was not initialized"
             return response
         if not self.spot_wrapper.has_arm():
-            # response.success = False
-            # response.message = "Spot {} does not have an arm.".format(self.name)
             return response
 
         try:
-            proto_response = self.spot_wrapper.spot_images.get_gripper_camera_params(request)
-            conv.convert_proto_to_bosdyn_msgs_list_world_object_response(proto_response, response.response)
-            # request.success = True
-            # request.message = (
-            #     "Successfully sent request to get gripper camera parameters"
-            # )
+            proto_request = gripper_camera_param_pb2.GripperCameraGetParamRequest()
+            conv.convert_bosdyn_msgs_gripper_camera_get_param_request_to_proto(request, proto_request)
+            proto_response = self.spot_wrapper.spot_images.get_gripper_camera_params(proto_request)
+            conv.convert_proto_to_bosdyn_msgs_gripper_camera_get_param_response(proto_response, response)
         except Exception as e:
             self.get_logger().error("Error:{}\n{}".format(e, traceback.format_exc()))
-            # request.success = False
-            # request.message = e + "\n" + traceback.format_exc()
 
         return response
 
@@ -2221,17 +2214,15 @@ class SpotROS(Node):
         response: SetGripperCameraParameters.Response,
     ) -> SetGripperCameraParameters.Response:
         if self.spot_wrapper is None:
-            # response.success = False
-            # response.message = "Spot wrapper was not initialized"
             return response
         if not self.spot_wrapper.has_arm():
-            # response.success = False
-            # response.message = "Spot {} does not have an arm.".format(self.name)
             return response
 
         try:
-            proto_response = self.spot_wrapper.spot_images.set_gripper_camera_params(request)
-            conv.convert_proto_to_bosdyn_msgs_list_world_object_response(proto_response, response.response)
+            proto_request = gripper_camera_param_pb2.GripperCameraParamRequest()
+            conv.convert_bosdyn_msgs_gripper_camera_param_request_to_proto(request, proto_request)
+            proto_response = self.spot_wrapper.spot_images.set_gripper_camera_params(proto_request)
+            conv.convert_proto_to_bosdyn_msgs_gripper_camera_param_response(proto_response, response)
         except Exception as e:
             self.get_logger().error("Error:{}\n{}".format(e, traceback.format_exc()))
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2197,12 +2197,11 @@ class SpotROS(Node):
             return response
         if not self.spot_wrapper.has_arm():
             return response
-
         try:
             proto_request = gripper_camera_param_pb2.GripperCameraGetParamRequest()
-            conv.convert_bosdyn_msgs_gripper_camera_get_param_request_to_proto(request, proto_request)
+            conv.convert_bosdyn_msgs_gripper_camera_get_param_request_to_proto(request.request, proto_request)
             proto_response = self.spot_wrapper.spot_images.get_gripper_camera_params(proto_request)
-            conv.convert_proto_to_bosdyn_msgs_gripper_camera_get_param_response(proto_response, response)
+            conv.convert_proto_to_bosdyn_msgs_gripper_camera_get_param_response(proto_response, response.response)
         except Exception as e:
             self.get_logger().error("Error:{}\n{}".format(e, traceback.format_exc()))
 
@@ -2220,9 +2219,9 @@ class SpotROS(Node):
 
         try:
             proto_request = gripper_camera_param_pb2.GripperCameraParamRequest()
-            conv.convert_bosdyn_msgs_gripper_camera_param_request_to_proto(request, proto_request)
+            conv.convert_bosdyn_msgs_gripper_camera_param_request_to_proto(request.request, proto_request)
             proto_response = self.spot_wrapper.spot_images.set_gripper_camera_params(proto_request)
-            conv.convert_proto_to_bosdyn_msgs_gripper_camera_param_response(proto_response, response)
+            conv.convert_proto_to_bosdyn_msgs_gripper_camera_param_response(proto_response, response.response)
         except Exception as e:
             self.get_logger().error("Error:{}\n{}".format(e, traceback.format_exc()))
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2193,22 +2193,24 @@ class SpotROS(Node):
         response: GetGripperCameraParameters.Response,
     ) -> GetGripperCameraParameters.Response:
         if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper was not initialized"
+            # response.success = False
+            # response.message = "Spot wrapper was not initialized"
             return response
         if not self.spot_wrapper.has_arm():
-            response.success = False
-            response.message = "Spot {} does not have an arm.".format(self.name)
+            # response.success = False
+            # response.message = "Spot {} does not have an arm.".format(self.name)
             return response
 
         try:
             response = self.spot_wrapper.spot_images.get_gripper_camera_params(request)
-            request.success = True
-            request.message = "Successfully sent request to get gripper camera parameters"
+            # request.success = True
+            # request.message = (
+            #     "Successfully sent request to get gripper camera parameters"
+            # )
         except Exception as e:
-            self.get_logger().error("Error:{}".format(e))
-            request.success = False
-            request.message = e
+            self.get_logger().error("Error:{}\n{}".format(e, traceback.format_exc()))
+            # request.success = False
+            # request.message = e + "\n" + traceback.format_exc()
 
         return response
 
@@ -2218,22 +2220,18 @@ class SpotROS(Node):
         response: SetGripperCameraParameters.Response,
     ) -> SetGripperCameraParameters.Response:
         if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper was not initialized"
+            # response.success = False
+            # response.message = "Spot wrapper was not initialized"
             return response
         if not self.spot_wrapper.has_arm():
-            response.success = False
-            response.message = "Spot {} does not have an arm.".format(self.name)
+            # response.success = False
+            # response.message = "Spot {} does not have an arm.".format(self.name)
             return response
 
         try:
             response = self.spot_wrapper.spot_images.set_gripper_camera_params(request)
-            request.success = True
-            request.message = "Successfully sent request to set gripper camera parameters"
         except Exception as e:
-            self.get_logger().error("Error:{}".format(e))
-            request.success = False
-            request.message = e
+            self.get_logger().error("Error:{}\n{}".format(e, traceback.format_exc()))
 
         return response
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2322,8 +2322,8 @@ class SpotROS(Node):
         request: GetGripperCameraParameters.Request,
         response: GetGripperCameraParameters.Response,
     ) -> GetGripperCameraParameters.Response:
-        if self.cam_wrapper is not None:
-            response = self.cam_wrapper.gripper.get_params(request)
+        if self.spot_cam_wrapper is not None:
+            response = self.spot_cam_wrapper.gripper.get_params(request)
         return response
 
     def handle_set_gripper_camera_parameters(
@@ -2331,8 +2331,8 @@ class SpotROS(Node):
         request: SetGripperCameraParameters.Request,
         response: SetGripperCameraParameters.Response,
     ) -> SetGripperCameraParameters.Response:
-        if self.cam_wrapper is not None:
-            response = self.cam_wrapper.gripper.set_params(request)
+        if self.spot_cam_wrapper is not None:
+            response = self.spot_cam_wrapper.gripper.set_params(request)
         return response
 
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -353,10 +353,6 @@ class SpotROS(Node):
         if self.name is not None:
             name_str = " for " + self.name
         self.get_logger().info("Starting ROS driver for Spot" + name_str)
-
-        all_cameras = ["frontleft", "frontright", "left", "right", "back"]
-        has_arm = False
-
         ############## testing with Robot
 
         if self.name == MOCK_HOSTNAME:
@@ -382,15 +378,17 @@ class SpotROS(Node):
             if not self.spot_wrapper.is_valid:
                 return
 
-            has_arm = self.spot_wrapper.has_arm()
-            if has_arm:
-                all_cameras.append("hand")
-
             try:
-                self.spot_cam_wrapper = SpotCamWrapper(self.ip, self.username, self.password, self.cam_logger, has_arm)
+                self.spot_cam_wrapper = SpotCamWrapper(self.ip, self.username, self.password, self.cam_logger)
             except SystemError:
                 self.spot_cam_wrapper = None
 
+        all_cameras = ["frontleft", "frontright", "left", "right", "back"]
+        has_arm = False
+        if self.spot_wrapper is not None:
+            has_arm = self.spot_wrapper.has_arm()
+        if has_arm:
+            all_cameras.append("hand")
         self.declare_parameter("cameras_used", all_cameras)
         self.cameras_used = self.get_parameter("cameras_used")
 
@@ -2322,8 +2320,8 @@ class SpotROS(Node):
         request: GetGripperCameraParameters.Request,
         response: GetGripperCameraParameters.Response,
     ) -> GetGripperCameraParameters.Response:
-        if self.spot_cam_wrapper is not None:
-            response = self.spot_cam_wrapper.gripper.get_params(request)
+        if self.spot_wrapper is not None:
+            response = self.spot_wrapper.spot_images.get_gripper_camera_params(request)
         return response
 
     def handle_set_gripper_camera_parameters(
@@ -2331,8 +2329,8 @@ class SpotROS(Node):
         request: SetGripperCameraParameters.Request,
         response: SetGripperCameraParameters.Response,
     ) -> SetGripperCameraParameters.Response:
-        if self.spot_cam_wrapper is not None:
-            response = self.spot_cam_wrapper.gripper.set_params(request)
+        if self.spot_wrapper is not None:
+            response = self.spot_wrapper.spot_images.gripper.set_gripper_camera_params(request)
         return response
 
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2202,7 +2202,8 @@ class SpotROS(Node):
             return response
 
         try:
-            response = self.spot_wrapper.spot_images.get_gripper_camera_params(request)
+            proto_response = self.spot_wrapper.spot_images.get_gripper_camera_params(request)
+            conv.convert_proto_to_bosdyn_msgs_list_world_object_response(proto_response, response.response)
             # request.success = True
             # request.message = (
             #     "Successfully sent request to get gripper camera parameters"
@@ -2229,7 +2230,8 @@ class SpotROS(Node):
             return response
 
         try:
-            response = self.spot_wrapper.spot_images.set_gripper_camera_params(request)
+            proto_response = self.spot_wrapper.spot_images.set_gripper_camera_params(request)
+            conv.convert_proto_to_bosdyn_msgs_list_world_object_response(proto_response, response.response)
         except Exception as e:
             self.get_logger().error("Error:{}\n{}".format(e, traceback.format_exc()))
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -665,30 +665,30 @@ class SpotROS(Node):
             self.handle_graph_nav_set_localization,
             callback_group=self.group,
         )
-
-        self.create_service(
-            GetGripperCameraParameters,
-            "get_gripper_camera_parameters",
-            lambda request, response: self.service_wrapper(
+        if has_arm:
+            self.create_service(
+                GetGripperCameraParameters,
                 "get_gripper_camera_parameters",
-                self.handle_get_gripper_camera_parameters,
-                request,
-                response,
-            ),
-            callback_group=self.group,
-        )
+                lambda request, response: self.service_wrapper(
+                    "get_gripper_camera_parameters",
+                    self.handle_get_gripper_camera_parameters,
+                    request,
+                    response,
+                ),
+                callback_group=self.group,
+            )
 
-        self.create_service(
-            SetGripperCameraParameters,
-            "set_gripper_camera_parameters",
-            lambda request, response: self.service_wrapper(
+            self.create_service(
+                SetGripperCameraParameters,
                 "set_gripper_camera_parameters",
-                self.handle_set_gripper_camera_parameters,
-                request,
-                response,
-            ),
-            callback_group=self.group,
-        )
+                lambda request, response: self.service_wrapper(
+                    "set_gripper_camera_parameters",
+                    self.handle_set_gripper_camera_parameters,
+                    request,
+                    response,
+                ),
+                callback_group=self.group,
+            )
 
         self.navigate_as = ActionServer(
             self,

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2320,8 +2320,12 @@ class SpotROS(Node):
         request: GetGripperCameraParameters.Request,
         response: GetGripperCameraParameters.Response,
     ) -> GetGripperCameraParameters.Response:
-        if self.spot_wrapper is not None:
-            response = self.spot_wrapper.spot_images.get_gripper_camera_params(request)
+        if self.spot_wrapper is not None and self.spot_wrapper.has_arm():
+            try:
+                response = self.spot_wrapper.spot_images.get_gripper_camera_params(request)
+            except Exception as e:
+                self.get_logger().error("Error:{}".format(e))
+                pass
         return response
 
     def handle_set_gripper_camera_parameters(
@@ -2329,8 +2333,12 @@ class SpotROS(Node):
         request: SetGripperCameraParameters.Request,
         response: SetGripperCameraParameters.Response,
     ) -> SetGripperCameraParameters.Response:
-        if self.spot_wrapper is not None:
-            response = self.spot_wrapper.spot_images.set_gripper_camera_params(request)
+        if self.spot_wrapper is not None and self.spot_wrapper.has_arm():
+            try:
+                response = self.spot_wrapper.spot_images.set_gripper_camera_params(request)
+            except Exception as e:
+                self.get_logger().error("Error:{}".format(e))
+                pass
         return response
 
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2194,16 +2194,25 @@ class SpotROS(Node):
         response: GetGripperCameraParameters.Response,
     ) -> GetGripperCameraParameters.Response:
         if self.spot_wrapper is None:
+            response.success = False
+            response.message = "Spot Wrapper not initialized"
             return response
         if not self.spot_wrapper.has_arm():
+            response.success = False
+            response.message = "Spot configuration does not have arm"
             return response
         try:
             proto_request = gripper_camera_param_pb2.GripperCameraGetParamRequest()
             conv.convert_bosdyn_msgs_gripper_camera_get_param_request_to_proto(request.request, proto_request)
             proto_response = self.spot_wrapper.spot_images.get_gripper_camera_params(proto_request)
             conv.convert_proto_to_bosdyn_msgs_gripper_camera_get_param_response(proto_response, response.response)
+            response.success = True
+            response.message = "Request to get gripper camera parameters sent"
         except Exception as e:
-            self.get_logger().error("Error:{}\n{}".format(e, traceback.format_exc()))
+            error_str = "Error:{}\n{}".format(e, traceback.format_exc())
+            self.get_logger().error(error_str)
+            response.success = False
+            response.message = error_str
 
         return response
 
@@ -2213,8 +2222,12 @@ class SpotROS(Node):
         response: SetGripperCameraParameters.Response,
     ) -> SetGripperCameraParameters.Response:
         if self.spot_wrapper is None:
+            response.success = False
+            response.message = "Spot Wrapper not initialized"
             return response
         if not self.spot_wrapper.has_arm():
+            response.success = False
+            response.message = "Spot configuration does not have arm"
             return response
 
         try:
@@ -2222,8 +2235,13 @@ class SpotROS(Node):
             conv.convert_bosdyn_msgs_gripper_camera_param_request_to_proto(request.request, proto_request)
             proto_response = self.spot_wrapper.spot_images.set_gripper_camera_params(proto_request)
             conv.convert_proto_to_bosdyn_msgs_gripper_camera_param_response(proto_response, response.response)
+            response.success = True
+            response.message = "Request to set gripper camera parameters sent"
         except Exception as e:
-            self.get_logger().error("Error:{}\n{}".format(e, traceback.format_exc()))
+            error_str = "Error:{}\n{}".format(e, traceback.format_exc())
+            self.get_logger().error(error_str)
+            response.success = False
+            response.message = error_str
 
         return response
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2330,7 +2330,7 @@ class SpotROS(Node):
         response: SetGripperCameraParameters.Response,
     ) -> SetGripperCameraParameters.Response:
         if self.spot_wrapper is not None:
-            response = self.spot_wrapper.spot_images.gripper.set_gripper_camera_params(request)
+            response = self.spot_wrapper.spot_images.set_gripper_camera_params(request)
         return response
 
 

--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -70,6 +70,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/GraphNavSetLocalization.srv"
   "srv/GraphNavGetLocalizationPose.srv"
   "srv/Dock.srv"
+  "srv/GetGripperCameraParameters.srv"
+  "srv/SetGripperCameraParameters.srv"
   "action/NavigateTo.action"
   "action/RobotCommand.action"
   "action/Trajectory.action"

--- a/spot_msgs/srv/GetGripperCameraParameters.srv
+++ b/spot_msgs/srv/GetGripperCameraParameters.srv
@@ -1,3 +1,5 @@
 bosdyn_msgs/GripperCameraGetParamRequest request
 ---
 bosdyn_msgs/GripperCameraGetParamResponse response
+bool success
+string message

--- a/spot_msgs/srv/GetGripperCameraParameters.srv
+++ b/spot_msgs/srv/GetGripperCameraParameters.srv
@@ -1,5 +1,3 @@
 bosdyn_msgs/GripperCameraGetParamRequest request
 ---
 bosdyn_msgs/GripperCameraGetParamResponse response
-bool success
-string message

--- a/spot_msgs/srv/GetGripperCameraParameters.srv
+++ b/spot_msgs/srv/GetGripperCameraParameters.srv
@@ -1,0 +1,3 @@
+bosdyn_msgs/GripperCameraGetParamRequest request
+---
+bosdyn_msgs/GripperCameraGetParamResponse response

--- a/spot_msgs/srv/SetGripperCameraParameters.srv
+++ b/spot_msgs/srv/SetGripperCameraParameters.srv
@@ -1,3 +1,5 @@
 bosdyn_msgs/GripperCameraParamRequest request
 ---
 bosdyn_msgs/GripperCameraParamResponse response
+bool success
+string message

--- a/spot_msgs/srv/SetGripperCameraParameters.srv
+++ b/spot_msgs/srv/SetGripperCameraParameters.srv
@@ -1,5 +1,3 @@
 bosdyn_msgs/GripperCameraParamRequest request
 ---
 bosdyn_msgs/GripperCameraParamResponse response
-bool success
-string message

--- a/spot_msgs/srv/SetGripperCameraParameters.srv
+++ b/spot_msgs/srv/SetGripperCameraParameters.srv
@@ -1,0 +1,3 @@
+bosdyn_msgs/GripperCameraParamRequest request
+---
+bosdyn_msgs/GripperCameraParamResponse response


### PR DESCRIPTION
This PR adds the services `GetGripperCameraParameter` and `SetGripperCameraParameter` as well as the corresponding callbacks needed to `Spot_ros2.py`. 

This PR depends on [another PR](https://github.com/bdaiinstitute/spot_wrapper/pull/71) to `spot_wrapper` that adds a wrapper around the gripper camera param python client.