### PR TITLE
Fix launch file param for RViz config filepath

### DIFF
--- a/examples/simple_arm_motion/README.md
+++ b/examples/simple_arm_motion/README.md
@@ -19,7 +19,7 @@ ros2 launch spot_driver spot_driver.launch.py
 ```
 If you want to launch with a namespace,
 ```bash
-ros2 launch spot_driver_with_namespace.launch.py spot_name:=<spot_name> 
+ros2 launch spot_driver.launch.py spot_name:=<spot_name> 
 ```
 
 5.  Run the example:

--- a/examples/simple_walk_forward/README.md
+++ b/examples/simple_walk_forward/README.md
@@ -18,7 +18,7 @@ ros2 launch spot_driver spot_driver.launch.py
 ```
 If you want to launch with a namespace,
 ```bash
-ros2 launch spot_driver_with_namespace.launch.py spot_name:=<spot_name> 
+ros2 launch spot_driver.launch.py spot_name:=<spot_name> 
 ```
 
 5.  Run the example:

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -90,9 +90,10 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     )
     ld.add_action(robot_state_publisher)
 
-    if not rviz_config_file:
+    # It looks like passing an optional of value "None" gets converted to a string of value "None"
+    if rviz_config_file is None or rviz_config_file == "None":
         create_rviz_config(spot_name)
-        rviz_config_file = PathJoinSubstitution([FindPackageShare("spot_driver"), "rviz", "spot.rviz"])
+        rviz_config_file = PathJoinSubstitution([FindPackageShare("spot_driver"), "rviz", "spot.rviz"]).perform(context)
 
     rviz = launch_ros.actions.Node(
         package="rviz2",

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -46,7 +46,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     config_file = LaunchConfiguration("config_file")
     has_arm = LaunchConfiguration("has_arm")
     launch_rviz = LaunchConfiguration("launch_rviz")
-    rviz_config_filename = LaunchConfiguration("rviz_config_filename").perform(context)
+    rviz_config_file = LaunchConfiguration("rviz_config_file").perform(context)
     spot_name = LaunchConfiguration("spot_name").perform(context)
     tf_prefix = LaunchConfiguration("tf_prefix").perform(context)
 
@@ -90,17 +90,15 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     )
     ld.add_action(robot_state_publisher)
 
-    if not rviz_config_filename:
+    if not rviz_config_file:
         create_rviz_config(spot_name)
         rviz_config_file = PathJoinSubstitution([FindPackageShare("spot_driver"), "rviz", "spot.rviz"])
-    else:
-        rviz_config_file = PathJoinSubstitution([FindPackageShare("spot_driver"), "rviz", rviz_config_filename])
 
     rviz = launch_ros.actions.Node(
         package="rviz2",
         executable="rviz2",
         name="rviz2",
-        arguments=["-d", rviz_config_file.perform(context)],
+        arguments=["-d", rviz_config_file],
         output="screen",
         condition=IfCondition(launch_rviz),
     )
@@ -131,9 +129,9 @@ def generate_launch_description() -> launch.LaunchDescription:
     launch_args.append(DeclareLaunchArgument("launch_rviz", default_value="False", description="Launch RViz?"))
     launch_args.append(
         DeclareLaunchArgument(
-            "rviz_config_filename",
+            "rviz_config_file",
             default_value="",
-            description="RViz config file name",
+            description="RViz config file",
         )
     )
 


### PR DESCRIPTION
This is a follow up PR to #125.
This PR changes the `rviz_config_filename` parameter to `rviz_config_file` and doesn't attempt to look for the rviz config inside of the `spot_driver` package. 

Also includes documentation changes that remove the reference to `spot_driver_with_namespace.launch.py`