### PR TITLE
[SW-416] Include feedback from the ArmImpedanceCommand when Spot-SDK gets upgraded

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -778,9 +778,12 @@ class SpotROS(Node):
         """Incredibly janky way to check if the bosdyn api is past 3.3.0, when impedance feedback is implemented"""
         sdk_version = version("bosdyn.api")
         sdk_numbers = [int(digit) for digit in sdk_version.split(".")]
-        if sdk_numbers[-2] > 2:
+        if sdk_numbers[0] > 3:
             return True
-        return False
+        elif sdk_numbers[0] == 3 and sdk_numbers[1] > 2:
+            return True
+        else:
+            return False
 
     def spin(self) -> None:
         self.get_logger().info("Spinning ros2_driver")

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1531,8 +1531,11 @@ class SpotROS(Node):
                     ):
                         return GoalResponse.FAILED
                 elif arm_feedback.feedback.feedback_choice == arm_feedback.feedback.FEEDBACK_ARM_IMPEDANCE_FEEDBACK_SET:
-                    self.get_logger().warn("WARNING: ArmImpedanceCommand provides no feedback")
-                    pass  # May return SUCCESS below
+                    if (
+                        arm_feedback.feedback.arm_impedance_feedback.status
+                        != arm_feedback.feedback.arm_impedance_feedback.status.STATUS_TRAJECTORY_COMPLETE
+                    ):
+                        return GoalResponse.IN_PROGRESS
                 else:
                     self.get_logger().error("ERROR: unknown arm command type")
                     return GoalResponse.IN_PROGRESS


### PR DESCRIPTION
Currently impedance control feedback isn't available over spot_ros2. This would allow us to check if impedance trajectories are done. This only works when we upgrade to 3.3.0 or higher though, so the PR is for visibility. 