### PR TITLE
[SW-526] Added an exception field to the ROS2 logger for SpotWrapper

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1,5 +1,6 @@
 ### Debug
 # from ros_helpers import *
+import logging
 import sys
 import threading
 import time
@@ -14,6 +15,9 @@ import builtin_interfaces.msg
 import rclpy
 import rclpy.time
 import tf2_ros
+from bdai_ros2_wrappers.logging import (
+    logs_to_ros,
+)
 from bdai_ros2_wrappers.single_goal_action_server import (
     SingleGoalActionServer,
 )
@@ -187,27 +191,6 @@ class SpotImageType(str, Enum):
     RegDepth = "depth_registered"
 
 
-class SpotWrapperLogger(rcutils_logger.RcutilsLogger):
-    """Class that wraps the logger so it behaves as the Spot-SDK expects."""
-
-    def __init__(self, name: str):
-        super().__init__(name=name)
-
-    def exception(self, msg: str, *args: str, **kwargs: str) -> None:
-        """Wraps an exception in the style format expected by logging.Logger.
-
-        This is required by the Spot-SDK (which is called by SpotWrapper on the chance that
-        the async_tasks function has an error.
-
-        See: https://github.com/boston-dynamics/spot-sdk/blob/6a03ae12056a74e65fd9715128e0c40762dfa7ba/python/bosdyn-client/src/bosdyn/client/async_tasks.py#L182C1-L182C1
-
-        Args:
-            msg: error message to report
-        """
-        error_msg = msg % args
-        self.error(error_msg, **kwargs)
-
-
 class SpotROS(Node):
     """Parent class for using the wrapper.  Defines all callbacks and keeps the wrapper alive"""
 
@@ -370,7 +353,7 @@ class SpotROS(Node):
         name_with_dot = ""
         if self.name is not None:
             name_with_dot = self.name + "."
-        self.wrapper_logger = SpotWrapperLogger(name=f"{name_with_dot}spot_wrapper")
+        self.wrapper_logger = logging.getLogger(f"{name_with_dot}spot_wrapper")
 
         name_str = ""
         if self.name is not None:
@@ -2413,7 +2396,8 @@ def main(args: Optional[List[str]] = None) -> None:
     rclpy.init(args=args)
     spot_ros = SpotROS()
     try:
-        spot_ros.spin()
+        with logs_to_ros(spot_ros):
+            spot_ros.spin()
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
     if spot_ros.spot_wrapper is not None:

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -353,6 +353,8 @@ class SpotROS(Node):
         name_with_dot = ""
         if self.name is not None:
             name_with_dot = self.name + "."
+
+        logging.basicConfig(format="[%(filename)s:%(lineno)d] %(message)s", level=logging.ERROR)
         self.wrapper_logger = logging.getLogger(f"{name_with_dot}spot_wrapper")
 
         name_str = ""


### PR DESCRIPTION
As referenced [here](https://github.com/boston-dynamics/spot-sdk/blob/6a03ae12056a74e65fd9715128e0c40762dfa7ba/python/bosdyn-client/src/bosdyn/client/async_tasks.py#L182), the logger on Spot expects a `logging.Logger` style logger with an exception field instead of the RCUtilsLogger. The RCUtilsLogger doens't have an `exception` method, so I just wrapped it with an exception method. 

This was HIL tested by calling the `_handle_error` in SpotWrapper's various classes that inherit from `AsyncPeriodicQuery`. This should log data for future failures in the robot's start up.   