### PR TITLE
[N/A] Add dependabot config to update submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "23:59"
+      timezone: "America/New_York"
+    commit-message:
+      prefix: "[dependabot] "
+    # 1 per submodule
+    open-pull-requests-limit: 2


### PR DESCRIPTION
This will configure dependabot to open PRs to update the submodules. It will check nightly. PRs will still have to be manually approved/merged.