### PR TITLE
Add exec_depend tags for packages used by spot_driver launch files at runtime

### DIFF
--- a/spot_driver/package.xml
+++ b/spot_driver/package.xml
@@ -18,6 +18,12 @@
 
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>
+  <exec_depend>depth_image_proc</exec_depend>
+  <exec_depend>rclcpp_components</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+  <exec_depend>spot_description</exec_depend>
+  <exec_depend>xacro</exec_depend>
   <build_depend>common_interfaces</build_depend>
   <build_depend>spot_msgs</build_depend>
 


### PR DESCRIPTION
These packages are installed by the `install_spot_ros2.sh` script, but to allow installing dependencies using `rosdep` they should be listed in `spot_driver/package.xml` as well.