### PR TITLE
[N/A] Add a mock launch argument

### DIFF
--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -114,15 +114,20 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     tf_prefix = LaunchConfiguration("tf_prefix").perform(context)
     depth_registered_mode_config = LaunchConfiguration("depth_registered_mode")
     publish_point_clouds_config = LaunchConfiguration("publish_point_clouds")
+    mock_enable = LaunchConfiguration("mock_enable", default=False).perform(context)
 
-    # Get parameters from Spot.
+    if not mock_enable:
+        # Get parameters from Spot.
 
-    username = os.getenv("BOSDYN_CLIENT_USERNAME", "username")
-    password = os.getenv("BOSDYN_CLIENT_PASSWORD", "password")
-    hostname = os.getenv("SPOT_IP", "hostname")
+        username = os.getenv("BOSDYN_CLIENT_USERNAME", "username")
+        password = os.getenv("BOSDYN_CLIENT_PASSWORD", "password")
+        hostname = os.getenv("SPOT_IP", "hostname")
 
-    spot_wrapper = SpotWrapper(username, password, hostname, spot_name, logger)
-    has_arm = spot_wrapper.has_arm()
+        spot_wrapper = SpotWrapper(username, password, hostname, spot_name, logger)
+        has_arm = spot_wrapper.has_arm()
+    else:
+        # TODO if it's not a boolean, correctly errors, but does not provide launch argument name
+        has_arm = IfCondition(LaunchConfiguration("mock_has_arm")).evaluate(context)
 
     pkg_share = FindPackageShare("spot_description").find("spot_description")
 
@@ -196,7 +201,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
             PathJoinSubstitution([pkg_share, "urdf", "spot.urdf.xacro"]),
             " ",
             "arm:=",
-            TextSubstitution(text=str(spot_wrapper.has_arm()).lower()),
+            TextSubstitution(text=str(has_arm).lower()),
             " ",
             "tf_prefix:=",
             tf_prefix,

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -115,10 +115,10 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     depth_registered_mode_config = LaunchConfiguration("depth_registered_mode")
     publish_point_clouds_config = LaunchConfiguration("publish_point_clouds")
     mock_enable = IfCondition(LaunchConfiguration("mock_enable", default="False")).evaluate(context)
-    
+
     if not mock_enable:
         # Get parameters from Spot.
-        
+
         username = os.getenv("BOSDYN_CLIENT_USERNAME", "username")
         password = os.getenv("BOSDYN_CLIENT_PASSWORD", "password")
         hostname = os.getenv("SPOT_IP", "hostname")
@@ -126,7 +126,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
         spot_wrapper = SpotWrapper(username, password, hostname, spot_name, logger)
         has_arm = spot_wrapper.has_arm()
     else:
-        mock_has_arm = IfCondition(LaunchConfiguration("mock_has_arm", default="True")).evaluate(context)
+        mock_has_arm = IfCondition(LaunchConfiguration("mock_has_arm")).evaluate(context)
         has_arm = mock_has_arm
 
     pkg_share = FindPackageShare("spot_description").find("spot_description")

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -114,7 +114,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     tf_prefix = LaunchConfiguration("tf_prefix").perform(context)
     depth_registered_mode_config = LaunchConfiguration("depth_registered_mode")
     publish_point_clouds_config = LaunchConfiguration("publish_point_clouds")
-    mock_enable = LaunchConfiguration("mock_enable").perform(context) == "True"
+    mock_enable = IfCondition(LaunchConfiguration("mock_enable", default="False")).evaluate(context)
     
     if not mock_enable:
         # Get parameters from Spot.
@@ -126,7 +126,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
         spot_wrapper = SpotWrapper(username, password, hostname, spot_name, logger)
         has_arm = spot_wrapper.has_arm()
     else:
-        mock_has_arm = LaunchConfiguration("mock_has_arm", default="True").perform(context) == "True"
+        mock_has_arm = IfCondition(LaunchConfiguration("mock_has_arm", default="True")).evaluate(context)
         has_arm = mock_has_arm
 
     pkg_share = FindPackageShare("spot_description").find("spot_description")
@@ -163,7 +163,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
         "mock_has_arm": mock_has_arm,
         "publish_depth_registered": False,
         "publish_depth": False,
-        "publish_rgb": False
+        "publish_rgb": False,
     }
 
     spot_driver_node = launch_ros.actions.Node(

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -114,11 +114,11 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     tf_prefix = LaunchConfiguration("tf_prefix").perform(context)
     depth_registered_mode_config = LaunchConfiguration("depth_registered_mode")
     publish_point_clouds_config = LaunchConfiguration("publish_point_clouds")
-    mock_enable = LaunchConfiguration("mock_enable", default=False).perform(context)
-
+    mock_enable = LaunchConfiguration("mock_enable").perform(context) == "True"
+    
     if not mock_enable:
         # Get parameters from Spot.
-
+        
         username = os.getenv("BOSDYN_CLIENT_USERNAME", "username")
         password = os.getenv("BOSDYN_CLIENT_PASSWORD", "password")
         hostname = os.getenv("SPOT_IP", "hostname")
@@ -126,8 +126,8 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
         spot_wrapper = SpotWrapper(username, password, hostname, spot_name, logger)
         has_arm = spot_wrapper.has_arm()
     else:
-        # TODO if it's not a boolean, correctly errors, but does not provide launch argument name
-        has_arm = IfCondition(LaunchConfiguration("mock_has_arm")).evaluate(context)
+        mock_has_arm = LaunchConfiguration("mock_has_arm", default="True").perform(context) == "True"
+        has_arm = mock_has_arm
 
     pkg_share = FindPackageShare("spot_description").find("spot_description")
 
@@ -159,9 +159,11 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     # in spot_driver.
     spot_driver_params = {
         "spot_name": spot_name,
+        "mock_enable": mock_enable,
+        "mock_has_arm": mock_has_arm,
         "publish_depth_registered": False,
         "publish_depth": False,
-        "publish_rgb": False,
+        "publish_rgb": False
     }
 
     spot_driver_node = launch_ros.actions.Node(

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -118,7 +118,8 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
 
     if not mock_enable:
         # Get parameters from Spot.
-
+        # TODO this deviates from the `get_from_env_and_fall_back_to_param` logic in `spot_ros2.py`,
+        # which would pull in values in `config_file`
         username = os.getenv("BOSDYN_CLIENT_USERNAME", "username")
         password = os.getenv("BOSDYN_CLIENT_PASSWORD", "password")
         hostname = os.getenv("SPOT_IP", "hostname")
@@ -160,11 +161,15 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     spot_driver_params = {
         "spot_name": spot_name,
         "mock_enable": mock_enable,
-        "mock_has_arm": mock_has_arm,
         "publish_depth_registered": False,
         "publish_depth": False,
         "publish_rgb": False,
     }
+
+    if mock_enable:
+        mock_spot_driver_params = {"mock_has_arm": mock_has_arm}
+        # Merge the two dicts
+        spot_driver_params = {**spot_driver_params, **mock_spot_driver_params}
 
     spot_driver_node = launch_ros.actions.Node(
         package="spot_driver",

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -415,10 +415,12 @@ class SpotROS(Node):
                     self.spot_cam_wrapper = None
 
             if self.frame_prefix != self.spot_wrapper.frame_prefix:
-                self.get_logger().warn(
-                    f"WARNING: disagreement between `self.frame_prefix` ({self.frame_prefix}) and"
+                error_msg = (
+                    f"ERROR: disagreement between `self.frame_prefix` ({self.frame_prefix}) and"
                     f" `self.spot_wrapper.frame_prefix` ({self.spot_wrapper.frame_prefix})"
                 )
+                self.get_logger().error(error_msg)
+                raise ValueError(error_msg)
 
         all_cameras = ["frontleft", "frontright", "left", "right", "back"]
         has_arm = self.mock_has_arm

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -296,9 +296,6 @@ class SpotROS(Node):
             self.name = None
         self.mock: Optional[bool] = self.get_parameter("mock_enable").value
         self.mock_has_arm: Optional[bool] = self.get_parameter("mock_has_arm").value
-        self.get_logger().info(f"self.name: {self.name}")
-        self.get_logger().info(f"self.mock: {self.mock}")
-        self.get_logger().info(f"self.mock_has_arm: {self.mock_has_arm}")
 
         self.motion_deadzone: Parameter = self.get_parameter("deadzone")
         self.estop_timeout: Parameter = self.get_parameter("estop_timeout")
@@ -2349,9 +2346,7 @@ class SpotROS(Node):
         # We exclude the odometry frames from static transforms since they are not static. We can ignore the body
         # frame because it is a child of odom or vision depending on the preferred_odom_frame, and will be published
         # by the non-static transform publishing that is done by the state callback
-        frame_prefix = ""
-        if self.spot_wrapper is not None:
-            frame_prefix = self.spot_wrapper.frame_prefix
+        frame_prefix = self.name + "/"
         excluded_frames = [
             self.tf_name_vision_odom.value,
             self.tf_name_kinematic_odom.value,

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -252,7 +252,8 @@ class SpotROS(Node):
 
         self.declare_parameter("spot_name", "")
         self.declare_parameter("mock_enable", False)
-        self.declare_parameter("mock_has_arm", True)
+        if self.get_parameter("mock_enable").value:
+            self.declare_parameter("mock_has_arm", rclpy.Parameter.Type.BOOL)
 
         # used for setting when not using launch file
         if parameter_list is not None:
@@ -294,8 +295,10 @@ class SpotROS(Node):
         self.name: Optional[str] = self.get_parameter("spot_name").value
         if not self.name:
             self.name = None
-        self.mock: Optional[bool] = self.get_parameter("mock_enable").value
-        self.mock_has_arm: Optional[bool] = self.get_parameter("mock_has_arm").value
+        self.mock: bool = self.get_parameter("mock_enable").value
+        self.mock_has_arm: Optional[bool] = None
+        if self.mock:
+            self.mock_has_arm = self.get_parameter("mock_has_arm").value
 
         self.motion_deadzone: Parameter = self.get_parameter("deadzone")
         self.estop_timeout: Parameter = self.get_parameter("estop_timeout")
@@ -365,7 +368,8 @@ class SpotROS(Node):
         name_str = ""
         if self.name is not None:
             name_str = " for " + self.name
-        self.get_logger().info("Starting ROS driver for Spot" + name_str)
+        mocking_designator = " (mocked)" if self.mock else ""
+        self.get_logger().info("Starting ROS driver for Spot" + name_str + mocking_designator)
         # testing with Robot
 
         if self.mock:

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -192,6 +192,14 @@ class SpotImageType(str, Enum):
     RegDepth = "depth_registered"
 
 
+def set_node_parameter_from_parameter_list(
+    node: Node, parameter_list: Optional[typing.List[Parameter]], parameter_name: str
+) -> None:
+    """Set parameters when the node starts not from a launch file."""
+    if parameter_list is not None:
+        node.set_parameters([parameter for parameter in parameter_list if parameter.name == parameter_name])
+
+
 class SpotROS(Node):
     """Parent class for using the wrapper.  Defines all callbacks and keeps the wrapper alive"""
 
@@ -252,6 +260,9 @@ class SpotROS(Node):
 
         self.declare_parameter("spot_name", "")
         self.declare_parameter("mock_enable", False)
+
+        # If `mock_enable:=True`, then there are additional parameters. We must set this one separately.
+        set_node_parameter_from_parameter_list(self, parameter_list, "mock_enable")
         if self.get_parameter("mock_enable").value:
             self.declare_parameter("mock_has_arm", rclpy.Parameter.Type.BOOL)
 

--- a/spot_driver/test/test_spot_driver.py
+++ b/spot_driver/test/test_spot_driver.py
@@ -18,8 +18,14 @@ class SpotDriverTest(unittest.TestCase):
         self.fixture = contextlib.ExitStack()
         self.ros = self.fixture.enter_context(ros_scope.top(namespace="fixture"))
         # create and run spot ros2 servers
-        mock_param = rclpy.parameter.Parameter("spot_name", rclpy.Parameter.Type.STRING, "Mock_spot")
-        self.spot_ros2 = self.ros.load(spot_driver.spot_ros2.SpotROS, parameter_list=[mock_param])
+        self.spot_ros2 = self.ros.load(
+            spot_driver.spot_ros2.SpotROS,
+            parameter_list=[
+                rclpy.parameter.Parameter("spot_name", value="Mock_spot"),
+                rclpy.parameter.Parameter("mock_enable", value=True),
+                rclpy.parameter.Parameter("mock_has_arm", value=False),
+            ],
+        )
 
         # clients
         self.claim_client: rclpy.node.Client = self.ros.node.create_client(Trigger, "claim")


### PR DESCRIPTION
This PR uses node / launch arguments to specify whether the driver should operate in "mock" mode, instead of using the sentinel name `Mock_spot`. With an explicit parameter, we can have multiple mocks, with different names, and also affect whether there is an arm.


For example, with this modification you can do

```
cd spot_driver
colcon build --symlink # (`symlink` [does not apply to launch files](https://github.com/colcon/colcon-core/issues/407))
source install/setup.bash
ros2 launch spot_driver spot_driver.launch.py spot_name:=AnyNameHere mock_enable:=True mock_has_arm:=True
```

and then, for example (`spot_utilities`, specifically in `bdai` repo)

```
# source so that `spot_driver` can be found
cd spot_utilities # /workspaces/bdai/ws/src/spot_utilities
colcon build
source install/setup.bash
ros2 run spot_utilities spot_teleop.py AnyNameHere
```

