### PR TITLE
Add ROS service to take new Spot lease

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -37,8 +37,8 @@ from bosdyn.api.geometry_pb2 import Quaternion, SE2VelocityLimit
 from bosdyn.api.spot import robot_command_pb2 as spot_command_pb2
 from bosdyn.api.spot.choreography_sequence_pb2 import Animation, ChoreographySequence
 from bosdyn.client import math_helpers
-from bosdyn.client.lease import LeaseKeepAlive
 from bosdyn.client.exceptions import InternalServerError
+from bosdyn.client.lease import LeaseKeepAlive
 from bosdyn_msgs.msg import (
     ArmCommandFeedback,
     Camera,

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -975,15 +975,14 @@ class SpotROS(Node):
             return response
 
         old_lease = self.spot_wrapper.lease2
-        # take() can technically raise an exception (although the two possibilities
+        # `take()` can technically raise an exception (although the two possibilities
         # in the documentation don't seem to apply when take() is not given an argument),
         # but handling exceptions inside a ROS callback is overcomplicated,
         # so we ignore this for now.
         lease = self.spot_wrapper._lease_client.take()
         self.spot_wrapper._lease_keepalive = LeaseKeepAlive(self.spot_wrapper._lease_client)
-        # There is no evidence that take() can give the same lease as before,
-        # but because aspects of the spot sdk have been surprising and
-        # undocumented, we do this check to be extra safe.
+        # There is no clear evidence that take() could return the same lease as before,
+        # but we do this check to be extra safe.
         have_new_lease = (old_lease is None and lease is not None) or (
             str(lease.lease_proto) != str(old_lease.lease_proto)
         )

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -975,8 +975,14 @@ class SpotROS(Node):
             return response
 
         old_lease = self.spot_wrapper.lease2
+        # take() can technically raise an exception (haven't observed it, very rare),
+        # but handling exceptions inside a ROS callback is overcomplicated,
+        # so we ignore this for now.
         lease = self.spot_wrapper._lease_client.take()
         self.spot_wrapper._lease_keepalive = LeaseKeepAlive(self.spot_wrapper._lease_client)
+        # There is no evidence that take() can give the same lease as before,
+        # but because many aspects of the spot sdk have been surprising and
+        # undocumented, we do this check to be extra safe.
         response.success = True if old_lease is None else str(lease.lease_proto) != str(old_lease.lease_proto)
         response.message = str(lease.lease_proto)
         return response


### PR DESCRIPTION
To support shared autonomy with multiple clients (e.g. `bosdyn.client.RobotCommandClient`), we need a way to ask `SpotROS` to take a new lease.

The underlying SpotWrapper exposes a `getLease` interface, which either takes or acquires the lease, depending on the configuration for the driver. This PR uses the underlying interface of SpotWrapper directly to expose a ROS service that takes the lease.

For example, a teleop agent may have taken control of Spot via `lease_client.take()`, and a skill commanding spot through `SpotROS` will need to ask `SpotROS` to generate a new lease when teleop is done in order to be able to control Spot again (because`SpotROS` would be running with `use_take_lease=True` and `get_lease_on_action=False`).  