### PR TITLE
[PN-112] Update install script with new Spot C++ SDK release

### DIFF
--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -37,9 +37,9 @@ if $ARM; then
     rm /tmp/ros-humble-bosdyn-msgs_3.3.2-0jammy_arm64.deb
 
     # Install spot-cpp-sdk
-    wget -q -O /tmp/spot-cpp-sdk_3.3.0_arm64.deb https://github.com/bdaiinstitute/spot-cpp-sdk/releases/download/v3.3.0-cmake-infra/spot-cpp-sdk_3.3.0_arm64.deb
-    sudo dpkg -i /tmp/spot-cpp-sdk_3.3.0_arm64.deb
-    rm /tmp/spot-cpp-sdk_3.3.0_arm64.deb
+    wget -q -O /tmp/spot-cpp-sdk_3.3.2_arm64.deb https://github.com/bdaiinstitute/spot-cpp-sdk/releases/download/3.3.2/spot-cpp-sdk_3.3.2_arm64.deb
+    sudo dpkg -i /tmp/spot-cpp-sdk_3.3.2_arm64.deb
+    rm /tmp/spot-cpp-sdk_3.3.2_arm64.deb
 else
     # Install bosdyn_msgs - automatic conversions of BD protobufs to ROS messages
     wget -q -O /tmp/ros-humble-bosdyn-msgs_3.3.2-0jammy_amd64.deb https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/v3.3.2-AMD64/ros-humble-bosdyn-msgs_3.3.2-0jammy_amd64.deb
@@ -47,7 +47,7 @@ else
     rm /tmp/ros-humble-bosdyn-msgs_3.3.2-0jammy_amd64.deb
 
     # Install spot-cpp-sdk
-    wget -q -O /tmp/spot-cpp-sdk_3.3.0_amd64.deb https://github.com/bdaiinstitute/spot-cpp-sdk/releases/download/v3.3.0-cmake-infra/spot-cpp-sdk_3.3.0_amd64.deb
-    sudo dpkg -i /tmp/spot-cpp-sdk_3.3.0_amd64.deb
-    rm /tmp/spot-cpp-sdk_3.3.0_amd64.deb
+    wget -q -O /tmp/spot-cpp-sdk_3.3.2_amd64.deb https://github.com/bdaiinstitute/spot-cpp-sdk/releases/download/3.3.2/spot-cpp-sdk_3.3.2_amd64.deb
+    sudo dpkg -i /tmp/spot-cpp-sdk_3.3.2_amd64.deb
+    rm /tmp/spot-cpp-sdk_3.3.2_amd64.deb
 fi


### PR DESCRIPTION
This PR bumps the version number of Spot C++ SDK install to 3.3.2 in the install script