### PR TITLE
Add dependency on spot wrapper

### DIFF
--- a/spot_driver/package.xml
+++ b/spot_driver/package.xml
@@ -18,6 +18,7 @@
 
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>spot_wrapper</depend>
   <exec_depend>depth_image_proc</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
@@ -29,7 +30,7 @@
   <build_depend>spot_msgs</build_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
-  
+
   <export>
     <build_type>ament_python</build_type>
   </export>


### PR DESCRIPTION
We were missing the dependency on spot wrapper so a naive colcon build of spot driver would not build spot wrapper.