### PR TITLE
[N/A] Update docker for CI to use the 3.3.2 dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,14 +45,14 @@ RUN apt-get update -q && \
     rm -rf /var/lib/apt/lists/*
 
 # Install bosdyn_msgs package
-RUN curl -sL https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/v3.2.0-frametreesnapshot/ros-humble-bosdyn-msgs_3.2.0-0jammy_amd64.deb --output /tmp/ros-humble-bosdyn-msgs_3.2.0-0jammy_amd64.deb --silent \
-  && dpkg -i /tmp/ros-humble-bosdyn-msgs_3.2.0-0jammy_amd64.deb \
-  && rm /tmp/ros-humble-bosdyn-msgs_3.2.0-0jammy_amd64.deb
+RUN curl -sL https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/v3.3.2-AMD64/ros-humble-bosdyn-msgs_3.3.2-0jammy_amd64.deb --output /tmp/ros-humble-bosdyn-msgs_3.3.2-0jammy_amd64.deb --silent \
+  && dpkg -i /tmp/ros-humble-bosdyn-msgs_3.3.2-0jammy_amd64.deb \
+  && rm /tmp/ros-humble-bosdyn-msgs_3.3.2-0jammy_amd64.deb
 
 # Install spot_cpp_sdk package
-RUN curl -sL https://github.com/bdaiinstitute/spot-cpp-sdk/releases/download/v3.3.0-cmake-infra/spot-cpp-sdk_3.3.0_amd64.deb --output /tmp/spot-cpp-sdk_3.3.0_amd64.deb --silent \
-  && dpkg -i /tmp/spot-cpp-sdk_3.3.0_amd64.deb \
-  && rm /tmp/spot-cpp-sdk_3.3.0_amd64.deb
+RUN curl -sL https://github.com/bdaiinstitute/spot-cpp-sdk/releases/download/3.3.2/spot-cpp-sdk_3.3.2_amd64.deb --output /tmp/spot-cpp-sdk_3.3.2_amd64.deb --silent \
+  && dpkg -i /tmp/spot-cpp-sdk_3.3.2_amd64.deb \
+  && rm /tmp/spot-cpp-sdk_3.3.2_amd64.deb
 
 # Install packages inside the new environment
 RUN python -m pip install --no-cache-dir --upgrade pip==22.3.1 \

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 </p>
 
 # Overview
-This is a ROS2 package for BostonDynamics' Spot. The package contains all necessary topics, services and actions to teleoperate or navigate Spot.
-This package is derived of this [ROS1 package](https://github.com/heuristicus/spot_ros). This package currently corresponds to version 3.2.0 of the [spot-sdk](https://github.com/boston-dynamics/spot-sdk/releases/tag/v3.2.0)
+This is a ROS2 package for Boston Dynamics' Spot. The package contains all necessary topics, services and actions to teleoperate or navigate Spot.
+This package is derived of this [ROS1 package](https://github.com/heuristicus/spot_ros). This package currently corresponds to version 3.3.2 of the [spot-sdk](https://github.com/boston-dynamics/spot-sdk/releases/tag/v3.3.2)
 
 ## Prerequisites
     - Tested for Ubuntu 22.04 + Humble


### PR DESCRIPTION
Changes:
- Updated the release of spot-cpp-sdk used for CI to 3.3.2
- Updated the release of bosdyn_msgs used for CI to 3.3.2
- Updated README to say we correspond to 3.3.2