### PR TITLE
Fix typo in spot_driver package.xml

### DIFF
--- a/spot_driver/package.xml
+++ b/spot_driver/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>spot_driver</name>
   <version>0.0.0</version>
-  <description>This is a ROS2 package for Boston Dynamics' Spot./description>
+  <description>This is a ROS2 package for Boston Dynamics' Spot.</description>
   <maintainer email="maximillian.kirsch@alumni.fh-aachen.de">max</maintainer>
   <license>MIT</license>
 


### PR DESCRIPTION
This PR fixes a small typo was introduced in the prior commit.