### PR TITLE
Add protobuf to addional dependencies for mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
   -   id: mypy
       pass_filenames: false
       additional_dependencies:
+      - protobuf
       - types-protobuf
       - types-requests
       - types-simplejson


### PR DESCRIPTION
Fixing issue https://github.com/bdaiinstitute/spot_ros2/issues/237 where mypy fails on pre-commit.  Tested by running pre-commit with additional dependency and mypy now passes.

