### PR TITLE
[SW-679] Config. file is not used to get hostname, username, or password when running the driver

### DIFF
--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -130,7 +130,7 @@ def get_login_parameters(context: LaunchContext) -> Tuple[str, str, str, int]:
                         hostname = ros_params["hostname"]
             except yaml.YAMLError as exc:
                 print("Parsing config_file yaml failed with: {}".format(exc))
-    if (username is None) or (password is None) or (hostname is None):
+    if (not username) or (not password) or (not hostname):
         raise ValueError(
             "One or more of your login credentials has not been specified! Got invalid values of "
             "[Username: '{}' Password: '{}' Hostname: '{}']. Ensure that your environment variables are set or "

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -106,7 +106,7 @@ def create_point_cloud_nodelets(
 
 
 def spot_has_arm(context: LaunchContext) -> bool:
-    # Check if spot has an arm by logging in and instantiating a SpotWrapper
+    """Check if spot has an arm by logging in and instantiating a SpotWrapper"""
     config_file_path = LaunchConfiguration("config_file").perform(context)
     spot_name = LaunchConfiguration("spot_name").perform(context)
     logger = logging.getLogger("spot_driver_launch")
@@ -122,11 +122,11 @@ def spot_has_arm(context: LaunchContext) -> bool:
                 if ("/**" in config_dict) and ("ros__parameters" in config_dict["/**"]):
                     ros_params = config_dict["/**"]["ros__parameters"]
                     # only set username/password/hostname if they were not already set as environment variables.
-                    if (username is None) and ("username" in ros_params):
+                    if (not username) and ("username" in ros_params):
                         username = ros_params["username"]
-                    if (password is None) and ("password" in ros_params):
+                    if (not password) and ("password" in ros_params):
                         password = ros_params["password"]
-                    if (hostname is None) and ("hostname" in ros_params):
+                    if (not hostname) and ("hostname" in ros_params):
                         hostname = ros_params["hostname"]
             except yaml.YAMLError as exc:
                 print("Parsing config_file yaml failed with: {}".format(exc))
@@ -156,11 +156,11 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     if (config_file_path != "") and (not os.path.isfile(config_file_path)):
         raise FileNotFoundError("Configuration file '{}' does not exist!".format(config_file_path))
 
-    if not mock_enable:
-        has_arm = spot_has_arm(context)
-    else:
+    if mock_enable:
         mock_has_arm = IfCondition(LaunchConfiguration("mock_has_arm")).evaluate(context)
         has_arm = mock_has_arm
+    else:
+        has_arm = spot_has_arm(context)
 
     pkg_share = FindPackageShare("spot_description").find("spot_description")
 

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
 
 import logging
 import os

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -1,4 +1,4 @@
-# Copyright [2023] Boston Dynamics AI Institute, Inc.
+# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
 
 import logging
 import os

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -7,6 +7,7 @@ from typing import List
 
 import launch
 import launch_ros
+import yaml
 from launch import LaunchContext, LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
 from launch.conditions import IfCondition
@@ -123,12 +124,30 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
 
     if not mock_enable:
         # Get parameters from Spot.
-        # TODO this deviates from the `get_from_env_and_fall_back_to_param` logic in `spot_ros2.py`,
-        # which would pull in values in `config_file`
-        username = os.getenv("BOSDYN_CLIENT_USERNAME", "username")
-        password = os.getenv("BOSDYN_CLIENT_PASSWORD", "password")
-        hostname = os.getenv("SPOT_IP", "hostname")
-        port = int(os.getenv("SPOT_PORT", "0"))
+        username = os.getenv("BOSDYN_CLIENT_USERNAME")
+        password = os.getenv("BOSDYN_CLIENT_PASSWORD")
+        hostname = os.getenv("SPOT_IP")
+        port = int(os.getenv("SPOT_PORT", "0"))  # TODO should the user be able to specify a port via config file?
+        if os.path.isfile(config_file_path):
+            with open(config_file_path, "r") as config_yaml:
+                try:
+                    config_dict = yaml.safe_load(config_yaml)
+                    if ("/**" in config_dict) and ("ros__parameters" in config_dict["/**"]):
+                        ros_params = config_dict["/**"]["ros__parameters"]
+                        # only set username/password/hostname if they were not already set as environment variables.
+                        if (username is None) and ("username" in ros_params):
+                            username = ros_params["username"]
+                        if (password is None) and ("password" in ros_params):
+                            password = ros_params["password"]
+                        if (hostname is None) and ("hostname" in ros_params):
+                            hostname = ros_params["hostname"]
+                except yaml.YAMLError as exc:
+                    print(exc)
+        if (username is None) or (password is None) or (hostname is None):
+            raise ValueError(
+                "Login to Spot failed using [Username: {} Password: {} Hostname: {}]. Update your config_file yaml or"
+                " ensure that your environment variables are set.".format(username, password, hostname)
+            )
 
         spot_wrapper = SpotWrapper(
             username=username, password=password, hostname=hostname, port=port, robot_name=spot_name, logger=logger


### PR DESCRIPTION
## Changes Overview
This addresses [this issue](https://github.com/bdaiinstitute/spot_ros2/issues/247) of not being able to connect to Spot from `spot_driver.launch.py` without setting environment variables. Now, the spot driver can be launched with only a configuration file yaml (`config_file`) if the user chooses. 

The implementation parses the `config_file` yaml within the launchfile to determine if `username`,  `password`, and `hostname` are set there as ROS parameters. If both environment variables and `config_file` parameters are set, then the environment variables take priority (similar to the `get_from_env_and_fall_back_to_param` logic in `spot_ros2.py`).  It also assumes a yaml structure for `config_file` (if used) of the following:
```
/**:
    ros__parameters:
        username: ...
        password: ...
        hostname: xxx.xxx.xxx.xxx
        .....
```
and also assumes environment variables (if used) are set as `BOSDYN_CLIENT_USERNAME`, `BOSDYN_CLIENT_PASSWORD,` and `SPOT_IP`. 


## Testing Done
* If an environment variable (any of `BOSDYN_CLIENT_USERNAME`, `BOSDYN_CLIENT_PASSWORD,` `SPOT_IP`) is set, this will be used for the login attempt. 
* If any environment variable is not set, the `config_file` yaml will be searched to see if the appropriate login information exists there. 
* If a parameter of username/password/hostname is set both by environment variable and by `config_file`, the value from the environment variable will be used for the login attempt. 
* If any one of username, password, and hostname is not set by anything, an exception will be thrown as login will not be possible and the driver will not launch. 
* If the `config_file` yaml passed in is malformed and cannot be parsed, a YAMLError is thrown. 

Verified that login is possible with a config file on-robot too. 

## Other comments
Currently the only use for these variables in the launchfile is to instantiate SpotWrapper in order to test if the robot has an arm. This affects which nodes get launched (specifically the robot description and the camera/point cloud nodes to stream from the hand camera). I feel that this implementation results in a messy launchfile, and also means the robot is logged into twice (once in the launchfile, and then again in the main `spot_ros2` node). Parsing a configuration file by hand is the only way to get the value of these parameters in the launchfile, as the standard ROS way of getting parameters from a yaml is only available for nodes. It would be nice in the future to try to rework this to make for a more declarative launchfile, potentially using things like ActionHandlers.