### PR TITLE
[SW-681] Add PR template to spot_ros2

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,4 +4,4 @@ Please include a summary of the changes made and the relevant ticket or issue.
 
 ## Testing Done
 
-Please create a checklist of tests you plan to do and check off the ones that have been completed successfully.
+Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,7 @@
+## Change Overview
+
+Please include a summary of the changes made and the relevant ticket or issue.
+
+## Testing Done
+
+Please create a checklist of tests you plan to do and check off the ones that have been completed successfully.


### PR DESCRIPTION
## Change Overview

This adds a basic PR template to `spot_ros2` (which was used to fill out this PR!). It is based off the template on our internal repositories. 

## Testing Done

N/A
