### PR TITLE
Add tests for applying Spot clock skew to timestamps

### DIFF
--- a/spot_driver/test/CMakeLists.txt
+++ b/spot_driver/test/CMakeLists.txt
@@ -11,6 +11,16 @@ target_include_directories(rclcpp_test
 )
 target_link_libraries(rclcpp_test PUBLIC rclcpp::rclcpp)
 
+ament_add_gmock(test_clock_skew
+  src/test_clock_skew.cpp
+)
+target_include_directories(test_clock_skew
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(test_clock_skew spot_api)
+
 # test_spot_image_publisher
 
 ament_add_gmock(test_spot_image_publisher

--- a/spot_driver/test/src/test_clock_skew.cpp
+++ b/spot_driver/test/src/test_clock_skew.cpp
@@ -1,0 +1,148 @@
+// Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+
+#include <gmock/gmock.h>
+#include <google/protobuf/timestamp.pb.h>
+
+#include <spot_driver/api/time_sync_api.hpp>
+
+namespace spot_ros2 {
+TEST(TestClockSkew, ZeroSkew) {
+  // GIVEN a positive timestamp and an all-zero clock skew
+  google::protobuf::Timestamp timestamp;
+  timestamp.set_seconds(1000);
+  timestamp.set_nanos(500);
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(0);
+  clock_skew.set_nanos(0);
+
+  // WHEN we apply the clock skew to the timestamp
+  auto out = applyClockSkew(timestamp, clock_skew);
+
+  // THEN the output timestamp is identical to the input timestamp
+  EXPECT_THAT(out.sec, testing::Eq(1000));
+  EXPECT_THAT(out.nanosec, testing::Eq(500));
+}
+
+TEST(TestClockSkew, PositiveSkew) {
+  // GIVEN a postiive timestamp and a clock skew with positive seconds and nanoseconds fields
+  google::protobuf::Timestamp timestamp;
+  timestamp.set_seconds(1000);
+  timestamp.set_nanos(500);
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(100);
+  clock_skew.set_nanos(10);
+
+  // WHEN we apply the clock skew to the timestamp
+  auto out = applyClockSkew(timestamp, clock_skew);
+
+  // THEN the output timestamp is decreased by the values in the clock skew
+  EXPECT_THAT(out.sec, testing::Eq(900));
+  EXPECT_THAT(out.nanosec, testing::Eq(490));
+}
+
+TEST(TestClockSkew, NegativeSkew) {
+  // GIVEN a postiive timestamp and a clock skew with negative seconds and nanoseconds fields
+  google::protobuf::Timestamp timestamp;
+  timestamp.set_seconds(1000);
+  timestamp.set_nanos(500);
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(-100);
+  clock_skew.set_nanos(-10);
+
+  // WHEN we apply the clock skew to the timestamp
+  auto out = applyClockSkew(timestamp, clock_skew);
+
+  // THEN the output timestamp is increased by the values in the clock skew
+  EXPECT_THAT(out.sec, testing::Eq(1100));
+  EXPECT_THAT(out.nanosec, testing::Eq(510));
+}
+
+TEST(TestClockSkew, PositiveSkewNanosecsCarry) {
+  // GIVEN a positive timestamp and a clock skew where the number of seconds is zero and the number of nanoseconds in
+  // the clock skew is greater than the number of nanoseconds in the timestamp
+  google::protobuf::Timestamp timestamp;
+  timestamp.set_seconds(1000);
+  timestamp.set_nanos(100000000);
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(0);
+  clock_skew.set_nanos(200000000);
+
+  // WHEN we apply the clock skew to the timestamp
+  auto out = applyClockSkew(timestamp, clock_skew);
+
+  // THEN a second is carried over into the nanoseconds field
+  EXPECT_THAT(out.sec, testing::Eq(999));
+  EXPECT_THAT(out.nanosec, testing::Eq(900000000));
+}
+
+TEST(TestClockSkew, NegativeSkewNanosecsCarry) {
+  // GIVEN a positive timestamp and a clock skew where the number of seconds is zero and the number of nanoseconds in
+  // the clock skew is negative and of sufficient magnitude to add to greater than one full second when summed with the
+  // timetamp nanoseconds
+  google::protobuf::Timestamp timestamp;
+  timestamp.set_seconds(1000);
+  timestamp.set_nanos(900000000);
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(0);
+  clock_skew.set_nanos(-200000000);
+
+  // WHEN we apply the clock skew to the timestamp
+  auto out = applyClockSkew(timestamp, clock_skew);
+
+  // THEN a full second and the remainder of nanoseconds are added to the timestamp
+  EXPECT_THAT(out.sec, testing::Eq(1001));
+  EXPECT_THAT(out.nanosec, testing::Eq(100000000));
+}
+
+TEST(TestClockSkew, HandleNegativeInputTimestamp) {
+  // GIVEN a timestamp with a negative number of seconds and an all-zero clock skew
+  google::protobuf::Timestamp timestamp;
+  timestamp.set_seconds(-1);
+  timestamp.set_nanos(0);
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(0);
+  clock_skew.set_nanos(0);
+
+  // WHEN we apply the clock skew to the timestamp
+  auto out = applyClockSkew(timestamp, clock_skew);
+
+  // THEN an all-zero timestamp is output
+  EXPECT_THAT(out.sec, testing::Eq(0));
+  EXPECT_THAT(out.nanosec, testing::Eq(0));
+}
+
+TEST(TestClockSkew, HandleNegativeUnskewedTimestamp) {
+  // GIVEN a timestamp with a positive number of seconds and a positive clock skew with a greater number of seconds than
+  // the timestamp
+  google::protobuf::Timestamp timestamp;
+  timestamp.set_seconds(1000);
+  timestamp.set_nanos(0);
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(1001);
+  clock_skew.set_nanos(0);
+
+  // WHEN we apply the clock skew to the timestamp
+  auto out = applyClockSkew(timestamp, clock_skew);
+
+  // THEN an all-zero timestamp is output
+  EXPECT_THAT(out.sec, testing::Eq(0));
+  EXPECT_THAT(out.nanosec, testing::Eq(0));
+}
+
+TEST(TestClockSkew, HandleNegativeUnskewedTimestampFromNanoseconds) {
+  // GIVEN an all-zero timestamp and a positive clock skew with a non-zero number of nanoseconds
+  google::protobuf::Timestamp timestamp;
+  timestamp.set_seconds(0);
+  timestamp.set_nanos(0);
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(0);
+  clock_skew.set_nanos(1);
+
+  // WHEN we apply the clock skew to the timestamp
+  auto out = applyClockSkew(timestamp, clock_skew);
+
+  // THEN an all-zero timestamp is output
+  EXPECT_THAT(out.sec, testing::Eq(0));
+  EXPECT_THAT(out.nanosec, testing::Eq(0));
+}
+}  // namespace spot_ros2

--- a/spot_driver/test/src/test_clock_skew.cpp
+++ b/spot_driver/test/src/test_clock_skew.cpp
@@ -5,7 +5,7 @@
 
 #include <spot_driver/api/time_sync_api.hpp>
 
-namespace spot_ros2 {
+namespace spot_ros2::test {
 TEST(TestClockSkew, ZeroSkew) {
   // GIVEN a positive timestamp and an all-zero clock skew
   google::protobuf::Timestamp timestamp;
@@ -145,4 +145,4 @@ TEST(TestClockSkew, HandleNegativeUnskewedTimestampFromNanoseconds) {
   EXPECT_THAT(out.sec, testing::Eq(0));
   EXPECT_THAT(out.nanosec, testing::Eq(0));
 }
-}  // namespace spot_ros2
+}  // namespace spot_ros2::test


### PR DESCRIPTION
## Change Overview

Add test cases for `spot_ros2::applyClockSkew`.

## Testing Done

- [ ] Check that the new tests run in CI.
