### PR TITLE
Make TfInterfaceBase::updateStaticTransforms return void instead of tl::expected

### DIFF
--- a/spot_driver/include/spot_driver/interfaces/rclcpp_tf_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_tf_interface.hpp
@@ -26,10 +26,8 @@ class RclcppTfInterface : public TfInterfaceBase {
   /**
    * @brief Add new transforms to the StaticTransformBroadcaster.
    * @param transforms Transforms to publish as static transforms.
-   * @return Currently updating static transforms will always succeed, so this function always returns void.
    */
-  tl::expected<void, std::string> updateStaticTransforms(
-      const std::vector<geometry_msgs::msg::TransformStamped>& transforms) override;
+  void updateStaticTransforms(const std::vector<geometry_msgs::msg::TransformStamped>& transforms) override;
 
  private:
   /**

--- a/spot_driver/include/spot_driver/interfaces/tf_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/tf_interface_base.hpp
@@ -17,7 +17,6 @@ class TfInterfaceBase {
  public:
   virtual ~TfInterfaceBase() {}
 
-  virtual tl::expected<void, std::string> updateStaticTransforms(
-      const std::vector<geometry_msgs::msg::TransformStamped>& transforms) = 0;
+  virtual void updateStaticTransforms(const std::vector<geometry_msgs::msg::TransformStamped>& transforms) = 0;
 };
 }  // namespace spot_ros2

--- a/spot_driver/src/interfaces/rclcpp_tf_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_tf_interface.cpp
@@ -5,8 +5,7 @@
 namespace spot_ros2 {
 RclcppTfInterface::RclcppTfInterface(const std::shared_ptr<rclcpp::Node>& node) : static_tf_broadcaster_{node} {}
 
-tl::expected<void, std::string> RclcppTfInterface::updateStaticTransforms(
-    const std::vector<geometry_msgs::msg::TransformStamped>& transforms) {
+void RclcppTfInterface::updateStaticTransforms(const std::vector<geometry_msgs::msg::TransformStamped>& transforms) {
   bool has_new_frame = false;
   for (const auto& transform : transforms) {
     // If one of the transforms is to a new child frame, flag that a new transform needs to be published and add the
@@ -22,6 +21,5 @@ tl::expected<void, std::string> RclcppTfInterface::updateStaticTransforms(
   if (has_new_frame) {
     static_tf_broadcaster_.sendTransform(transforms);
   }
-  return {};
 }
 }  // namespace spot_ros2

--- a/spot_driver/test/include/spot_driver/mock/mock_tf_interface.hpp
+++ b/spot_driver/test/include/spot_driver/mock/mock_tf_interface.hpp
@@ -10,7 +10,7 @@
 namespace spot_ros2::test {
 class MockTfInterface : public TfInterfaceBase {
  public:
-  MOCK_METHOD((tl::expected<void, std::string>), updateStaticTransforms,
-              (const std::vector<geometry_msgs::msg::TransformStamped>& transforms), (override));
+  MOCK_METHOD(void, updateStaticTransforms, (const std::vector<geometry_msgs::msg::TransformStamped>& transforms),
+              (override));
 };
 }  // namespace spot_ros2::test


### PR DESCRIPTION
## Change Overview

In practice, the rclcpp TF broadcaster cannot fail to send TF messages, so it's unnecessary to allow our TF broadcaster wrapper class to return an error result.

## Testing Done

- [x] Builds
- [x] CI passes
