### PR TITLE
Move functions to convert between ROS and proto messages into top-level spot_ros2 namespace

### DIFF
--- a/spot_driver/include/spot_driver/conversions/common_conversions.hpp
+++ b/spot_driver/include/spot_driver/conversions/common_conversions.hpp
@@ -21,7 +21,7 @@
 #include <geometry_msgs/msg/twist.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 
-namespace spot_ros2::common_conversions {
+namespace spot_ros2 {
 
 ///////////////////////////////////////////////////////////////////////////////
 // ROS to Protobuf.
@@ -38,7 +38,7 @@ void convertToProto(const geometry_msgs::msg::Quaternion& ros_msg, bosdyn::api::
 
 void convertToProto(const geometry_msgs::msg::Pose& ros_msg, bosdyn::api::SE3Pose& proto);
 
-void convertToProto(const double ros_msg, google::protobuf::DoubleValue& proto);
+void convertToProto(const double& ros_msg, google::protobuf::DoubleValue& proto);
 
 void convertToProto(const bosdyn_msgs::msg::ArmJointPosition& ros_msg, bosdyn::api::ArmJointPosition& proto);
 
@@ -63,4 +63,4 @@ void convertToRos(const bosdyn::api::SE3Pose& proto, geometry_msgs::msg::Pose& r
 
 void convertToRos(const bosdyn::api::SE3Velocity& proto, geometry_msgs::msg::Twist& ros_msg);
 
-}  // namespace spot_ros2::common_conversions
+}  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/conversions/geometry.hpp
+++ b/spot_driver/include/spot_driver/conversions/geometry.hpp
@@ -8,7 +8,7 @@
 
 #include <string>
 
-namespace spot_ros2::conversions {
+namespace spot_ros2 {
 /**
  * @brief Convert SE3Pose messages to ROS TransformStamped messages
  *
@@ -22,4 +22,4 @@ geometry_msgs::msg::TransformStamped toTransformStamped(const ::bosdyn::api::SE3
                                                         const std::string& parent_frame, const std::string& child_frame,
                                                         const builtin_interfaces::msg::Time& tf_time);
 
-}  // namespace spot_ros2::conversions
+}  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/conversions/kinematic_conversions.hpp
+++ b/spot_driver/include/spot_driver/conversions/kinematic_conversions.hpp
@@ -7,7 +7,7 @@
 #include <bosdyn_msgs/msg/inverse_kinematics_request.hpp>
 #include <bosdyn_msgs/msg/inverse_kinematics_response.hpp>
 
-namespace spot_ros2::kinematic_conversions {
+namespace spot_ros2 {
 
 ///////////////////////////////////////////////////////////////////////////////
 // ROS to Protobuf.
@@ -57,4 +57,4 @@ void convertToRos(const bosdyn::api::KinematicState& proto, bosdyn_msgs::msg::Ki
 void convertToRos(const bosdyn::api::spot::InverseKinematicsResponse& proto,
                   bosdyn_msgs::msg::InverseKinematicsResponse& ros_msg);
 
-}  // namespace spot_ros2::kinematic_conversions
+}  // namespace spot_ros2

--- a/spot_driver/src/api/default_image_client.cpp
+++ b/spot_driver/src/api/default_image_client.cpp
@@ -174,7 +174,7 @@ tl::expected<std::vector<geometry_msgs::msg::TransformStamped>, std::string> get
     const auto parent_frame_id =
         (transform.parent_frame_name() == "arm0.link_wr1") ? "link_wr1" : transform.parent_frame_name();
 
-    const auto tform_msg = spot_ros2::conversions::toTransformStamped(
+    const auto tform_msg = spot_ros2::toTransformStamped(
         transform.parent_tform_child(), robot_name.empty() ? parent_frame_id : (robot_name + "/" + parent_frame_id),
         robot_name.empty() ? child_frame_id : (robot_name + "/" + child_frame_id),
         spot_ros2::applyClockSkew(image_response.shot().acquisition_time(), clock_skew));

--- a/spot_driver/src/conversions/common_conversions.cpp
+++ b/spot_driver/src/conversions/common_conversions.cpp
@@ -2,7 +2,7 @@
 
 #include <spot_driver/conversions/common_conversions.hpp>
 
-namespace spot_ros2::common_conversions {
+namespace spot_ros2 {
 
 ///////////////////////////////////////////////////////////////////////////////
 // ROS to Protobuf.
@@ -44,7 +44,7 @@ void convertToProto(const geometry_msgs::msg::Pose& ros_msg, bosdyn::api::SE3Pos
   convertToProto(ros_msg.orientation, *proto.mutable_rotation());
 }
 
-void convertToProto(const double ros_msg, google::protobuf::DoubleValue& proto) {
+void convertToProto(const double& ros_msg, google::protobuf::DoubleValue& proto) {
   proto.set_value(ros_msg);
 }
 
@@ -73,7 +73,7 @@ void convertToProto(const bosdyn_msgs::msg::ArmJointPosition& ros_msg, bosdyn::a
 // Protobuf to ROS.
 
 void convertToRos(const bosdyn::api::RequestHeader& proto, bosdyn_msgs::msg::RequestHeader& ros_msg) {
-  common_conversions::convertToRos(proto.request_timestamp(), ros_msg.request_timestamp);
+  convertToRos(proto.request_timestamp(), ros_msg.request_timestamp);
   ros_msg.request_timestamp_is_set = proto.has_request_timestamp();
   ros_msg.client_name = proto.client_name();
   ros_msg.disable_rpc_logging = proto.disable_rpc_logging();
@@ -87,9 +87,9 @@ void convertToRos(const bosdyn::api::CommonError& proto, bosdyn_msgs::msg::Commo
 void convertToRos(const bosdyn::api::ResponseHeader& proto, bosdyn_msgs::msg::ResponseHeader& ros_msg) {
   convertToRos(proto.request_header(), ros_msg.request_header);
   ros_msg.request_header_is_set = proto.has_request_header();
-  common_conversions::convertToRos(proto.request_received_timestamp(), ros_msg.request_received_timestamp);
+  convertToRos(proto.request_received_timestamp(), ros_msg.request_received_timestamp);
   ros_msg.request_received_timestamp_is_set = proto.has_request_received_timestamp();
-  common_conversions::convertToRos(proto.response_timestamp(), ros_msg.response_timestamp);
+  convertToRos(proto.response_timestamp(), ros_msg.response_timestamp);
   ros_msg.response_timestamp_is_set = proto.has_response_timestamp();
   convertToRos(proto.error(), ros_msg.error);
   ros_msg.error_is_set = proto.has_error();
@@ -129,4 +129,4 @@ void convertToRos(const bosdyn::api::SE3Velocity& proto, geometry_msgs::msg::Twi
   convertToRos(proto.angular(), ros_msg.angular);
 }
 
-}  // namespace spot_ros2::common_conversions
+}  // namespace spot_ros2

--- a/spot_driver/src/conversions/geometry.cpp
+++ b/spot_driver/src/conversions/geometry.cpp
@@ -9,7 +9,7 @@
 #include <spot_driver/conversions/common_conversions.hpp>
 #include <string>
 
-namespace spot_ros2::conversions {
+namespace spot_ros2 {
 geometry_msgs::msg::TransformStamped toTransformStamped(const ::bosdyn::api::SE3Pose& transform,
                                                         const std::string& parent_frame, const std::string& child_frame,
                                                         const builtin_interfaces::msg::Time& tf_time) {
@@ -18,9 +18,9 @@ geometry_msgs::msg::TransformStamped toTransformStamped(const ::bosdyn::api::SE3
   tf.header.frame_id = parent_frame;
   tf.child_frame_id = child_frame;
 
-  common_conversions::convertToRos(transform.position(), tf.transform.translation);
-  common_conversions::convertToRos(transform.rotation(), tf.transform.rotation);
+  convertToRos(transform.position(), tf.transform.translation);
+  convertToRos(transform.rotation(), tf.transform.rotation);
 
   return tf;
 }
-}  // namespace spot_ros2::conversions
+}  // namespace spot_ros2

--- a/spot_driver/src/conversions/kinematic_conversions.cpp
+++ b/spot_driver/src/conversions/kinematic_conversions.cpp
@@ -4,7 +4,7 @@
 
 #include <spot_driver/conversions/common_conversions.hpp>
 
-namespace spot_ros2::kinematic_conversions {
+namespace spot_ros2 {
 
 ///////////////////////////////////////////////////////////////////////////////
 // ROS to Protobuf.
@@ -12,23 +12,23 @@ namespace spot_ros2::kinematic_conversions {
 void convertToProto(const bosdyn_msgs::msg::InverseKinematicsRequestFixedStance& ros_msg,
                     bosdyn::api::spot::InverseKinematicsRequest::FixedStance& proto) {
   if (ros_msg.fl_rt_scene_is_set) {
-    common_conversions::convertToProto(ros_msg.fl_rt_scene, *proto.mutable_fl_rt_scene());
+    convertToProto(ros_msg.fl_rt_scene, *proto.mutable_fl_rt_scene());
   }
   if (ros_msg.fr_rt_scene_is_set) {
-    common_conversions::convertToProto(ros_msg.fr_rt_scene, *proto.mutable_fr_rt_scene());
+    convertToProto(ros_msg.fr_rt_scene, *proto.mutable_fr_rt_scene());
   }
   if (ros_msg.hl_rt_scene_is_set) {
-    common_conversions::convertToProto(ros_msg.hl_rt_scene, *proto.mutable_hl_rt_scene());
+    convertToProto(ros_msg.hl_rt_scene, *proto.mutable_hl_rt_scene());
   }
   if (ros_msg.hr_rt_scene_is_set) {
-    common_conversions::convertToProto(ros_msg.hr_rt_scene, *proto.mutable_hr_rt_scene());
+    convertToProto(ros_msg.hr_rt_scene, *proto.mutable_hr_rt_scene());
   }
 }
 
 void convertToProto(const bosdyn_msgs::msg::InverseKinematicsRequestOnGroundPlaneStance& ros_msg,
                     bosdyn::api::spot::InverseKinematicsRequest::OnGroundPlaneStance& proto) {
   if (ros_msg.scene_tform_ground_is_set) {
-    common_conversions::convertToProto(ros_msg.scene_tform_ground, *proto.mutable_scene_tform_ground());
+    convertToProto(ros_msg.scene_tform_ground, *proto.mutable_scene_tform_ground());
   }
 }
 
@@ -47,14 +47,14 @@ void convertToProto(const bosdyn_msgs::msg::InverseKinematicsRequestOneOfStanceS
 void convertToProto(const bosdyn_msgs::msg::InverseKinematicsRequestWristMountedTool& ros_msg,
                     bosdyn::api::spot::InverseKinematicsRequest::WristMountedTool& proto) {
   if (ros_msg.wrist_tform_tool_is_set) {
-    common_conversions::convertToProto(ros_msg.wrist_tform_tool, *proto.mutable_wrist_tform_tool());
+    convertToProto(ros_msg.wrist_tform_tool, *proto.mutable_wrist_tform_tool());
   }
 }
 
 void convertToProto(const bosdyn_msgs::msg::InverseKinematicsRequestBodyMountedTool& ros_msg,
                     bosdyn::api::spot::InverseKinematicsRequest::BodyMountedTool& proto) {
   if (ros_msg.body_tform_tool_is_set) {
-    common_conversions::convertToProto(ros_msg.body_tform_tool, *proto.mutable_body_tform_tool());
+    convertToProto(ros_msg.body_tform_tool, *proto.mutable_body_tform_tool());
   }
 }
 
@@ -73,17 +73,17 @@ void convertToProto(const bosdyn_msgs::msg::InverseKinematicsRequestOneOfToolSpe
 void convertToProto(const bosdyn_msgs::msg::InverseKinematicsRequestToolPoseTask& ros_msg,
                     bosdyn::api::spot::InverseKinematicsRequest::ToolPoseTask& proto) {
   if (ros_msg.task_tform_desired_tool_is_set) {
-    common_conversions::convertToProto(ros_msg.task_tform_desired_tool, *proto.mutable_task_tform_desired_tool());
+    convertToProto(ros_msg.task_tform_desired_tool, *proto.mutable_task_tform_desired_tool());
   }
 }
 
 void convertToProto(const bosdyn_msgs::msg::InverseKinematicsRequestToolGazeTask& ros_msg,
                     bosdyn::api::spot::InverseKinematicsRequest::ToolGazeTask& proto) {
   if (ros_msg.target_in_task_is_set) {
-    common_conversions::convertToProto(ros_msg.target_in_task, *proto.mutable_target_in_task());
+    convertToProto(ros_msg.target_in_task, *proto.mutable_target_in_task());
   }
   if (ros_msg.task_tform_desired_tool_is_set) {
-    common_conversions::convertToProto(ros_msg.task_tform_desired_tool, *proto.mutable_task_tform_desired_tool());
+    convertToProto(ros_msg.task_tform_desired_tool, *proto.mutable_task_tform_desired_tool());
   }
 }
 
@@ -102,14 +102,14 @@ void convertToProto(const bosdyn_msgs::msg::InverseKinematicsRequestOneOfTaskSpe
 void convertToProto(const bosdyn_msgs::msg::InverseKinematicsRequest& ros_msg,
                     bosdyn::api::spot::InverseKinematicsRequest& proto) {
   if (ros_msg.header_is_set) {
-    common_conversions::convertToProto(ros_msg.header, *proto.mutable_header());
+    convertToProto(ros_msg.header, *proto.mutable_header());
   }
   proto.set_root_frame_name(ros_msg.root_frame_name);
   if (ros_msg.root_tform_scene_is_set) {
-    common_conversions::convertToProto(ros_msg.root_tform_scene, *proto.mutable_root_tform_scene());
+    convertToProto(ros_msg.root_tform_scene, *proto.mutable_root_tform_scene());
   }
   if (ros_msg.scene_tform_task_is_set) {
-    common_conversions::convertToProto(ros_msg.scene_tform_task, *proto.mutable_scene_tform_task());
+    convertToProto(ros_msg.scene_tform_task, *proto.mutable_scene_tform_task());
   }
 
   switch (ros_msg.nominal_arm_configuration.value) {
@@ -125,11 +125,10 @@ void convertToProto(const bosdyn_msgs::msg::InverseKinematicsRequest& ros_msg,
   }
 
   if (ros_msg.nominal_arm_configuration_overrides_is_set) {
-    common_conversions::convertToProto(ros_msg.nominal_arm_configuration_overrides,
-                                       *proto.mutable_nominal_arm_configuration_overrides());
+    convertToProto(ros_msg.nominal_arm_configuration_overrides, *proto.mutable_nominal_arm_configuration_overrides());
   }
   if (ros_msg.scene_tform_body_nominal_is_set) {
-    common_conversions::convertToProto(ros_msg.scene_tform_body_nominal, *proto.mutable_scene_tform_body_nominal());
+    convertToProto(ros_msg.scene_tform_body_nominal, *proto.mutable_scene_tform_body_nominal());
   }
 
   convertToProto(ros_msg.stance_specification, proto);
@@ -155,7 +154,7 @@ void convertToRos(const bosdyn::api::JointState& proto, bosdyn_msgs::msg::JointS
 void convertToRos(const bosdyn::api::FrameTreeSnapshot::ParentEdge& proto,
                   bosdyn_msgs::msg::FrameTreeSnapshotParentEdge& ros_msg) {
   ros_msg.parent_frame_name = proto.parent_frame_name();
-  common_conversions::convertToRos(proto.parent_tform_child(), ros_msg.parent_tform_child);
+  convertToRos(proto.parent_tform_child(), ros_msg.parent_tform_child);
   ros_msg.parent_tform_child_is_set = proto.has_parent_tform_child();
 }
 
@@ -176,23 +175,23 @@ void convertToRos(const bosdyn::api::KinematicState& proto, bosdyn_msgs::msg::Ki
     convertToRos(item, joint_state);
     ros_msg.joint_states.push_back(joint_state);
   }
-  common_conversions::convertToRos(proto.acquisition_timestamp(), ros_msg.acquisition_timestamp);
+  convertToRos(proto.acquisition_timestamp(), ros_msg.acquisition_timestamp);
   ros_msg.acquisition_timestamp_is_set = proto.has_acquisition_timestamp();
   convertToRos(proto.transforms_snapshot(), ros_msg.transforms_snapshot);
   ros_msg.transforms_snapshot_is_set = proto.has_transforms_snapshot();
-  common_conversions::convertToRos(proto.velocity_of_body_in_vision(), ros_msg.velocity_of_body_in_vision);
+  convertToRos(proto.velocity_of_body_in_vision(), ros_msg.velocity_of_body_in_vision);
   ros_msg.velocity_of_body_in_vision_is_set = proto.has_velocity_of_body_in_vision();
-  common_conversions::convertToRos(proto.velocity_of_body_in_odom(), ros_msg.velocity_of_body_in_odom);
+  convertToRos(proto.velocity_of_body_in_odom(), ros_msg.velocity_of_body_in_odom);
   ros_msg.velocity_of_body_in_odom_is_set = proto.has_velocity_of_body_in_odom();
 }
 
 void convertToRos(const bosdyn::api::spot::InverseKinematicsResponse& proto,
                   bosdyn_msgs::msg::InverseKinematicsResponse& ros_msg) {
-  common_conversions::convertToRos(proto.header(), ros_msg.header);
+  convertToRos(proto.header(), ros_msg.header);
   ros_msg.header_is_set = proto.has_header();
   ros_msg.status.value = proto.status();
   convertToRos(proto.robot_configuration(), ros_msg.robot_configuration);
   ros_msg.robot_configuration_is_set = proto.has_robot_configuration();
 }
 
-}  // namespace spot_ros2::kinematic_conversions
+}  // namespace spot_ros2

--- a/spot_driver/src/conversions/robot_state.cpp
+++ b/spot_driver/src/conversions/robot_state.cpp
@@ -54,7 +54,7 @@ spot_msgs::msg::FootStateArray getFootState(const ::bosdyn::api::RobotState& rob
 
   for (const auto& foot : robot_state.foot_state()) {
     spot_msgs::msg::FootState foot_state;
-    common_conversions::convertToRos(foot.foot_position_rt_body(), foot_state.foot_position_rt_body);
+    convertToRos(foot.foot_position_rt_body(), foot_state.foot_position_rt_body);
     foot_state.contact = foot.contact();
     foot_states.states.push_back(foot_state);
   }
@@ -125,11 +125,11 @@ std::optional<tf2_msgs::msg::TFMessage> getTf(const ::bosdyn::api::RobotState& r
 
     // set target frame(preferred odom frame) as the root node in tf tree
     if (preferred_base_frame_id == frame_name) {
-      tf_msg.transforms.push_back(conversions::toTransformStamped(~(transform.parent_tform_child()), frame_name,
-                                                                  parent_frame_name, local_time));
+      tf_msg.transforms.push_back(
+          toTransformStamped(~(transform.parent_tform_child()), frame_name, parent_frame_name, local_time));
     } else {
       tf_msg.transforms.push_back(
-          conversions::toTransformStamped(transform.parent_tform_child(), parent_frame_name, frame_name, local_time));
+          toTransformStamped(transform.parent_tform_child(), parent_frame_name, frame_name, local_time));
     }
   }
   return tf_msg;
@@ -145,8 +145,7 @@ std::optional<geometry_msgs::msg::TwistWithCovarianceStamped> getOdomTwist(
   // TODO(schornakj): need to add the frame ID here?
   odom_twist_msg.header.stamp =
       spot_ros2::applyClockSkew(robot_state.kinematic_state().acquisition_timestamp(), clock_skew);
-  common_conversions::convertToRos(robot_state.kinematic_state().velocity_of_body_in_odom(),
-                                   odom_twist_msg.twist.twist);
+  convertToRos(robot_state.kinematic_state().velocity_of_body_in_odom(), odom_twist_msg.twist.twist);
   return odom_twist_msg;
 }
 
@@ -182,7 +181,7 @@ std::optional<nav_msgs::msg::Odometry> getOdom(const ::bosdyn::api::RobotState& 
     }
     odom_msg.header.frame_id = prefix + "odom";
   }
-  common_conversions::convertToRos(tf_body_pose, odom_msg.pose.pose);
+  convertToRos(tf_body_pose, odom_msg.pose.pose);
   odom_msg.child_frame_id = prefix + "body";
   return odom_msg;
 }
@@ -251,19 +250,17 @@ std::optional<bosdyn_msgs::msg::ManipulatorState> getManipulatorState(const ::bo
   manipulator_state_msg.gripper_open_percentage = manipulator_state.gripper_open_percentage();
   manipulator_state_msg.is_gripper_holding_item = manipulator_state.is_gripper_holding_item();
 
-  common_conversions::convertToRos(manipulator_state.estimated_end_effector_force_in_hand(),
-                                   manipulator_state_msg.estimated_end_effector_force_in_hand);
+  convertToRos(manipulator_state.estimated_end_effector_force_in_hand(),
+               manipulator_state_msg.estimated_end_effector_force_in_hand);
   manipulator_state_msg.estimated_end_effector_force_in_hand_is_set =
       manipulator_state.has_estimated_end_effector_force_in_hand();
 
   manipulator_state_msg.stow_state.value = manipulator_state.stow_state();
 
-  common_conversions::convertToRos(manipulator_state.velocity_of_hand_in_vision(),
-                                   manipulator_state_msg.velocity_of_hand_in_vision);
+  convertToRos(manipulator_state.velocity_of_hand_in_vision(), manipulator_state_msg.velocity_of_hand_in_vision);
   manipulator_state_msg.velocity_of_hand_in_vision_is_set = manipulator_state.has_velocity_of_hand_in_vision();
 
-  common_conversions::convertToRos(manipulator_state.velocity_of_hand_in_odom(),
-                                   manipulator_state_msg.velocity_of_hand_in_odom);
+  convertToRos(manipulator_state.velocity_of_hand_in_odom(), manipulator_state_msg.velocity_of_hand_in_odom);
   manipulator_state_msg.velocity_of_hand_in_odom_is_set = manipulator_state.has_velocity_of_hand_in_odom();
 
   manipulator_state_msg.carry_state.value = manipulator_state.carry_state();
@@ -279,8 +276,7 @@ std::optional<geometry_msgs::msg::Vector3Stamped> getEndEffectorForce(const ::bo
   geometry_msgs::msg::Vector3Stamped force;
   force.header.stamp = applyClockSkew(robot_state.kinematic_state().acquisition_timestamp(), clock_skew);
   force.header.frame_id = prefix + "hand";
-  common_conversions::convertToRos(robot_state.manipulator_state().estimated_end_effector_force_in_hand(),
-                                   force.vector);
+  convertToRos(robot_state.manipulator_state().estimated_end_effector_force_in_hand(), force.vector);
   return force;
 }
 

--- a/spot_driver/src/kinematic/kinematic_service.cpp
+++ b/spot_driver/src/kinematic/kinematic_service.cpp
@@ -29,14 +29,14 @@ void KinematicService::getSolutions(const std::shared_ptr<GetInverseKinematicSol
   auto ros_request = request->request;
 
   bosdyn::api::spot::InverseKinematicsRequest proto_request;
-  kinematic_conversions::convertToProto(ros_request, proto_request);
+  convertToProto(ros_request, proto_request);
 
   auto expected = kinematic_api_->getSolutions(proto_request);
   if (!expected) {
     logger_->logError(std::string{"Error querying the Inverse Kinematics service: "}.append(expected.error()));
     response->response.status.value = bosdyn_msgs::msg::InverseKinematicsResponseStatus::STATUS_UNKNOWN;
   } else {
-    kinematic_conversions::convertToRos(expected.value(), response->response);
+    convertToRos(expected.value(), response->response);
   }
 }
 }  // namespace spot_ros2::kinematic

--- a/spot_driver/test/src/conversions/test_common_conversions.cpp
+++ b/spot_driver/test/src/conversions/test_common_conversions.cpp
@@ -1,9 +1,19 @@
-// Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+// Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
 
+#include <gmock/gmock-matchers.h>
+#include <gmock/gmock-more-matchers.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
+#include <bosdyn_msgs/msg/arm_joint_position.hpp>
+#include <bosdyn_msgs/msg/inverse_kinematics_request.hpp>
 #include <spot_driver/conversions/common_conversions.hpp>
 
 #include <rclcpp/rclcpp.hpp>
+
+namespace {
+using ArmJointPosition = bosdyn_msgs::msg::ArmJointPosition;
+}
 
 namespace spot_ros2::test {
 
@@ -85,38 +95,136 @@ TEST(TestCommonConversions, convertBosdynMsgsRequestHeaderToProto) {
   ASSERT_EQ(rosMsg.disable_rpc_logging = true, protoMsg.disable_rpc_logging());
 }
 
-TEST(TestCommonConversions, convertBosdynMsgsArmJointPositionToProto) {
-  bosdyn_msgs::msg::ArmJointPosition rosMsg;
-  bosdyn::api::ArmJointPosition protoMsg;
+class ConvertBosdynMsgsArmJointPositionToProtoParameterized : public ::testing::TestWithParam<ArmJointPosition> {};
 
-  rosMsg.sh0_is_set = true;
-  rosMsg.sh0 = 0.1;
-  rosMsg.sh1_is_set = true;
-  rosMsg.sh1 = 0.2;
-  rosMsg.el0_is_set = true;
-  rosMsg.el0 = 0.3;
-  rosMsg.el1_is_set = true;
-  rosMsg.el1 = 0.4;
-  rosMsg.wr0_is_set = true;
-  rosMsg.wr0 = 0.5;
-  rosMsg.wr1_is_set = true;
-  rosMsg.wr1 = 0.6;
+TEST_P(ConvertBosdynMsgsArmJointPositionToProtoParameterized, CheckFieldsNotSet) {
+  ArmJointPosition ros_msg = GetParam();
+  bosdyn::api::ArmJointPosition proto_msg;
+  convertToProto(ros_msg, proto_msg);
 
-  convertToProto(rosMsg, protoMsg);
+  EXPECT_THAT(proto_msg.has_sh0(), testing::Eq(ros_msg.sh0_is_set));
+  if (ros_msg.sh0_is_set) {
+    EXPECT_THAT(proto_msg.sh0().value(), testing::DoubleEq(ros_msg.sh0));
+  }
 
-  ASSERT_EQ(rosMsg.sh0_is_set, protoMsg.has_sh0());
-  ASSERT_EQ(rosMsg.sh0, protoMsg.sh0().value());
-  ASSERT_EQ(rosMsg.sh1_is_set, protoMsg.has_sh1());
-  ASSERT_EQ(rosMsg.sh1, protoMsg.sh1().value());
-  ASSERT_EQ(rosMsg.el0_is_set, protoMsg.has_el0());
-  ASSERT_EQ(rosMsg.el0, protoMsg.el0().value());
-  ASSERT_EQ(rosMsg.el1_is_set, protoMsg.has_el1());
-  ASSERT_EQ(rosMsg.el1, protoMsg.el1().value());
-  ASSERT_EQ(rosMsg.wr0_is_set, protoMsg.has_wr0());
-  ASSERT_EQ(rosMsg.wr0, protoMsg.wr0().value());
-  ASSERT_EQ(rosMsg.wr1_is_set, protoMsg.has_wr1());
-  ASSERT_EQ(rosMsg.wr1, protoMsg.wr1().value());
+  EXPECT_THAT(proto_msg.has_sh1(), testing::Eq(ros_msg.sh1_is_set));
+  if (ros_msg.sh1_is_set) {
+    EXPECT_THAT(proto_msg.sh1().value(), testing::DoubleEq(ros_msg.sh1));
+  }
+
+  EXPECT_THAT(proto_msg.has_el0(), testing::Eq(ros_msg.el0_is_set));
+  if (ros_msg.el0_is_set) {
+    EXPECT_THAT(proto_msg.el0().value(), testing::DoubleEq(ros_msg.el0));
+  }
+
+  EXPECT_THAT(proto_msg.has_el1(), testing::Eq(ros_msg.el1_is_set));
+  if (ros_msg.el1_is_set) {
+    EXPECT_THAT(proto_msg.el1().value(), testing::DoubleEq(ros_msg.el1));
+  }
+
+  EXPECT_THAT(proto_msg.has_wr0(), testing::Eq(ros_msg.wr0_is_set));
+  if (ros_msg.wr0_is_set) {
+    EXPECT_THAT(proto_msg.wr0().value(), testing::DoubleEq(ros_msg.wr0));
+  }
+
+  EXPECT_THAT(proto_msg.has_wr1(), testing::Eq(ros_msg.wr1_is_set));
+  if (ros_msg.wr1_is_set) {
+    EXPECT_THAT(proto_msg.wr1().value(), testing::DoubleEq(ros_msg.wr1));
+  }
 }
+
+INSTANTIATE_TEST_CASE_P(ConvertBosdynMsgsArmJointPositionToProto, ConvertBosdynMsgsArmJointPositionToProtoParameterized,
+                        ::testing::Values(bosdyn_msgs::build<ArmJointPosition>()
+                                              .sh0(0.1)
+                                              .sh0_is_set(true)
+                                              .sh1(0.2)
+                                              .sh1_is_set(true)
+                                              .el0(0.3)
+                                              .el0_is_set(true)
+                                              .el1(0.4)
+                                              .el1_is_set(true)
+                                              .wr0(0.5)
+                                              .wr0_is_set(true)
+                                              .wr1(0.6)
+                                              .wr1_is_set(true),
+                                          bosdyn_msgs::build<ArmJointPosition>()
+                                              .sh0(0.0)
+                                              .sh0_is_set(false)
+                                              .sh1(0.2)
+                                              .sh1_is_set(true)
+                                              .el0(0.3)
+                                              .el0_is_set(true)
+                                              .el1(0.4)
+                                              .el1_is_set(true)
+                                              .wr0(0.5)
+                                              .wr0_is_set(true)
+                                              .wr1(0.6)
+                                              .wr1_is_set(true),
+                                          bosdyn_msgs::build<ArmJointPosition>()
+                                              .sh0(0.1)
+                                              .sh0_is_set(true)
+                                              .sh1(0.0)
+                                              .sh1_is_set(false)
+                                              .el0(0.3)
+                                              .el0_is_set(true)
+                                              .el1(0.4)
+                                              .el1_is_set(true)
+                                              .wr0(0.5)
+                                              .wr0_is_set(true)
+                                              .wr1(0.6)
+                                              .wr1_is_set(true),
+                                          bosdyn_msgs::build<ArmJointPosition>()
+                                              .sh0(0.1)
+                                              .sh0_is_set(true)
+                                              .sh1(0.2)
+                                              .sh1_is_set(true)
+                                              .el0(0.0)
+                                              .el0_is_set(false)
+                                              .el1(0.4)
+                                              .el1_is_set(true)
+                                              .wr0(0.5)
+                                              .wr0_is_set(true)
+                                              .wr1(0.6)
+                                              .wr1_is_set(true),
+                                          bosdyn_msgs::build<ArmJointPosition>()
+                                              .sh0(0.1)
+                                              .sh0_is_set(true)
+                                              .sh1(0.2)
+                                              .sh1_is_set(true)
+                                              .el0(0.3)
+                                              .el0_is_set(true)
+                                              .el1(0.0)
+                                              .el1_is_set(false)
+                                              .wr0(0.5)
+                                              .wr0_is_set(true)
+                                              .wr1(0.6)
+                                              .wr1_is_set(true),
+                                          bosdyn_msgs::build<ArmJointPosition>()
+                                              .sh0(0.1)
+                                              .sh0_is_set(true)
+                                              .sh1(0.2)
+                                              .sh1_is_set(true)
+                                              .el0(0.3)
+                                              .el0_is_set(true)
+                                              .el1(0.4)
+                                              .el1_is_set(true)
+                                              .wr0(0.0)
+                                              .wr0_is_set(false)
+                                              .wr1(0.6)
+                                              .wr1_is_set(true),
+                                          bosdyn_msgs::build<ArmJointPosition>()
+                                              .sh0(0.1)
+                                              .sh0_is_set(true)
+                                              .sh1(0.2)
+                                              .sh1_is_set(true)
+                                              .el0(0.3)
+                                              .el0_is_set(true)
+                                              .el1(0.4)
+                                              .el1_is_set(true)
+                                              .wr0(0.5)
+                                              .wr0_is_set(true)
+                                              .wr1(0.0)
+                                              .wr1_is_set(false)));
 
 ///////////////////////////////////////////////////////////////////////////////
 // Protobuf to ROS.

--- a/spot_driver/test/src/conversions/test_common_conversions.cpp
+++ b/spot_driver/test/src/conversions/test_common_conversions.cpp
@@ -98,10 +98,13 @@ TEST(TestCommonConversions, convertBosdynMsgsRequestHeaderToProto) {
 class ConvertBosdynMsgsArmJointPositionToProtoParameterized : public ::testing::TestWithParam<ArmJointPosition> {};
 
 TEST_P(ConvertBosdynMsgsArmJointPositionToProtoParameterized, CheckFieldsNotSet) {
+  // GIVEN an arm joint position message with some number of fields set or not set
   ArmJointPosition ros_msg = GetParam();
   bosdyn::api::ArmJointPosition proto_msg;
+  // WHEN converting to a protobuf message
   convertToProto(ros_msg, proto_msg);
 
+  // THEN we expect that each corresponding field is set and has the same value
   EXPECT_THAT(proto_msg.has_sh0(), testing::Eq(ros_msg.sh0_is_set));
   if (ros_msg.sh0_is_set) {
     EXPECT_THAT(proto_msg.sh0().value(), testing::DoubleEq(ros_msg.sh0));

--- a/spot_driver/test/src/conversions/test_common_conversions.cpp
+++ b/spot_driver/test/src/conversions/test_common_conversions.cpp
@@ -17,7 +17,7 @@ TEST(TestCommonConversions, convert_builtin_interfaces_time_to_proto) {
   rosMsg.sec = 2;
   rosMsg.nanosec = 200;
 
-  common_conversions::convertToProto(rosMsg, protoMsg);
+  convertToProto(rosMsg, protoMsg);
 
   ASSERT_EQ(rosMsg.sec, protoMsg.seconds());
   ASSERT_EQ(rosMsg.nanosec, protoMsg.nanos());
@@ -31,7 +31,7 @@ TEST(TestCommonConversions, convertGeometryMsgsVector3ToProto) {
   rosMsg.y = 0.2;
   rosMsg.z = 0.3;
 
-  common_conversions::convertToProto(rosMsg, protoMsg);
+  convertToProto(rosMsg, protoMsg);
 
   ASSERT_EQ(rosMsg.x, protoMsg.x());
   ASSERT_EQ(rosMsg.y, protoMsg.y());
@@ -46,7 +46,7 @@ TEST(TestCommonConversions, convertGeometryMsgsPointToProto) {
   rosMsg.y = 0.2;
   rosMsg.z = 0.3;
 
-  common_conversions::convertToProto(rosMsg, protoMsg);
+  convertToProto(rosMsg, protoMsg);
 
   ASSERT_EQ(rosMsg.x, protoMsg.x());
   ASSERT_EQ(rosMsg.y, protoMsg.y());
@@ -62,7 +62,7 @@ TEST(TestCommonConversions, convertGeometryMsgsQuaternionToProto) {
   rosMsg.y = 0.4336;
   rosMsg.z = 0.3709;
 
-  common_conversions::convertToProto(rosMsg, protoMsg);
+  convertToProto(rosMsg, protoMsg);
 
   ASSERT_EQ(rosMsg.w, protoMsg.w());
   ASSERT_EQ(rosMsg.x, protoMsg.x());
@@ -78,7 +78,7 @@ TEST(TestCommonConversions, convertBosdynMsgsRequestHeaderToProto) {
   rosMsg.client_name = "client_name";
   rosMsg.disable_rpc_logging = true;
 
-  common_conversions::convertToProto(rosMsg, protoMsg);
+  convertToProto(rosMsg, protoMsg);
 
   ASSERT_EQ(rosMsg.request_timestamp_is_set, protoMsg.has_request_timestamp());
   ASSERT_EQ(rosMsg.client_name = "client_name", protoMsg.client_name());
@@ -102,7 +102,7 @@ TEST(TestCommonConversions, convertBosdynMsgsArmJointPositionToProto) {
   rosMsg.wr1_is_set = true;
   rosMsg.wr1 = 0.6;
 
-  common_conversions::convertToProto(rosMsg, protoMsg);
+  convertToProto(rosMsg, protoMsg);
 
   ASSERT_EQ(rosMsg.sh0_is_set, protoMsg.has_sh0());
   ASSERT_EQ(rosMsg.sh0, protoMsg.sh0().value());
@@ -128,7 +128,7 @@ TEST(TestCommonConversions, convertProtoToBuiltinInterfacesTime) {
   protoMsg.set_seconds(5);
   protoMsg.set_nanos(200);
 
-  common_conversions::convertToRos(protoMsg, rosMsg);
+  convertToRos(protoMsg, rosMsg);
 
   ASSERT_EQ(protoMsg.seconds(), rosMsg.sec);
   ASSERT_EQ(protoMsg.nanos(), rosMsg.nanosec);
@@ -142,7 +142,7 @@ TEST(TestCommonConversions, convertProtoToGeometryMsgsVector3) {
   protoMsg.set_y(0.2);
   protoMsg.set_z(0.3);
 
-  common_conversions::convertToRos(protoMsg, rosMsg);
+  convertToRos(protoMsg, rosMsg);
 
   ASSERT_EQ(protoMsg.x(), rosMsg.x);
   ASSERT_EQ(protoMsg.y(), rosMsg.y);
@@ -158,7 +158,7 @@ TEST(TestCommonConversions, convertProtoToGeometryMsgsQuaternion) {
   protoMsg.set_y(0.4336);
   protoMsg.set_z(0.3709);
 
-  common_conversions::convertToRos(protoMsg, rosMsg);
+  convertToRos(protoMsg, rosMsg);
 
   ASSERT_EQ(protoMsg.w(), rosMsg.w);
   ASSERT_EQ(protoMsg.x(), rosMsg.x);

--- a/spot_driver/test/src/conversions/test_geometry.cpp
+++ b/spot_driver/test/src/conversions/test_geometry.cpp
@@ -24,7 +24,7 @@ bool areTransformsEqual(const geometry_msgs::msg::Transform& tf1, const ::bosdyn
 }
 }  // namespace
 
-namespace spot_ros2::conversions::test {
+namespace spot_ros2::test {
 TEST(GeometryConversion, toTransformStampedTest) {
   // GIVEN a bosdyn protobuf transform, the parent frame name, the child frame name, and a timestamp
   const auto transform =
@@ -43,4 +43,4 @@ TEST(GeometryConversion, toTransformStampedTest) {
   EXPECT_TRUE(areTransformsEqual(msg.transform, transform));
 }
 
-}  // namespace spot_ros2::conversions::test
+}  // namespace spot_ros2::test

--- a/spot_driver/test/src/conversions/test_kinematic_conversions.cpp
+++ b/spot_driver/test/src/conversions/test_kinematic_conversions.cpp
@@ -23,7 +23,7 @@ TEST(TestKinematicConversions, convertBosdynMsgsInverseKinematicsRequestToProto)
   rosMsg.nominal_arm_configuration_overrides_is_set = true;
   rosMsg.scene_tform_body_nominal_is_set = true;
 
-  kinematic_conversions::convertToProto(rosMsg, protoMsg);
+  convertToProto(rosMsg, protoMsg);
 
   ASSERT_EQ(rosMsg.header_is_set, protoMsg.has_header());
   ASSERT_EQ(rosMsg.root_frame_name, protoMsg.root_frame_name());
@@ -58,7 +58,7 @@ TEST(TestKinematicConversions, convertBosdynMsgsInverseKinematicsRequestFixedSta
   rosMsg.stance_specification.fixed_stance.hr_rt_scene.y = 0.2;
   rosMsg.stance_specification.fixed_stance.hr_rt_scene.z = 0.3;
 
-  kinematic_conversions::convertToProto(rosMsg.stance_specification.fixed_stance, *protoMsg.mutable_fixed_stance());
+  convertToProto(rosMsg.stance_specification.fixed_stance, *protoMsg.mutable_fixed_stance());
 
   ASSERT_EQ(rosMsg.stance_specification.fixed_stance.fl_rt_scene_is_set, protoMsg.fixed_stance().has_fl_rt_scene());
   ASSERT_EQ(rosMsg.stance_specification.fixed_stance.fl_rt_scene.x, protoMsg.fixed_stance().fl_rt_scene().x());
@@ -94,8 +94,7 @@ TEST(TestKinematicConversions, convertBosdynMsgsInverseKinematicsRequestOnGround
   rosMsg.stance_specification.on_ground_plane_stance.scene_tform_ground.orientation.y = 0.4336;
   rosMsg.stance_specification.on_ground_plane_stance.scene_tform_ground.orientation.z = 0.3709;
 
-  kinematic_conversions::convertToProto(rosMsg.stance_specification.on_ground_plane_stance,
-                                        *protoMsg.mutable_on_ground_plane_stance());
+  convertToProto(rosMsg.stance_specification.on_ground_plane_stance, *protoMsg.mutable_on_ground_plane_stance());
 
   ASSERT_EQ(rosMsg.stance_specification.on_ground_plane_stance.scene_tform_ground_is_set,
             protoMsg.on_ground_plane_stance().has_scene_tform_ground());
@@ -130,7 +129,7 @@ TEST(TestKinematicConversions, convertBosdynMsgsInverseKinematicsRequestOneOfToo
   rosMsg.wrist_mounted_tool.wrist_tform_tool.orientation.y = 0.4336;
   rosMsg.wrist_mounted_tool.wrist_tform_tool.orientation.z = 0.3709;
 
-  kinematic_conversions::convertToProto(rosMsg, protoMsg);
+  convertToProto(rosMsg, protoMsg);
   ASSERT_EQ(rosMsg.wrist_mounted_tool.wrist_tform_tool.position.x,
             protoMsg.wrist_mounted_tool().wrist_tform_tool().position().x());
   ASSERT_EQ(rosMsg.wrist_mounted_tool.wrist_tform_tool.position.y,
@@ -162,7 +161,7 @@ TEST(TestKinematicConversions, convertBosdynMsgsInverseKinematicsRequestOneOfToo
   rosMsg.body_mounted_tool.body_tform_tool.orientation.y = 0.4336;
   rosMsg.body_mounted_tool.body_tform_tool.orientation.z = 0.3709;
 
-  kinematic_conversions::convertToProto(rosMsg, protoMsg);
+  convertToProto(rosMsg, protoMsg);
   ASSERT_EQ(rosMsg.body_mounted_tool.body_tform_tool.position.x,
             protoMsg.body_mounted_tool().body_tform_tool().position().x());
   ASSERT_EQ(rosMsg.body_mounted_tool.body_tform_tool.position.y,
@@ -194,7 +193,7 @@ TEST(TestKinematicConversions, convertBosdynMsgsInverseKinematicsRequestOneOfTas
   rosMsg.tool_pose_task.task_tform_desired_tool.orientation.y = 0.4336;
   rosMsg.tool_pose_task.task_tform_desired_tool.orientation.z = 0.3709;
 
-  kinematic_conversions::convertToProto(rosMsg, protoMsg);
+  convertToProto(rosMsg, protoMsg);
   ASSERT_EQ(rosMsg.tool_pose_task.task_tform_desired_tool.position.x,
             protoMsg.tool_pose_task().task_tform_desired_tool().position().x());
   ASSERT_EQ(rosMsg.tool_pose_task.task_tform_desired_tool.position.y,
@@ -226,7 +225,7 @@ TEST(TestKinematicConversions, convertBosdynMsgsInverseKinematicsRequestOneOfTas
   rosMsg.tool_gaze_task.task_tform_desired_tool.orientation.y = 0.4336;
   rosMsg.tool_gaze_task.task_tform_desired_tool.orientation.z = 0.3709;
 
-  kinematic_conversions::convertToProto(rosMsg, protoMsg);
+  convertToProto(rosMsg, protoMsg);
   ASSERT_EQ(rosMsg.tool_gaze_task.task_tform_desired_tool.position.x,
             protoMsg.tool_gaze_task().task_tform_desired_tool().position().x());
   ASSERT_EQ(rosMsg.tool_gaze_task.task_tform_desired_tool.position.y,


### PR DESCRIPTION
## Change Overview

This changes the namespace of the `convertToRos` and `convertToProto` utility functions. Previously they were in specific namespaces depending on the type of messages they converted (e.g., `spot_ros2::kinematic_conversions::convertToRos`). A problem with this is that it requires the user to know all the namespaces in order to find a specific conversion function, which can result in developers inadvertently adding duplicate functions. After this change, they're all in the top-level `spot_ros2` namespace.

This also changes one input parameter to be passed by const reference instead of by const value. The parameter is `double` so there's no performance gain for avoiding the copy but it makes a warning in my IDE go away.

This also adds a parameterized test case for a message conversion that had lots of internal conditionals. This is mostly to get the coverage metric up a bit.

## Testing Done

It is sufficient to make sure these packages compile and CI passes. This doesn't change robot behavior.