### PR TITLE
[SW-794] hotfix for spot driver launchfile not launching

### DIFF
--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -245,7 +245,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     kinematc_node_params = {"spot_name": spot_name}
     kinematic_node = launch_ros.actions.Node(
         package="spot_driver",
-        executable="kinematic_node",
+        executable="spot_inverse_kinematics_node",
         output="screen",
         parameters=[config_file, kinematc_node_params],
         namespace=spot_name,
@@ -280,7 +280,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     spot_robot_state_publisher_params = {"spot_name": spot_name, "preferred_odom_frame": "odom"}
     spot_robot_state_publisher = launch_ros.actions.Node(
         package="spot_driver",
-        executable="spot_robot_state_publisher_node",
+        executable="state_publisher_node",
         output="screen",
         parameters=[config_file, spot_robot_state_publisher_params],
         namespace=spot_name,


### PR DESCRIPTION
## Change Overview

Current `spot_driver.launch.py` launchfile on main does not work, fails with
`executable 'kinematic_node' not found on the libexec directory`
and, when this was fixed,
`executable 'spot_robot_state_publisher_node' not found on the libexec directory`

These errors were introduced with #209 which implemented the robot state publisher in C++ and also changed the name of some nodes. This just updates to the correct node names.

## Testing Done

- [x] successfully able to launch the driver in a ROS 2 environment and control the robot, call services, etc. 
