### PR TITLE
[PN-134] Add function to convert host-relative time to robot-relative time

### DIFF
--- a/spot_driver/CMakeLists.txt
+++ b/spot_driver/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(spot_api
   src/conversions/geometry.cpp
   src/conversions/kinematic_conversions.cpp
   src/conversions/robot_state.cpp
+  src/conversions/time.cpp
   src/images/spot_image_publisher.cpp
   src/images/images_middleware_handle.cpp
   src/images/spot_image_publisher_node.cpp

--- a/spot_driver/include/spot_driver/api/default_time_sync_api.hpp
+++ b/spot_driver/include/spot_driver/api/default_time_sync_api.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+// Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
 
 #pragma once
 
@@ -17,9 +17,6 @@ namespace spot_ros2 {
 class DefaultTimeSyncApi : public TimeSyncApi {
  public:
   explicit DefaultTimeSyncApi(std::shared_ptr<::bosdyn::client::TimeSyncThread> time_sync_thread);
-
-  tl::expected<builtin_interfaces::msg::Time, std::string> convertRobotTimeToLocalTime(
-      const google::protobuf::Timestamp& robot_timestamp) override;
 
   /**
   * @brief Get the current clock skew from the Spot SDK's time sync endpoint.

--- a/spot_driver/include/spot_driver/api/time_sync_api.hpp
+++ b/spot_driver/include/spot_driver/api/time_sync_api.hpp
@@ -1,47 +1,15 @@
-// Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+// Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
 
 #pragma once
 
 #include <google/protobuf/duration.pb.h>
-#include <google/protobuf/timestamp.pb.h>
-#include <builtin_interfaces/msg/time.hpp>
+#include <string>
 #include <tl_expected/expected.hpp>
 
-#include <memory>
-#include <string>
-
 namespace spot_ros2 {
-
-inline builtin_interfaces::msg::Time applyClockSkew(const google::protobuf::Timestamp& timestamp,
-                                                    const google::protobuf::Duration& clock_skew) {
-  int64_t seconds_unskewed = timestamp.seconds() - clock_skew.seconds();
-  int32_t nanos_unskewed = timestamp.nanos() - clock_skew.nanos();
-
-  // Carry over a second if needed
-  // Note: Since ROS Time messages store the nanoseconds component as an unsigned integer, we need to do this before
-  // converting to ROS Time.
-  if (nanos_unskewed < 0) {
-    nanos_unskewed += 1e9;
-    seconds_unskewed -= 1;
-  } else if (nanos_unskewed >= 1e9) {
-    nanos_unskewed -= 1e9;
-    seconds_unskewed += 1;
-  }
-
-  // If the timestamp contains a negative time, create an all-zero ROS Time.
-  if (seconds_unskewed < 0) {
-    return builtin_interfaces::build<builtin_interfaces::msg::Time>().sec(0).nanosec(0);
-  } else {
-    return builtin_interfaces::build<builtin_interfaces::msg::Time>().sec(seconds_unskewed).nanosec(nanos_unskewed);
-  }
-}
-
 class TimeSyncApi {
  public:
   virtual ~TimeSyncApi() = default;
-
-  virtual tl::expected<builtin_interfaces::msg::Time, std::string> convertRobotTimeToLocalTime(
-      const google::protobuf::Timestamp& robot_timestamp) = 0;
 
   /**
   * @brief Get the current clock skew from the Spot SDK's time sync endpoint.

--- a/spot_driver/include/spot_driver/conversions/time.hpp
+++ b/spot_driver/include/spot_driver/conversions/time.hpp
@@ -13,7 +13,8 @@ namespace spot_ros2 {
  *
  * @param timestamp_robot Timestamp relative to Spot's clock.
  * @param clock_skew The difference as measured by Spot between the host's clock and Spot's onboard clock.
- * @return builtin_interfaces::msg::Time Timestamp relative to the host's clock.
+ * @return builtin_interfaces::msg::Time Timestamp relative to the host's clock. If applying the clock skew would result
+ * in a timestamp earlier than the epoch, return an all-zero timestamp.
  */
 builtin_interfaces::msg::Time robotTimeToLocalTime(const google::protobuf::Timestamp& timestamp_robot,
                                                    const google::protobuf::Duration& clock_skew);
@@ -24,7 +25,8 @@ builtin_interfaces::msg::Time robotTimeToLocalTime(const google::protobuf::Times
  *
  * @param timestamp_local Timestamp relative to the host's clock
  * @param clock_skew The difference as measured by Spot between the host's clock and Spot's onboard clock.
- * @return google::protobuf::Timestamp Timestamp relative to Spot's onboard clock.
+ * @return google::protobuf::Timestamp Timestamp relative to Spot's onboard clock. If applying the clock skew would
+ * result in a timestamp earlier than the epoch, return an all-zero timestamp.
  */
 google::protobuf::Timestamp localTimeToRobotTime(const builtin_interfaces::msg::Time& timestamp_local,
                                                  const google::protobuf::Duration& clock_skew);

--- a/spot_driver/include/spot_driver/conversions/time.hpp
+++ b/spot_driver/include/spot_driver/conversions/time.hpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+
+#pragma once
+
+#include <google/protobuf/duration.pb.h>
+#include <google/protobuf/timestamp.pb.h>
+#include <builtin_interfaces/msg/time.hpp>
+
+namespace spot_ros2 {
+/**
+ * @brief Convert a timestamp that was reported relative to Spot's onboard clock into a timestamp relative to the host's
+ * clock.
+ *
+ * @param timestamp_robot Timestamp relative to Spot's clock.
+ * @param clock_skew The difference as measured by Spot between the host's clock and Spot's onboard clock.
+ * @return builtin_interfaces::msg::Time Timestamp relative to the host's clock.
+ */
+builtin_interfaces::msg::Time robotTimeToLocalTime(const google::protobuf::Timestamp& timestamp_robot,
+                                                   const google::protobuf::Duration& clock_skew);
+
+/**
+ * @brief Convert a timestamp that was reported relative to the host's clock into a timestamp relative to Spot's onboard
+ * clock.
+ *
+ * @param timestamp_local Timestamp relative to the host's clock
+ * @param clock_skew The difference as measured by Spot between the host's clock and Spot's onboard clock.
+ * @return google::protobuf::Timestamp Timestamp relative to Spot's onboard clock.
+ */
+google::protobuf::Timestamp localTimeToRobotTime(const builtin_interfaces::msg::Time& timestamp_local,
+                                                 const google::protobuf::Duration& clock_skew);
+}  // namespace spot_ros2

--- a/spot_driver/src/api/default_time_sync_api.cpp
+++ b/spot_driver/src/api/default_time_sync_api.cpp
@@ -1,3 +1,4 @@
+// Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
 
 #include <spot_driver/api/default_time_sync_api.hpp>
 
@@ -5,16 +6,6 @@ namespace spot_ros2 {
 
 DefaultTimeSyncApi::DefaultTimeSyncApi(std::shared_ptr<::bosdyn::client::TimeSyncThread> time_sync_thread)
     : time_sync_thread_{time_sync_thread} {}
-
-tl::expected<builtin_interfaces::msg::Time, std::string> DefaultTimeSyncApi::convertRobotTimeToLocalTime(
-    const google::protobuf::Timestamp& robot_timestamp) {
-  const auto get_clock_skew_result = getClockSkew();
-  if (!get_clock_skew_result) {
-    return tl::make_unexpected("Failed to get clock skew: " + get_clock_skew_result.error());
-  }
-
-  return applyClockSkew(robot_timestamp, get_clock_skew_result.value());
-}
 
 tl::expected<google::protobuf::Duration, std::string> DefaultTimeSyncApi::getClockSkew() {
   if (!time_sync_thread_) {

--- a/spot_driver/src/conversions/time.cpp
+++ b/spot_driver/src/conversions/time.cpp
@@ -45,13 +45,16 @@ google::protobuf::Timestamp localTimeToRobotTime(const builtin_interfaces::msg::
   int32_t nanos_robot = static_cast<int32_t>(timestamp_local.nanosec) + clock_skew.nanos();
 
   // Carry over a second if needed
-  // Note: protobuf timestamps can have a negative seconds component, which would represent a timestamp prior to the
-  // epoch.
   normalize(seconds_robot, nanos_robot);
 
-  google::protobuf::Timestamp out;
-  out.set_seconds(seconds_robot);
-  out.set_nanos(nanos_robot);
-  return out;
+  // If the timestamp contains a negative time, return an all-zero timestamp
+  if (seconds_robot < 0) {
+    return google::protobuf::Timestamp{};
+  }
+
+  google::protobuf::Timestamp timestamp_robot;
+  timestamp_robot.set_seconds(seconds_robot);
+  timestamp_robot.set_nanos(nanos_robot);
+  return timestamp_robot;
 }
 }  // namespace spot_ros2

--- a/spot_driver/src/conversions/time.cpp
+++ b/spot_driver/src/conversions/time.cpp
@@ -32,11 +32,10 @@ builtin_interfaces::msg::Time robotTimeToLocalTime(const google::protobuf::Times
   // If the timestamp contains a negative time, create an all-zero ROS Time.
   if (seconds_local < 0) {
     return builtin_interfaces::build<builtin_interfaces::msg::Time>().sec(0).nanosec(0);
-  } else {
-    return builtin_interfaces::build<builtin_interfaces::msg::Time>()
-        .sec(static_cast<int>(seconds_local))
-        .nanosec(nanos_local);
   }
+  return builtin_interfaces::build<builtin_interfaces::msg::Time>()
+      .sec(static_cast<int>(seconds_local))
+      .nanosec(nanos_local);
 }
 
 google::protobuf::Timestamp localTimeToRobotTime(const builtin_interfaces::msg::Time& timestamp_local,

--- a/spot_driver/src/conversions/time.cpp
+++ b/spot_driver/src/conversions/time.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+
+#include <spot_driver/conversions/time.hpp>
+
+namespace {
+/**
+ * @brief Modify seconds and nanoseconds in-place to enforce that the nanoseconds must contain a value between 0 and
+ * 999,999,999 by adding or removing whole seconds.
+ */
+void normalize(int64_t& seconds, int32_t& nanos) {
+  if (nanos < 0) {
+    nanos += 1e9;
+    seconds -= 1;
+  } else if (nanos >= 1e9) {
+    nanos -= 1e9;
+    seconds += 1;
+  }
+}
+}  // namespace
+
+namespace spot_ros2 {
+builtin_interfaces::msg::Time robotTimeToLocalTime(const google::protobuf::Timestamp& timestamp_robot,
+                                                   const google::protobuf::Duration& clock_skew) {
+  int64_t seconds_local = timestamp_robot.seconds() - clock_skew.seconds();
+  int32_t nanos_local = timestamp_robot.nanos() - clock_skew.nanos();
+
+  // Carry over a second if needed
+  // Note: Since ROS Time messages store the nanoseconds component as an unsigned integer, we need to do this before
+  // converting to ROS Time.
+  normalize(seconds_local, nanos_local);
+
+  // If the timestamp contains a negative time, create an all-zero ROS Time.
+  if (seconds_local < 0) {
+    return builtin_interfaces::build<builtin_interfaces::msg::Time>().sec(0).nanosec(0);
+  } else {
+    return builtin_interfaces::build<builtin_interfaces::msg::Time>()
+        .sec(static_cast<int>(seconds_local))
+        .nanosec(nanos_local);
+  }
+}
+
+google::protobuf::Timestamp localTimeToRobotTime(const builtin_interfaces::msg::Time& timestamp_local,
+                                                 const google::protobuf::Duration& clock_skew) {
+  int64_t seconds_robot = static_cast<int64_t>(timestamp_local.sec) + clock_skew.seconds();
+  int32_t nanos_robot = static_cast<int32_t>(timestamp_local.nanosec) + clock_skew.nanos();
+
+  // Carry over a second if needed
+  // Note: protobuf timestamps can have a negative seconds component, which would represent a timestamp prior to the
+  // epoch.
+  normalize(seconds_robot, nanos_robot);
+
+  google::protobuf::Timestamp out;
+  out.set_seconds(seconds_robot);
+  out.set_nanos(nanos_robot);
+  return out;
+}
+}  // namespace spot_ros2

--- a/spot_driver/src/conversions/time.cpp
+++ b/spot_driver/src/conversions/time.cpp
@@ -2,6 +2,10 @@
 
 #include <spot_driver/conversions/time.hpp>
 
+#include <google/protobuf/duration.pb.h>
+#include <google/protobuf/timestamp.pb.h>
+#include <builtin_interfaces/msg/time.hpp>
+
 namespace {
 /**
  * @brief Modify seconds and nanoseconds in-place to enforce that the nanoseconds must contain a value between 0 and

--- a/spot_driver/test/include/spot_driver/matchers.hpp
+++ b/spot_driver/test/include/spot_driver/matchers.hpp
@@ -15,6 +15,7 @@
 #include <geometry_msgs/msg/twist.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <spot_driver/api/time_sync_api.hpp>
+#include <spot_driver/conversions/time.hpp>
 #include <spot_driver/serialization.hpp>
 #include <spot_msgs/msg/battery_state.hpp>
 #include <spot_msgs/msg/battery_state_array.hpp>
@@ -28,12 +29,12 @@
 namespace spot_ros2::test {
 /**
  * @brief This verifies that the difference between the input timestamp and the original timestamp matches the output of
- * the applyClockSkew function.
- * @details Don't use this to test applyClockSkew itself, since that would be rather tautological.
+ * the robotTimeToLocalTime function.
+ * @details Don't use this to test robotTimeToLocalTime itself, since that would be rather tautological.
  */
 MATCHER_P2(ClockSkewIsAppliedToHeader, original_stamp, clock_skew, "") {
-  return testing::ExplainMatchResult(testing::Eq(spot_ros2::applyClockSkew(original_stamp, clock_skew)), arg.stamp,
-                                     result_listener);
+  return testing::ExplainMatchResult(testing::Eq(spot_ros2::robotTimeToLocalTime(original_stamp, clock_skew)),
+                                     arg.stamp, result_listener);
 }
 
 MATCHER_P3(GeometryMsgsVector3Eq, x, y, z, "") {

--- a/spot_driver/test/include/spot_driver/mock/mock_time_sync_api.hpp
+++ b/spot_driver/test/include/spot_driver/mock/mock_time_sync_api.hpp
@@ -12,8 +12,6 @@
 namespace spot_ros2::test {
 class MockTimeSyncApi : public TimeSyncApi {
  public:
-  MOCK_METHOD((tl::expected<builtin_interfaces::msg::Time, std::string>), convertRobotTimeToLocalTime,
-              (const google::protobuf::Timestamp& robot_timestamp), (override));
   MOCK_METHOD((tl::expected<google::protobuf::Duration, std::string>), getClockSkew, (), (override));
 };
 }  // namespace spot_ros2::test

--- a/spot_driver/test/src/test_clock_skew.cpp
+++ b/spot_driver/test/src/test_clock_skew.cpp
@@ -28,7 +28,7 @@ TEST(TestClockSkewRobotToLocal, ZeroSkew) {
 }
 
 TEST(TestClockSkewRobotToLocal, PositiveSkew) {
-  // GIVEN a postiive timestamp and a clock skew with positive seconds and nanoseconds fields
+  // GIVEN a positive timestamp and a clock skew with positive seconds and nanoseconds fields
   google::protobuf::Timestamp timestamp;
   timestamp.set_seconds(1000);
   timestamp.set_nanos(500);
@@ -45,7 +45,7 @@ TEST(TestClockSkewRobotToLocal, PositiveSkew) {
 }
 
 TEST(TestClockSkewRobotToLocal, NegativeSkew) {
-  // GIVEN a postiive timestamp and a clock skew with negative seconds and nanoseconds fields
+  // GIVEN a positive timestamp and a clock skew with negative seconds and nanoseconds fields
   google::protobuf::Timestamp timestamp;
   timestamp.set_seconds(1000);
   timestamp.set_nanos(500);
@@ -166,7 +166,7 @@ TEST(TestClockSkewLocalToRobot, ZeroSkew) {
 }
 
 TEST(TestClockSkewLocalToRobot, PositiveSkew) {
-  // GIVEN a postiive timestamp and a clock skew with positive seconds and nanoseconds fields
+  // GIVEN a positive timestamp and a clock skew with positive seconds and nanoseconds fields
   const auto timestamp = builtin_interfaces::build<Time>().sec(1000).nanosec(500);
   google::protobuf::Duration clock_skew;
   clock_skew.set_seconds(100);
@@ -181,7 +181,7 @@ TEST(TestClockSkewLocalToRobot, PositiveSkew) {
 }
 
 TEST(TestClockSkewLocalToRobot, NegativeSkew) {
-  // GIVEN a postiive timestamp and a clock skew with negative seconds and nanoseconds fields
+  // GIVEN a positive timestamp and a clock skew with negative seconds and nanoseconds fields
   const auto timestamp = builtin_interfaces::build<Time>().sec(1000).nanosec(500);
   google::protobuf::Duration clock_skew;
   clock_skew.set_seconds(-100);
@@ -197,7 +197,7 @@ TEST(TestClockSkewLocalToRobot, NegativeSkew) {
 
 TEST(TestClockSkewLocalToRobot, PositiveSkewNanosecsCarry) {
   // GIVEN a positive timestamp and a clock skew where the number of seconds is zero and the number of nanoseconds in
-  // the clock skew is greater than the number of nanoseconds in the timestamp
+  // the clock skew is of sufficient magnitude to carry over a full second from the nanoseconds
   const auto timestamp = builtin_interfaces::build<Time>().sec(1000).nanosec(900'000'000);
   google::protobuf::Duration clock_skew;
   clock_skew.set_seconds(0);
@@ -213,8 +213,7 @@ TEST(TestClockSkewLocalToRobot, PositiveSkewNanosecsCarry) {
 
 TEST(TestClockSkewLocalToRobot, NegativeSkewNanosecsCarry) {
   // GIVEN a positive timestamp and a clock skew where the number of seconds is zero and the number of nanoseconds in
-  // the clock skew is negative and of sufficient magnitude to add to greater than one full second when summed with the
-  // timetamp nanoseconds
+  // the clock skew is negative and of sufficient magnitude to require carrying over a second into nanoseconds
   const auto timestamp = builtin_interfaces::build<Time>().sec(1000).nanosec(100'000'000);
   google::protobuf::Duration clock_skew;
   clock_skew.set_seconds(0);
@@ -231,9 +230,9 @@ TEST(TestClockSkewLocalToRobot, NegativeSkewNanosecsCarry) {
 TEST(TestClockSkewLocalToRobot, HandleNegativeUnskewedTimestamp) {
   // GIVEN a timestamp with a positive number of seconds and a positive clock skew with a greater number of seconds than
   // the timestamp
-  const auto timestamp = builtin_interfaces::build<Time>().sec(0).nanosec(0);
+  const auto timestamp = builtin_interfaces::build<Time>().sec(1000).nanosec(0);
   google::protobuf::Duration clock_skew;
-  clock_skew.set_seconds(-1);
+  clock_skew.set_seconds(-1001);
   clock_skew.set_nanos(0);
 
   // WHEN we apply the clock skew to the timestamp

--- a/spot_driver/test/src/test_clock_skew.cpp
+++ b/spot_driver/test/src/test_clock_skew.cpp
@@ -66,17 +66,17 @@ TEST(TestClockSkewRobotToLocal, PositiveSkewNanosecsCarry) {
   // the clock skew is greater than the number of nanoseconds in the timestamp
   google::protobuf::Timestamp timestamp;
   timestamp.set_seconds(1000);
-  timestamp.set_nanos(100000000);
+  timestamp.set_nanos(100'000'000);
   google::protobuf::Duration clock_skew;
   clock_skew.set_seconds(0);
-  clock_skew.set_nanos(200000000);
+  clock_skew.set_nanos(200'000'000);
 
   // WHEN we apply the clock skew to the timestamp
   const auto out = robotTimeToLocalTime(timestamp, clock_skew);
 
   // THEN a second is carried over into the nanoseconds field
   EXPECT_THAT(out.sec, testing::Eq(999));
-  EXPECT_THAT(out.nanosec, testing::Eq(900000000));
+  EXPECT_THAT(out.nanosec, testing::Eq(900'000'000));
 }
 
 TEST(TestClockSkewRobotToLocal, NegativeSkewNanosecsCarry) {
@@ -85,17 +85,17 @@ TEST(TestClockSkewRobotToLocal, NegativeSkewNanosecsCarry) {
   // timetamp nanoseconds
   google::protobuf::Timestamp timestamp;
   timestamp.set_seconds(1000);
-  timestamp.set_nanos(900000000);
+  timestamp.set_nanos(900'000'000);
   google::protobuf::Duration clock_skew;
   clock_skew.set_seconds(0);
-  clock_skew.set_nanos(-200000000);
+  clock_skew.set_nanos(-200'000'000);
 
   // WHEN we apply the clock skew to the timestamp
   const auto out = robotTimeToLocalTime(timestamp, clock_skew);
 
   // THEN a full second and the remainder of nanoseconds are added to the timestamp
   EXPECT_THAT(out.sec, testing::Eq(1001));
-  EXPECT_THAT(out.nanosec, testing::Eq(100000000));
+  EXPECT_THAT(out.nanosec, testing::Eq(100'000'000));
 }
 
 TEST(TestClockSkewRobotToLocal, HandleNegativeInputTimestamp) {
@@ -198,10 +198,10 @@ TEST(TestClockSkewLocalToRobot, NegativeSkew) {
 TEST(TestClockSkewLocalToRobot, PositiveSkewNanosecsCarry) {
   // GIVEN a positive timestamp and a clock skew where the number of seconds is zero and the number of nanoseconds in
   // the clock skew is greater than the number of nanoseconds in the timestamp
-  const auto timestamp = builtin_interfaces::build<Time>().sec(1000).nanosec(900000000);
+  const auto timestamp = builtin_interfaces::build<Time>().sec(1000).nanosec(900'000'000);
   google::protobuf::Duration clock_skew;
   clock_skew.set_seconds(0);
-  clock_skew.set_nanos(200000000);
+  clock_skew.set_nanos(200'000'000);
 
   // WHEN we apply the clock skew to the timestamp
   const auto out = localTimeToRobotTime(timestamp, clock_skew);
@@ -215,17 +215,17 @@ TEST(TestClockSkewLocalToRobot, NegativeSkewNanosecsCarry) {
   // GIVEN a positive timestamp and a clock skew where the number of seconds is zero and the number of nanoseconds in
   // the clock skew is negative and of sufficient magnitude to add to greater than one full second when summed with the
   // timetamp nanoseconds
-  const auto timestamp = builtin_interfaces::build<Time>().sec(1000).nanosec(100000000);
+  const auto timestamp = builtin_interfaces::build<Time>().sec(1000).nanosec(100'000'000);
   google::protobuf::Duration clock_skew;
   clock_skew.set_seconds(0);
-  clock_skew.set_nanos(-200000000);
+  clock_skew.set_nanos(-200'000'000);
 
   // WHEN we apply the clock skew to the timestamp
   const auto out = localTimeToRobotTime(timestamp, clock_skew);
 
   // THEN a second is carried over from the nanoseconds field
   EXPECT_THAT(out.seconds(), testing::Eq(999));
-  EXPECT_THAT(out.nanos(), testing::Eq(90000000));
+  EXPECT_THAT(out.nanos(), testing::Eq(900'000'000));
 }
 
 TEST(TestClockSkewLocalToRobot, HandleNegativeUnskewedTimestamp) {
@@ -237,10 +237,10 @@ TEST(TestClockSkewLocalToRobot, HandleNegativeUnskewedTimestamp) {
   clock_skew.set_nanos(0);
 
   // WHEN we apply the clock skew to the timestamp
-  auto out = localTimeToRobotTime(timestamp, clock_skew);
+  const auto out = localTimeToRobotTime(timestamp, clock_skew);
 
   // THEN an all-zero timestamp is output
-  EXPECT_THAT(out.seconds(), testing::Eq(-1));
+  EXPECT_THAT(out.seconds(), testing::Eq(0));
   EXPECT_THAT(out.nanos(), testing::Eq(0));
 }
 
@@ -252,11 +252,11 @@ TEST(TestClockSkewLocalToRobot, HandleNegativeUnskewedTimestampFromNanoseconds) 
   clock_skew.set_nanos(-1);
 
   // WHEN we apply the clock skew to the timestamp
-  auto out = localTimeToRobotTime(timestamp, clock_skew);
+  const auto out = localTimeToRobotTime(timestamp, clock_skew);
 
   // THEN an all-zero timestamp is output
   EXPECT_THAT(out.seconds(), testing::Eq(0));
-  EXPECT_THAT(out.nanos(), testing::Eq(-1));
+  EXPECT_THAT(out.nanos(), testing::Eq(0));
 }
 
 }  // namespace spot_ros2::test

--- a/spot_driver/test/src/test_clock_skew.cpp
+++ b/spot_driver/test/src/test_clock_skew.cpp
@@ -2,11 +2,15 @@
 
 #include <gmock/gmock.h>
 #include <google/protobuf/timestamp.pb.h>
+#include <builtin_interfaces/msg/time.hpp>
+#include <spot_driver/conversions/time.hpp>
 
-#include <spot_driver/api/time_sync_api.hpp>
+namespace {
+using Time = builtin_interfaces::msg::Time;
+}
 
 namespace spot_ros2::test {
-TEST(TestClockSkew, ZeroSkew) {
+TEST(TestClockSkewRobotToLocal, ZeroSkew) {
   // GIVEN a positive timestamp and an all-zero clock skew
   google::protobuf::Timestamp timestamp;
   timestamp.set_seconds(1000);
@@ -16,14 +20,14 @@ TEST(TestClockSkew, ZeroSkew) {
   clock_skew.set_nanos(0);
 
   // WHEN we apply the clock skew to the timestamp
-  auto out = applyClockSkew(timestamp, clock_skew);
+  const auto out = robotTimeToLocalTime(timestamp, clock_skew);
 
   // THEN the output timestamp is identical to the input timestamp
   EXPECT_THAT(out.sec, testing::Eq(1000));
   EXPECT_THAT(out.nanosec, testing::Eq(500));
 }
 
-TEST(TestClockSkew, PositiveSkew) {
+TEST(TestClockSkewRobotToLocal, PositiveSkew) {
   // GIVEN a postiive timestamp and a clock skew with positive seconds and nanoseconds fields
   google::protobuf::Timestamp timestamp;
   timestamp.set_seconds(1000);
@@ -33,14 +37,14 @@ TEST(TestClockSkew, PositiveSkew) {
   clock_skew.set_nanos(10);
 
   // WHEN we apply the clock skew to the timestamp
-  auto out = applyClockSkew(timestamp, clock_skew);
+  const auto out = robotTimeToLocalTime(timestamp, clock_skew);
 
   // THEN the output timestamp is decreased by the values in the clock skew
   EXPECT_THAT(out.sec, testing::Eq(900));
   EXPECT_THAT(out.nanosec, testing::Eq(490));
 }
 
-TEST(TestClockSkew, NegativeSkew) {
+TEST(TestClockSkewRobotToLocal, NegativeSkew) {
   // GIVEN a postiive timestamp and a clock skew with negative seconds and nanoseconds fields
   google::protobuf::Timestamp timestamp;
   timestamp.set_seconds(1000);
@@ -50,14 +54,14 @@ TEST(TestClockSkew, NegativeSkew) {
   clock_skew.set_nanos(-10);
 
   // WHEN we apply the clock skew to the timestamp
-  auto out = applyClockSkew(timestamp, clock_skew);
+  const auto out = robotTimeToLocalTime(timestamp, clock_skew);
 
   // THEN the output timestamp is increased by the values in the clock skew
   EXPECT_THAT(out.sec, testing::Eq(1100));
   EXPECT_THAT(out.nanosec, testing::Eq(510));
 }
 
-TEST(TestClockSkew, PositiveSkewNanosecsCarry) {
+TEST(TestClockSkewRobotToLocal, PositiveSkewNanosecsCarry) {
   // GIVEN a positive timestamp and a clock skew where the number of seconds is zero and the number of nanoseconds in
   // the clock skew is greater than the number of nanoseconds in the timestamp
   google::protobuf::Timestamp timestamp;
@@ -68,14 +72,14 @@ TEST(TestClockSkew, PositiveSkewNanosecsCarry) {
   clock_skew.set_nanos(200000000);
 
   // WHEN we apply the clock skew to the timestamp
-  auto out = applyClockSkew(timestamp, clock_skew);
+  const auto out = robotTimeToLocalTime(timestamp, clock_skew);
 
   // THEN a second is carried over into the nanoseconds field
   EXPECT_THAT(out.sec, testing::Eq(999));
   EXPECT_THAT(out.nanosec, testing::Eq(900000000));
 }
 
-TEST(TestClockSkew, NegativeSkewNanosecsCarry) {
+TEST(TestClockSkewRobotToLocal, NegativeSkewNanosecsCarry) {
   // GIVEN a positive timestamp and a clock skew where the number of seconds is zero and the number of nanoseconds in
   // the clock skew is negative and of sufficient magnitude to add to greater than one full second when summed with the
   // timetamp nanoseconds
@@ -87,14 +91,14 @@ TEST(TestClockSkew, NegativeSkewNanosecsCarry) {
   clock_skew.set_nanos(-200000000);
 
   // WHEN we apply the clock skew to the timestamp
-  auto out = applyClockSkew(timestamp, clock_skew);
+  const auto out = robotTimeToLocalTime(timestamp, clock_skew);
 
   // THEN a full second and the remainder of nanoseconds are added to the timestamp
   EXPECT_THAT(out.sec, testing::Eq(1001));
   EXPECT_THAT(out.nanosec, testing::Eq(100000000));
 }
 
-TEST(TestClockSkew, HandleNegativeInputTimestamp) {
+TEST(TestClockSkewRobotToLocal, HandleNegativeInputTimestamp) {
   // GIVEN a timestamp with a negative number of seconds and an all-zero clock skew
   google::protobuf::Timestamp timestamp;
   timestamp.set_seconds(-1);
@@ -104,14 +108,14 @@ TEST(TestClockSkew, HandleNegativeInputTimestamp) {
   clock_skew.set_nanos(0);
 
   // WHEN we apply the clock skew to the timestamp
-  auto out = applyClockSkew(timestamp, clock_skew);
+  const auto out = robotTimeToLocalTime(timestamp, clock_skew);
 
   // THEN an all-zero timestamp is output
   EXPECT_THAT(out.sec, testing::Eq(0));
   EXPECT_THAT(out.nanosec, testing::Eq(0));
 }
 
-TEST(TestClockSkew, HandleNegativeUnskewedTimestamp) {
+TEST(TestClockSkewRobotToLocal, HandleNegativeUnskewedTimestamp) {
   // GIVEN a timestamp with a positive number of seconds and a positive clock skew with a greater number of seconds than
   // the timestamp
   google::protobuf::Timestamp timestamp;
@@ -122,14 +126,14 @@ TEST(TestClockSkew, HandleNegativeUnskewedTimestamp) {
   clock_skew.set_nanos(0);
 
   // WHEN we apply the clock skew to the timestamp
-  auto out = applyClockSkew(timestamp, clock_skew);
+  const auto out = robotTimeToLocalTime(timestamp, clock_skew);
 
   // THEN an all-zero timestamp is output
   EXPECT_THAT(out.sec, testing::Eq(0));
   EXPECT_THAT(out.nanosec, testing::Eq(0));
 }
 
-TEST(TestClockSkew, HandleNegativeUnskewedTimestampFromNanoseconds) {
+TEST(TestClockSkewRobotToLocal, HandleNegativeUnskewedTimestampFromNanoseconds) {
   // GIVEN an all-zero timestamp and a positive clock skew with a non-zero number of nanoseconds
   google::protobuf::Timestamp timestamp;
   timestamp.set_seconds(0);
@@ -139,10 +143,120 @@ TEST(TestClockSkew, HandleNegativeUnskewedTimestampFromNanoseconds) {
   clock_skew.set_nanos(1);
 
   // WHEN we apply the clock skew to the timestamp
-  auto out = applyClockSkew(timestamp, clock_skew);
+  const auto out = robotTimeToLocalTime(timestamp, clock_skew);
 
   // THEN an all-zero timestamp is output
   EXPECT_THAT(out.sec, testing::Eq(0));
   EXPECT_THAT(out.nanosec, testing::Eq(0));
 }
+
+TEST(TestClockSkewLocalToRobot, ZeroSkew) {
+  // GIVEN a positive timestamp and an all-zero clock skew
+  const auto timestamp = builtin_interfaces::build<Time>().sec(1000).nanosec(500);
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(0);
+  clock_skew.set_nanos(0);
+
+  // WHEN we apply the clock skew to the timestamp
+  const auto out = localTimeToRobotTime(timestamp, clock_skew);
+
+  // THEN the output timestamp is identical to the input timestamp
+  EXPECT_THAT(out.seconds(), testing::Eq(1000));
+  EXPECT_THAT(out.nanos(), testing::Eq(500));
+}
+
+TEST(TestClockSkewLocalToRobot, PositiveSkew) {
+  // GIVEN a postiive timestamp and a clock skew with positive seconds and nanoseconds fields
+  const auto timestamp = builtin_interfaces::build<Time>().sec(1000).nanosec(500);
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(100);
+  clock_skew.set_nanos(10);
+
+  // WHEN we apply the clock skew to the timestamp
+  const auto out = localTimeToRobotTime(timestamp, clock_skew);
+
+  // THEN the output timestamp is increased by the values in the clock skew
+  EXPECT_THAT(out.seconds(), testing::Eq(1100));
+  EXPECT_THAT(out.nanos(), testing::Eq(510));
+}
+
+TEST(TestClockSkewLocalToRobot, NegativeSkew) {
+  // GIVEN a postiive timestamp and a clock skew with negative seconds and nanoseconds fields
+  const auto timestamp = builtin_interfaces::build<Time>().sec(1000).nanosec(500);
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(-100);
+  clock_skew.set_nanos(-10);
+
+  // WHEN we apply the clock skew to the timestamp
+  const auto out = localTimeToRobotTime(timestamp, clock_skew);
+
+  // THEN the output timestamp is decreased by the values in the clock skew
+  EXPECT_THAT(out.seconds(), testing::Eq(900));
+  EXPECT_THAT(out.nanos(), testing::Eq(490));
+}
+
+TEST(TestClockSkewLocalToRobot, PositiveSkewNanosecsCarry) {
+  // GIVEN a positive timestamp and a clock skew where the number of seconds is zero and the number of nanoseconds in
+  // the clock skew is greater than the number of nanoseconds in the timestamp
+  const auto timestamp = builtin_interfaces::build<Time>().sec(1000).nanosec(900000000);
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(0);
+  clock_skew.set_nanos(200000000);
+
+  // WHEN we apply the clock skew to the timestamp
+  const auto out = localTimeToRobotTime(timestamp, clock_skew);
+
+  // THEN a second is carried over from the nanoseconds field
+  EXPECT_THAT(out.seconds(), testing::Eq(1001));
+  EXPECT_THAT(out.nanos(), testing::Eq(100000000));
+}
+
+TEST(TestClockSkewLocalToRobot, NegativeSkewNanosecsCarry) {
+  // GIVEN a positive timestamp and a clock skew where the number of seconds is zero and the number of nanoseconds in
+  // the clock skew is negative and of sufficient magnitude to add to greater than one full second when summed with the
+  // timetamp nanoseconds
+  const auto timestamp = builtin_interfaces::build<Time>().sec(1000).nanosec(100000000);
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(0);
+  clock_skew.set_nanos(-200000000);
+
+  // WHEN we apply the clock skew to the timestamp
+  const auto out = localTimeToRobotTime(timestamp, clock_skew);
+
+  // THEN a second is carried over from the nanoseconds field
+  EXPECT_THAT(out.seconds(), testing::Eq(999));
+  EXPECT_THAT(out.nanos(), testing::Eq(90000000));
+}
+
+TEST(TestClockSkewLocalToRobot, HandleNegativeUnskewedTimestamp) {
+  // GIVEN a timestamp with a positive number of seconds and a positive clock skew with a greater number of seconds than
+  // the timestamp
+  const auto timestamp = builtin_interfaces::build<Time>().sec(0).nanosec(0);
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(-1);
+  clock_skew.set_nanos(0);
+
+  // WHEN we apply the clock skew to the timestamp
+  auto out = localTimeToRobotTime(timestamp, clock_skew);
+
+  // THEN an all-zero timestamp is output
+  EXPECT_THAT(out.seconds(), testing::Eq(-1));
+  EXPECT_THAT(out.nanos(), testing::Eq(0));
+}
+
+TEST(TestClockSkewLocalToRobot, HandleNegativeUnskewedTimestampFromNanoseconds) {
+  // GIVEN an all-zero timestamp and a positive clock skew with a non-zero number of nanoseconds
+  const auto timestamp = builtin_interfaces::build<Time>().sec(0).nanosec(0);
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(0);
+  clock_skew.set_nanos(-1);
+
+  // WHEN we apply the clock skew to the timestamp
+  auto out = localTimeToRobotTime(timestamp, clock_skew);
+
+  // THEN an all-zero timestamp is output
+  EXPECT_THAT(out.seconds(), testing::Eq(0));
+  EXPECT_THAT(out.nanos(), testing::Eq(-1));
+}
+
 }  // namespace spot_ros2::test


### PR DESCRIPTION
## Change Overview

- Rename functions for applying clock skew to timestamps to make their purpose clearer (from `applyClockSkew` to `localTimeToRobotTime`).
- Add `robotTimeToLocalTime` function to convert host-relative time to robot-relative time.
- Move functions related to converting timestamps into a new file.
- Remove unused `convertRobotTimeToLocalTime()` from time sync interface.
  - This function combined retrieving the clock skew from Spot with applying it to a timestamp. In practice, we want to use a specific previously-retrieved clock skew instead of acquiring a new one, since the clock skew could change over time and we want to make sure it corresponds to the timestamp we're converting, so this function wasn't used.

These changes are needed for an in-development feature to synchronize TF frames with Spot's internal world model, since that requires converting the host-relative TF timestamps to Spot-relative timestamps.

## Testing Done

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).

- [x] Make sure CI still passes.
- [x] I tested this on a real Spot to check that this did not introduce functional regressions.
