### PR TITLE
Hotfix to fix segfault in DefaultStateClient

### DIFF
--- a/spot_driver/src/api/default_state_client.cpp
+++ b/spot_driver/src/api/default_state_client.cpp
@@ -11,7 +11,7 @@ namespace spot_ros2 {
 DefaultStateClient::DefaultStateClient(::bosdyn::client::RobotStateClient* client) : client_{client} {}
 
 tl::expected<bosdyn::api::RobotState, std::string> DefaultStateClient::getRobotState() {
-  const auto& get_robot_state_result = client_->GetRobotStateAsync().get();
+  const auto get_robot_state_result = client_->GetRobotStateAsync().get();
   if (!get_robot_state_result.status || !get_robot_state_result.response.has_robot_state()) {
     return tl::make_unexpected("Failed to get robot state: " + get_robot_state_result.status.DebugString());
   }


### PR DESCRIPTION
## Change Overview

`GetRobotStateAsync().get()` returns a reference to the robot state response and not a value. Since `DefaultStateClient` was storing a reference to this response message, there were situations where the response could be destroyed before the state client returned it, which could cause the StatePublisherNode to segfault.

## Testing Done

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).

I tested this on a real Spot, and made sure that the StatePublisherNode launched and published robot states without crashing.
