### PR TITLE
Fix Coveralls path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,20 +102,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          path: src
 
       - name: Build packages
         run: |
           source /opt/ros/$ROS_DISTRO/setup.bash
           colcon build --symlink-install --packages-skip-regex proto2ros --cmake-args -DCMAKE_CXX_FLAGS="--coverage"
+        working-directory: ${{ github.workspace }}/../../
 
       - name: Test packages
         run: |
           source install/setup.bash
           colcon test --python-testing pytest --pytest-with-coverage --event-handlers console_direct+ --packages-skip-regex bdai_ros2_wrappers proto2ros
+        working-directory: ${{ github.workspace }}/../../
 
       - name: Generate coverage report
         run: lcov -c -d build/spot_driver/ -o coverage_spot_driver.info --include "*/spot_driver/*" --exclude "*/test/*"
+        working-directory: ${{ github.workspace }}/../../
 
       - name: Upload python coverage to Coveralls
         uses: coverallsapp/github-action@v2
@@ -125,8 +127,7 @@ jobs:
           flag-name: unittests-python
           parallel: true
           debug: true
-          files: $(find . -name "coverage.xml" -type f)
-          base-path: ${{ github.workspace }}/src
+          files: $(find ../../ -name "coverage.xml" -type f)
 
       - name: Upload cpp coverage to Coveralls
         uses: coverallsapp/github-action@v2
@@ -135,20 +136,19 @@ jobs:
           fail-on-error: true
           flag-name: unittests-cpp
           debug: true
-          files: coverage_spot_driver.info
+          files: ../../coverage_spot_driver.info
           format: lcov
-          base-path: ${{ github.workspace }}/src
 
       - name: Aggregate coverage
         uses: coverallsapp/github-action@v2
         with:
           parallel-finished: true
           carryforward: "unittests-python, unittests-cpp"
-          base-path: ${{ github.workspace }}/src
 
-      - name: Report on test results
+      - if: always()
+        name: Report on test results
         run: colcon test-result --all --verbose
-        if: always()
+        working-directory: ${{ github.workspace }}/../../
 
       - name: Build packages documentation
         run: |
@@ -160,4 +160,3 @@ jobs:
           sphinx-apidoc -f -o source/ ../ ../*setup* ../examples ../*launch.py ../*command_spot_driver.py
           cd ..
           sphinx-build docs _build -v
-        working-directory: ${{ github.workspace }}/src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
           parallel: true
           debug: true
           files: $(find . -name "coverage.xml" -type f)
+          base-path: ${{ github.workspace }}/src
 
       - name: Upload cpp coverage to Coveralls
         uses: coverallsapp/github-action@v2
@@ -136,12 +137,14 @@ jobs:
           debug: true
           files: coverage_spot_driver.info
           format: lcov
+          base-path: ${{ github.workspace }}/src
 
       - name: Aggregate coverage
         uses: coverallsapp/github-action@v2
         with:
           parallel-finished: true
           carryforward: "unittests-python, unittests-cpp"
+          base-path: ${{ github.workspace }}/src
 
       - name: Report on test results
         run: colcon test-result --all --verbose


### PR DESCRIPTION
## Change Overview

Follow-up to #256. It broke source paths in coverage reports. 

This patch amends the situation.

## Testing Done

- [ ] Test Coveralls report can locate sources in repository
