### PR TITLE
[SW-817] Unify login parameter names for launching driver from a config file

### DIFF
--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -16,7 +16,7 @@ class ParameterInterfaceBase {
   // These functions retrieve optional parameters, where a default value can be used if the user does not provide a
   // specific value. If the parameter was set, return the value provided by the user. If the parameter was not set,
   // return the default value.
-  virtual std::string getAddress() const = 0;
+  virtual std::string getHostname() const = 0;
   virtual std::string getUsername() const = 0;
   virtual std::string getPassword() const = 0;
   virtual double getRGBImageQuality() const = 0;
@@ -29,7 +29,7 @@ class ParameterInterfaceBase {
 
  protected:
   // These are the definitions of the default values for optional parameters.
-  static constexpr auto kDefaultAddress = "10.0.0.3";
+  static constexpr auto kDefaultHostname = "10.0.0.3";
   static constexpr auto kDefaultUsername = "user";
   static constexpr auto kDefaultPassword = "password";
   static constexpr double kDefaultRGBImageQuality{70.0};

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
@@ -19,7 +19,7 @@ class RclcppParameterInterface : public ParameterInterfaceBase {
    * @param node A shared_ptr to a rclcpp node. RclcppParameterInterface shares ownership of the shared_ptr.
    */
   explicit RclcppParameterInterface(const std::shared_ptr<rclcpp::Node>& node);
-  std::string getAddress() const override;
+  std::string getHostname() const override;
   std::string getUsername() const override;
   std::string getPassword() const override;
   double getRGBImageQuality() const override;

--- a/spot_driver/src/images/spot_image_publisher_node.cpp
+++ b/spot_driver/src/images/spot_image_publisher_node.cpp
@@ -16,13 +16,13 @@ namespace spot_ros2::images {
 SpotImagePublisherNode::SpotImagePublisherNode(std::unique_ptr<SpotApi> spot_api,
                                                std::unique_ptr<SpotImagePublisher::MiddlewareHandle> mw_handle)
     : node_{mw_handle->node()}, spot_api_{std::move(spot_api)} {
-  const auto address = mw_handle->parameter_interface()->getAddress();
+  const auto hostname = mw_handle->parameter_interface()->getHostname();
   const auto robot_name = mw_handle->parameter_interface()->getSpotName();
   const auto username = mw_handle->parameter_interface()->getUsername();
   const auto password = mw_handle->parameter_interface()->getPassword();
 
   // create and authenticate robot
-  if (const auto create_robot_result = spot_api_->createRobot(address, robot_name); !create_robot_result) {
+  if (const auto create_robot_result = spot_api_->createRobot(hostname, robot_name); !create_robot_result) {
     const auto error_msg{std::string{"Failed to create interface to robot: "}.append(create_robot_result.error())};
     mw_handle->logger_interface()->logError(error_msg);
     throw std::runtime_error(error_msg);

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -5,11 +5,11 @@
 #include <cstdlib>
 
 namespace {
-constexpr auto kEnvVarNameAddress = "SPOT_IP";
+constexpr auto kEnvVarNameHostname = "SPOT_IP";
 constexpr auto kEnvVarNameUsername = "BOSDYN_CLIENT_USERNAME";
 constexpr auto kEnvVarNamePassword = "BOSDYN_CLIENT_PASSWORD";
 
-constexpr auto kParameterNameAddress = "hostname";
+constexpr auto kParameterNameHostname = "hostname";
 constexpr auto kParameterNameUsername = "username";
 constexpr auto kParameterNamePassword = "password";
 constexpr auto kParameterNameRGBImageQuality = "image_quality";
@@ -78,8 +78,8 @@ namespace spot_ros2 {
 
 RclcppParameterInterface::RclcppParameterInterface(const std::shared_ptr<rclcpp::Node>& node) : node_{node} {}
 
-std::string RclcppParameterInterface::getAddress() const {
-  return getEnvironmentVariableParameterFallback(node_, kEnvVarNameAddress, kParameterNameAddress, kDefaultAddress);
+std::string RclcppParameterInterface::getHostname() const {
+  return getEnvironmentVariableParameterFallback(node_, kEnvVarNameHostname, kParameterNameHostname, kDefaultHostname);
 }
 
 std::string RclcppParameterInterface::getUsername() const {

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -9,7 +9,7 @@ constexpr auto kEnvVarNameAddress = "SPOT_IP";
 constexpr auto kEnvVarNameUsername = "BOSDYN_CLIENT_USERNAME";
 constexpr auto kEnvVarNamePassword = "BOSDYN_CLIENT_PASSWORD";
 
-constexpr auto kParameterNameAddress = "address";
+constexpr auto kParameterNameAddress = "hostname";
 constexpr auto kParameterNameUsername = "username";
 constexpr auto kParameterNamePassword = "password";
 constexpr auto kParameterNameRGBImageQuality = "image_quality";

--- a/spot_driver/src/kinematic/kinematic_node.cpp
+++ b/spot_driver/src/kinematic/kinematic_node.cpp
@@ -35,13 +35,13 @@ void KinematicNode::initialize(std::shared_ptr<rclcpp::Node> node, std::unique_p
   node_ = node;
   spot_api_ = std::move(spot_api);
 
-  const auto address = parameter_interface->getAddress();
+  const auto hostname = parameter_interface->getHostname();
   const auto robot_name = parameter_interface->getSpotName();
   const auto username = parameter_interface->getUsername();
   const auto password = parameter_interface->getPassword();
 
   // create and authenticate robot
-  if (const auto create_robot_result = spot_api_->createRobot(address, robot_name); !create_robot_result) {
+  if (const auto create_robot_result = spot_api_->createRobot(hostname, robot_name); !create_robot_result) {
     const auto error_msg{std::string{"Failed to create interface to robot: "}.append(create_robot_result.error())};
     logger_interface->logError(error_msg);
     throw std::runtime_error(error_msg);

--- a/spot_driver/src/robot_state/state_publisher_node.cpp
+++ b/spot_driver/src/robot_state/state_publisher_node.cpp
@@ -55,13 +55,13 @@ void StatePublisherNode::initialize(std::unique_ptr<SpotApi> spot_api,
                                     std::unique_ptr<TimerInterfaceBase> timer_interface) {
   spot_api_ = std::move(spot_api);
 
-  const auto address = parameter_interface->getAddress();
+  const auto hostname = parameter_interface->getHostname();
   const auto robot_name = parameter_interface->getSpotName();
   const auto username = parameter_interface->getUsername();
   const auto password = parameter_interface->getPassword();
 
   // create and authenticate robot
-  if (const auto create_robot_result = spot_api_->createRobot(address, robot_name); !create_robot_result) {
+  if (const auto create_robot_result = spot_api_->createRobot(hostname, robot_name); !create_robot_result) {
     const auto error_msg{std::string{"Failed to create interface to robot: "}.append(create_robot_result.error())};
     logger_interface->logError(error_msg);
     throw std::runtime_error(error_msg);

--- a/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
+++ b/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
@@ -9,7 +9,7 @@
 namespace spot_ros2::test {
 class FakeParameterInterface : public ParameterInterfaceBase {
  public:
-  std::string getAddress() const override { return kExampleAddress; }
+  std::string getHostname() const override { return kExampleHostname; }
 
   std::string getUsername() const override { return kExampleUsername; }
 
@@ -29,7 +29,7 @@ class FakeParameterInterface : public ParameterInterfaceBase {
 
   std::string getSpotName() const override { return spot_name; }
 
-  static constexpr auto kExampleAddress{"192.168.0.10"};
+  static constexpr auto kExampleHostname{"192.168.0.10"};
   static constexpr auto kExampleUsername{"spot_user"};
   static constexpr auto kExamplePassword{"hunter2"};
 

--- a/spot_driver/test/src/images/test_spot_image_publisher.cpp
+++ b/spot_driver/test/src/images/test_spot_image_publisher.cpp
@@ -33,7 +33,7 @@ constexpr auto kSomeErrorMessage = "some error message";
 
 class FakeParameterInterface : public ParameterInterfaceBase {
  public:
-  std::string getAddress() const override { return kExampleAddress; }
+  std::string getHostname() const override { return kExampleAddress; }
 
   std::string getUsername() const override { return kExampleUsername; }
 

--- a/spot_driver/test/src/images/test_spot_image_publisher_node.cpp
+++ b/spot_driver/test/src/images/test_spot_image_publisher_node.cpp
@@ -25,7 +25,7 @@ using ::testing::Return;
 
 namespace spot_ros2::images::test {
 
-constexpr auto kExampleAddress{"192.168.0.10"};
+constexpr auto kExampleHostname{"192.168.0.10"};
 constexpr auto kExampleUsername{"spot_user"};
 constexpr auto kExamplePassword{"hunter2"};
 
@@ -33,7 +33,7 @@ constexpr auto kSomeErrorMessage = "some error message";
 
 class FakeParameterInterface : public ParameterInterfaceBase {
  public:
-  std::string getAddress() const override { return address; }
+  std::string getHostname() const override { return hostname; }
 
   std::string getUsername() const override { return username; }
 
@@ -53,7 +53,7 @@ class FakeParameterInterface : public ParameterInterfaceBase {
 
   std::string getSpotName() const override { return spot_name; }
 
-  std::string address;
+  std::string hostname;
   std::string username;
   std::string password;
 

--- a/spot_driver/test/src/test_parameter_interface.cpp
+++ b/spot_driver/test/src/test_parameter_interface.cpp
@@ -19,7 +19,7 @@ using ::testing::StrEq;
 constexpr auto kNodeName = "my_node_name";
 constexpr auto kNamespace = "my_namespace";
 
-constexpr auto kEnvVarNameAddress = "SPOT_IP";
+constexpr auto kEnvVarNameHostname = "SPOT_IP";
 constexpr auto kEnvVarNameUsername = "BOSDYN_CLIENT_USERNAME";
 constexpr auto kEnvVarNamePassword = "BOSDYN_CLIENT_PASSWORD";
 }  // namespace
@@ -39,13 +39,13 @@ class RclcppParameterInterfaceEnvVarTest : public RclcppParameterInterfaceTest {
     RclcppTest::SetUp();
 
     // Get current values of these environment variables.
-    const auto address = std::getenv(kEnvVarNameAddress);
+    const auto hostname = std::getenv(kEnvVarNameHostname);
     const auto username = std::getenv(kEnvVarNameUsername);
     const auto password = std::getenv(kEnvVarNamePassword);
 
     // If any are already set, cache them in private members.
-    if (address) {
-      spot_address_env_var_cached_ = address;
+    if (hostname) {
+      spot_hostname_env_var_cached_ = hostname;
     }
     if (username) {
       spot_username_env_var_cached_ = username;
@@ -55,7 +55,7 @@ class RclcppParameterInterfaceEnvVarTest : public RclcppParameterInterfaceTest {
     }
 
     // Unset the values of the environment variables to create a clean environment for the test cases.
-    unsetenv(kEnvVarNameAddress);
+    unsetenv(kEnvVarNameHostname);
     unsetenv(kEnvVarNameUsername);
     unsetenv(kEnvVarNamePassword);
 
@@ -67,10 +67,10 @@ class RclcppParameterInterfaceEnvVarTest : public RclcppParameterInterfaceTest {
     RclcppTest::TearDown();
 
     // Restore any cached environment variables.
-    if (spot_address_env_var_cached_) {
+    if (spot_hostname_env_var_cached_) {
       // Calling setenv with the last parameter == 1 replaces any existing value of the environment variable with the
       // new value.
-      setenv(kEnvVarNameAddress, spot_address_env_var_cached_->c_str(), 1);
+      setenv(kEnvVarNameHostname, spot_hostname_env_var_cached_->c_str(), 1);
     }
     if (spot_username_env_var_cached_) {
       setenv(kEnvVarNameUsername, spot_username_env_var_cached_->c_str(), 1);
@@ -83,7 +83,7 @@ class RclcppParameterInterfaceEnvVarTest : public RclcppParameterInterfaceTest {
   std::shared_ptr<rclcpp::Node> node_;
 
  private:
-  std::optional<std::string> spot_address_env_var_cached_;
+  std::optional<std::string> spot_hostname_env_var_cached_;
   std::optional<std::string> spot_username_env_var_cached_;
   std::optional<std::string> spot_password_env_var_cached_;
 };
@@ -122,9 +122,9 @@ TEST_F(RclcppParameterInterfaceTest, GetSpotNameWithDefaultNamespace) {
 }
 
 TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromEnvVars) {
-  // GIVEN we declare environment variables for Spot's address, username, and password
-  constexpr auto address_env_var = "10.0.20.5";
-  setenv(kEnvVarNameAddress, address_env_var, 1);
+  // GIVEN we declare environment variables for Spot's hostname, username, and password
+  constexpr auto hostname_env_var = "10.0.20.5";
+  setenv(kEnvVarNameHostname, hostname_env_var, 1);
   constexpr auto username_env_var = "some_username";
   setenv(kEnvVarNameUsername, username_env_var, 1);
   constexpr auto password_env_var = "very_secure_password";
@@ -133,17 +133,17 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromEnvVars) {
   // GIVEN we create a RclcppParameterInterface using the node
   RclcppParameterInterface parameter_interface{node_};
 
-  // WHEN we call getAddress(), getUsername(), and getPassword()
+  // WHEN we call getHostname(), getUsername(), and getPassword()
   // THEN the returned values match the values we set on the environment variables
-  EXPECT_THAT(parameter_interface.getAddress(), StrEq(address_env_var));
+  EXPECT_THAT(parameter_interface.getHostname(), StrEq(hostname_env_var));
   EXPECT_THAT(parameter_interface.getUsername(), StrEq(username_env_var));
   EXPECT_THAT(parameter_interface.getPassword(), StrEq(password_env_var));
 }
 
 TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromParameters) {
   // GIVEN we set all Spot config parameters to values which are different than the default values
-  constexpr auto address_parameter = "192.168.100.10";
-  node_->declare_parameter("hostname", address_parameter);
+  constexpr auto hostname_parameter = "192.168.100.10";
+  node_->declare_parameter("hostname", hostname_parameter);
   constexpr auto username_parameter = "a_different_username";
   node_->declare_parameter("username", username_parameter);
   constexpr auto password_parameter = "other_password";
@@ -164,7 +164,7 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromParameters) {
 
   // WHEN we call the functions to get the config values from the parameter interface
   // THEN the returned values all match the values we used when declaring the parameters
-  EXPECT_THAT(parameter_interface.getAddress(), StrEq(address_parameter));
+  EXPECT_THAT(parameter_interface.getHostname(), StrEq(hostname_parameter));
   EXPECT_THAT(parameter_interface.getUsername(), StrEq(username_parameter));
   EXPECT_THAT(parameter_interface.getPassword(), StrEq(password_parameter));
   EXPECT_THAT(parameter_interface.getRGBImageQuality(), Eq(rgb_image_quality_parameter));
@@ -175,17 +175,17 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromParameters) {
 }
 
 TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigEnvVarsOverruleParameters) {
-  // GIVEN we declare a environment variables for Spot's address, username, and password
-  constexpr auto address_env_var = "10.0.20.5";
-  setenv(kEnvVarNameAddress, address_env_var, 1);
+  // GIVEN we declare a environment variables for Spot's hostname, username, and password
+  constexpr auto hostname_env_var = "10.0.20.5";
+  setenv(kEnvVarNameHostname, hostname_env_var, 1);
   constexpr auto username_env_var = "some_username";
   setenv(kEnvVarNameUsername, username_env_var, 1);
   constexpr auto password_env_var = "very_secure_password";
   setenv(kEnvVarNamePassword, password_env_var, 1);
 
-  // GIVEN we set parameters with different values for Spot's address, username, and password
-  constexpr auto address_parameter = "192.168.100.10";
-  node_->declare_parameter("hostname", address_parameter);
+  // GIVEN we set parameters with different values for Spot's hostname, username, and password
+  constexpr auto hostname_parameter = "192.168.100.10";
+  node_->declare_parameter("hostname", hostname_parameter);
   constexpr auto username_parameter = "a_different_username";
   node_->declare_parameter("username", username_parameter);
   constexpr auto password_parameter = "other_password";
@@ -194,10 +194,10 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigEnvVarsOverruleParameter
   // GIVEN we create a RclcppParameterInterface using the node
   RclcppParameterInterface parameter_interface{node_};
 
-  // WHEN we call getAddress(), getUsername(), and getPassword()
+  // WHEN we call getHostname(), getUsername(), and getPassword()
   // THEN the returned values match the values we used when declaring the environment variables, since we expect that
   // the environment variables take precedence over the parameters.
-  EXPECT_THAT(parameter_interface.getAddress(), StrEq(address_env_var));
+  EXPECT_THAT(parameter_interface.getHostname(), StrEq(hostname_env_var));
   EXPECT_THAT(parameter_interface.getUsername(), StrEq(username_env_var));
   EXPECT_THAT(parameter_interface.getPassword(), StrEq(password_env_var));
 }
@@ -209,7 +209,7 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetConfigDefaults) {
 
   // WHEN we get the values from the parameter interface
   // THEN the returned values match the expected default values
-  EXPECT_THAT(parameter_interface.getAddress(), StrEq("10.0.0.3"));
+  EXPECT_THAT(parameter_interface.getHostname(), StrEq("10.0.0.3"));
   EXPECT_THAT(parameter_interface.getUsername(), StrEq("user"));
   EXPECT_THAT(parameter_interface.getPassword(), StrEq("password"));
   EXPECT_THAT(parameter_interface.getRGBImageQuality(), Eq(70.0));

--- a/spot_driver/test/src/test_parameter_interface.cpp
+++ b/spot_driver/test/src/test_parameter_interface.cpp
@@ -143,7 +143,7 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromEnvVars) {
 TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromParameters) {
   // GIVEN we set all Spot config parameters to values which are different than the default values
   constexpr auto address_parameter = "192.168.100.10";
-  node_->declare_parameter("address", address_parameter);
+  node_->declare_parameter("hostname", address_parameter);
   constexpr auto username_parameter = "a_different_username";
   node_->declare_parameter("username", username_parameter);
   constexpr auto password_parameter = "other_password";
@@ -185,7 +185,7 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigEnvVarsOverruleParameter
 
   // GIVEN we set parameters with different values for Spot's address, username, and password
   constexpr auto address_parameter = "192.168.100.10";
-  node_->declare_parameter("address", address_parameter);
+  node_->declare_parameter("hostname", address_parameter);
   constexpr auto username_parameter = "a_different_username";
   node_->declare_parameter("username", username_parameter);
   constexpr auto password_parameter = "other_password";


### PR DESCRIPTION
## Change Overview

When launching the spot driver, there is logic to get the username, password, and spot IP address from an environment variable, and if they are not found, fall back to a ROS parameter. The `spot_ros2` node assumes that Spot's IP address, if specified in a config file, is listed as `hostname` whereas the `rclcpp_parameter_interface` in `spot_driver` assumes it is listed as `address`. This changes all instances of `address` to `hostname` to make launching with a config file fully functional and match the config file template given in [`spot_driver/config/spot_ros_example.yaml`](https://github.com/bdaiinstitute/spot_ros2/blob/main/spot_driver/config/spot_ros_example.yaml). 

## Testing Done

- [x] Successfully able to launch the driver and log in with the hostname set in a configuration file, and not as an environment variable. From here, was able to run the examples `walk_forward` and `send_inverse_kinematics_examples`. 
- [x] tests passed with updated function names
