### PR TITLE
Synchronize Spot leasing

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -863,18 +863,8 @@ class SpotROS(Node):
             self.robot_command_and_manipulation_servers = SingleGoalMultipleActionServers(
                 self,
                 [
-                    (
-                        RobotCommand,
-                        "robot_command",
-                        self.handle_robot_command,
-                        None
-                    ),
-                    (
-                        Manipulation,
-                        "manipulation",
-                        self.handle_manipulation_command,
-                        None
-                    ),
+                    (RobotCommand, "robot_command", self.handle_robot_command, None),
+                    (Manipulation, "manipulation", self.handle_manipulation_command, None),
                 ],
             )
         else:

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -847,7 +847,6 @@ class SpotROS(Node):
             NavigateTo,
             "navigate_to",
             self.handle_navigate_to,
-            callback_group=self.group,
         )
         # spot_ros.navigate_as.start() # As is online
 
@@ -856,7 +855,6 @@ class SpotROS(Node):
             Trajectory,
             "trajectory",
             self.handle_trajectory,
-            callback_group=self.group,
         )
         # spot_ros.trajectory_server.start()
 
@@ -869,13 +867,13 @@ class SpotROS(Node):
                         RobotCommand,
                         "robot_command",
                         self.handle_robot_command,
-                        self.group,
+                        None
                     ),
                     (
                         Manipulation,
                         "manipulation",
                         self.handle_manipulation_command,
-                        self.group,
+                        None
                     ),
                 ],
             )
@@ -885,7 +883,6 @@ class SpotROS(Node):
                 RobotCommand,
                 "robot_command",
                 self.handle_robot_command,
-                callback_group=self.group,
             )
 
         # Register Shutdown Handle
@@ -908,7 +905,7 @@ class SpotROS(Node):
                 time.sleep(0.5)
             self.get_logger().info("Found estop!")
 
-        self.create_timer(1 / self.async_tasks_rate, self.step, callback_group=self.group)
+        self.create_timer(1 / self.async_tasks_rate, self.step)
 
         if self.spot_wrapper is not None and self.auto_claim.value:
             self.spot_wrapper.claim()


### PR DESCRIPTION
## Change Overview

`SpotWrapper` is not thread-safe, and thus reentrant ROS 2 callbacks risk resource contention. This patch synchronizes `SpotWrapper` use in general, and lease management in particular, by making all ROS 2 callbacks mutually exclusive.

It also makes use of https://github.com/bdaiinstitute/spot_wrapper/pull/92 to avoid reaching out to `SpotWrapper` internals.

## Testing Done

In addition to green CI, I manually ran multiple examples on a real Spot (those in this repository and others in downstream repositories as well). 
