### PR TITLE
[SW-735] Update spot_ros2 for the new ArmImpedanceCommandStatus enum

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1917,7 +1917,8 @@ class SpotROS(Node):
                 return GoalResponse.FAILED
         elif choice == fb.FEEDBACK_ARM_IMPEDANCE_FEEDBACK_SET:
             if (
-                fb.arm_impedance_feedback.status.value == fb.arm_impedance_feedback.status.STATUS_TRAJECTORY_STALLED
+                fb.arm_impedance_feedback.status.value == fb.arm_impedance_feedback.status.STATUS_TRAJECTORY_CANCELLED
+                or fb.arm_impedance_feedback.status.value == fb.arm_impedance_feedback.status.STATUS_TRAJECTORY_STALLED
                 or fb.arm_impedance_feedback.status.value == fb.arm_impedance_feedback.status.STATUS_UNKNOWN
             ):
                 return GoalResponse.FAILED

--- a/spot_driver/test/pytests/test_ros_interfaces.py
+++ b/spot_driver/test/pytests/test_ros_interfaces.py
@@ -622,6 +622,15 @@ class SpotDriverTest(unittest.TestCase):
         )
 
         feedback.command.synchronized_feedback.arm_command_feedback.feedback.arm_impedance_feedback.status.value = (
+            arm_command_feedback.feedback.arm_impedance_feedback.status.STATUS_TRAJECTORY_CANCELLED
+        )
+        self.assertEqual(
+            self.spot_ros2._robot_command_goal_complete(feedback),
+            GoalResponse.FAILED,
+            "FEEDBACK_ARM_IMPEDANCE_FEEDBACK_SET | STATUS_TRAJECTORY_CANCELLED",
+        )
+
+        feedback.command.synchronized_feedback.arm_command_feedback.feedback.arm_impedance_feedback.status.value = (
             arm_command_feedback.feedback.arm_impedance_feedback.status.STATUS_TRAJECTORY_STALLED
         )
         self.assertEqual(


### PR DESCRIPTION
## Change Overview

Per the [4.0.0 release notes](https://dev.bostondynamics.com/docs/release_notes) there is a new enum in `ArmImpedanceFeedbackStatus` called `STATUS_TRAJECTORY_CANCELLED` (view details with `ros2 interface show bosdyn_api_msgs/msg/ArmImpedanceCommandFeedbackStatus`). If we receive a feedback message from a robot command with this status in `spot_ros2`, this will indicate that the Goal Response has failed. 

## Testing Done

- [x] All `spot_examples` successful (`walk_forward`, `arm_simple`, `send_inverse_kinematics_requests`)
- [x] internal examples using arm impedance control still work (`example_impedance_control.py`)
- [x] Manually try setting status to `STATUS_TRAJECTORY_CANCELLED` within `spot_ros2.py` to force a cancellation, verify that it gets cancelled on same internal arm impedance control examples. 
- [x] new unit tests passed

