### PR TITLE
[SW-859] Resolve TF errors with odom if driver is launched without a namespace

### DIFF
--- a/spot_driver/src/robot_state/state_publisher.cpp
+++ b/spot_driver/src/robot_state/state_publisher.cpp
@@ -35,8 +35,8 @@ StatePublisher::StatePublisher(const std::shared_ptr<StateClientInterface>& stat
 
   const auto preferred_odom_frame = parameter_interface_->getPreferredOdomFrame();
   is_using_vision_ = preferred_odom_frame == "vision";
-  full_odom_frame_id_ = preferred_odom_frame.find('/') == std::string::npos ? spot_name + "/" + preferred_odom_frame
-                                                                            : preferred_odom_frame;
+  full_odom_frame_id_ =
+      preferred_odom_frame.find('/') == std::string::npos ? frame_prefix_ + preferred_odom_frame : preferred_odom_frame;
 
   // Create a timer to request and publish robot state at a fixed rate
   timer_interface_->setTimer(kRobotStateCallbackPeriod, [this] {


### PR DESCRIPTION
## Change Overview

Currently, if the spot driver is launched without a namespace, the odom frame will incorrectly be a child of the body frame. This is because there is some logic to set the full odom frame ID as `spot_name + "/" + preferred_odom_frame`.  
So with a namespace, this frame is `SpotName/odom`, and without a namespace it becomes `/odom` when it should be `odom` -- leading to some string comparison mismatches in `robot_state.cpp`. This PR makes the TF tree structure the same regardless of if there is a namespace or not. 

Relevant github issue: https://github.com/bdaiinstitute/spot_ros2/issues/302

## Testing Done

- [x] Driver can be launched without a namespace, and the body frame is a child of the odom frame by default. 
![frames_no_namespace_resolved.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Xynj6CBpA3NqqBFfE8Q9/dd697356-2b38-4d86-afaf-607d8b1da382.png)
- [x] No change to the previous TF structure if the driver is launched with a namespace. 



