### PR TITLE
[N/A] Update coverage report to ignore spot_wrapper & spot_examples

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = */test/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,7 +19,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
     python3-argcomplete \
     python3-colcon-common-extensions \
     python3-colcon-mixin \
-    python3-pytest-cov \
     python3-rosdep \
     libpython3-dev \
     python3-vcstool \
@@ -44,10 +43,13 @@ RUN curl -sL https://github.com/bdaiinstitute/spot-cpp-sdk/releases/download/4.0
 RUN python -m pip install --no-cache-dir --upgrade pip==22.3.1 \
     && pip install --root-user-action=ignore --no-cache-dir --default-timeout=900 \
     numpy==1.24.1 \
-    bosdyn-client==4.0.0 \
-    bosdyn-mission==4.0.0 \
+    pytest-cov==4.1.0 \
+    pytest-xdist==3.5.0 \
     bosdyn-api==4.0.0 \
     bosdyn-core==4.0.0 \
+    bosdyn-client==4.0.0 \
+    bosdyn-mission==4.0.0 \
+    bosdyn-choreography-client==4.0.0 \
     pip cache purge
 
 # Install spot_wrapper requirements

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: spot_ros2 CI
+name: CI
 
 on:
   pull_request:
@@ -103,16 +103,31 @@ jobs:
         with:
           submodules: recursive
 
+      - run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
       - name: Build packages
         run: |
           source /opt/ros/$ROS_DISTRO/setup.bash
-          colcon build --symlink-install --packages-skip-regex proto2ros --cmake-args -DCMAKE_CXX_FLAGS="--coverage"
+          colcon build --symlink-install --packages-up-to spot_driver spot_description spot_msgs spot_examples --cmake-args -DCMAKE_CXX_FLAGS="--coverage"
         working-directory: ${{ github.workspace }}/../../
 
-      - name: Test packages
+      - name: Test non-spot-driver packages
         run: |
           source install/setup.bash
-          colcon test --python-testing pytest --pytest-with-coverage --event-handlers console_direct+ --packages-skip-regex bdai_ros2_wrappers proto2ros
+          colcon test --event-handlers console_direct+ --packages-select spot_description spot_examples spot_msgs
+        working-directory: ${{ github.workspace }}/../../
+      
+      # Per https://github.com/colcon/colcon-ros/issues/151, `pytest-args` cannot be used in an ament_cmake package, so in order to pass arguments to pytest we have to run pytest directly
+      - name: Test python part of spot-driver package
+        run: |
+          source install/setup.bash
+          pytest -n auto --cov-report xml --cov-config=$GITHUB_WORKSPACE/.coveragerc --cov-report term --cov=spot_driver $GITHUB_WORKSPACE/spot_driver/test/pytests/
+        working-directory: ${{ github.workspace }}/../../
+
+      - name: Test c++ part of spot-driver packages
+        run: |
+          source install/setup.bash
+          colcon test --event-handlers console_direct+ --packages-select spot_driver
         working-directory: ${{ github.workspace }}/../../
 
       - name: Generate coverage report

--- a/README.md
+++ b/README.md
@@ -2,17 +2,21 @@
   <img src="spot.png" width="350">
   <h1 align="center">Spot ROS 2 Driver</h1>
   <p align="center">
-    <a href="https://github.com/MASKOR/spot_ros2/blob/main/LICENSE">
-    <img src="https://img.shields.io/badge/License-MIT-yellow.svg" />
+    <img src="https://img.shields.io/badge/python-3.8|3.9|3.10-blue"/>
+    <a href="https://github.com/astral-sh/ruff">
+      <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"/>
     </a>
-    <a href="https://www.python.org/">
-    <img src="https://img.shields.io/badge/built%20with-Python3-red.svg" />
+    <a href="https://github.com/psf/black">
+      <img src="https://img.shields.io/badge/code%20style-black-000000.svg"/>
     </a>
-    <a href="https://github.com/bdaiinstitute/spot_ros2/actions">
-    <img src="https://github.com/bdaiinstitute/spot_ros2/actions/workflows/test.yml/badge.svg">
+    <a href="https://github.com/bdaiinstitute/spot_ros2/actions/workflows/ci.yml">
+      <img src="https://github.com/bdaiinstitute/spot_ros2/actions/workflows/ci.yml/badge.svg?branch=main"/>
     </a>
-    <a href="https://bdaiinstitute.github.io/spot_ros2">
-    <img src="https://img.shields.io/badge/docs-Python3-blue">
+    <a href="https://coveralls.io/github/bdaiinstitute/spot_ros2?branch=main">
+      <img src="https://coveralls.io/repos/github/bdaiinstitute/spot_ros2/badge.svg?branch=main"/>
+    </a>
+    <a href="LICENSE">
+      <img src="https://img.shields.io/badge/license-MIT-purple"/>
     </a>
   </p>
 </p>

--- a/spot_driver/package.xml
+++ b/spot_driver/package.xml
@@ -37,6 +37,7 @@
   <!-- Support for gtest and gmock-based tests in the ament buildsystem in CMake. -->
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>python3-pytest-cov</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/spot_driver/test/CMakeLists.txt
+++ b/spot_driver/test/CMakeLists.txt
@@ -130,39 +130,40 @@ target_include_directories(test_kinematic_service
 )
 target_link_libraries(test_kinematic_service spot_api)
 
+# Per https://github.com/colcon/colcon-ros/issues/151, `pytest-args` cannot be used in an ament_cmake package, so in order to pass arguments to pytest we have to run pytest directly
+# If that gets fixed, then we can bring this back
 #rclpy_test
-
-set(_pytest_tests
-  pytests/test_copyright.py
-  pytests/test_dock.py
-  pytests/test_execute_dance.py
-  pytests/test_get_choreography_status.py
-  pytests/test_list_all_dances.py
-  pytests/test_list_all_moves.py
-  pytests/test_locomotion_mode.py
-  pytests/test_max_velocity.py
-  pytests/test_pep257.py
-  pytests/test_power_off.py
-  pytests/test_recorded_state_to_animation.py
-  pytests/test_release.py
-  pytests/test_robot_command.py
-  pytests/test_rollover.py
-  pytests/test_ros_interfaces.py
-  pytests/test_self_right.py
-  pytests/test_sit.py
-  pytests/test_stair_mode.py
-  pytests/test_stand.py
-  pytests/test_start_recording_state.py
-  pytests/test_stop.py
-  pytests/test_stop_recording_state.py
-  pytests/test_undock.py
-  pytests/test_upload_animation.py
-)
-foreach(_test_path ${_pytest_tests})
-  get_filename_component(_test_name ${_test_path} NAME_WE)
-  ament_add_pytest_test(${_test_name} ${_test_path}
-    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
-    TIMEOUT 60
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  )
-endforeach()
+# set(_pytest_tests
+#   pytests/test_copyright.py
+#   pytests/test_dock.py
+#   pytests/test_execute_dance.py
+#   pytests/test_get_choreography_status.py
+#   pytests/test_list_all_dances.py
+#   pytests/test_list_all_moves.py
+#   pytests/test_locomotion_mode.py
+#   pytests/test_max_velocity.py
+#   pytests/test_pep257.py
+#   pytests/test_power_off.py
+#   pytests/test_recorded_state_to_animation.py
+#   pytests/test_release.py
+#   pytests/test_robot_command.py
+#   pytests/test_rollover.py
+#   pytests/test_ros_interfaces.py
+#   pytests/test_self_right.py
+#   pytests/test_sit.py
+#   pytests/test_stair_mode.py
+#   pytests/test_stand.py
+#   pytests/test_start_recording_state.py
+#   pytests/test_stop.py
+#   pytests/test_stop_recording_state.py
+#   pytests/test_undock.py
+#   pytests/test_upload_animation.py
+# )
+# foreach(_test_path ${_pytest_tests})
+#   get_filename_component(_test_name ${_test_path} NAME_WE)
+#   ament_add_pytest_test(${_test_name} ${_test_path}
+#     APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
+#     TIMEOUT 60
+#     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+#   )
+# endforeach()


### PR DESCRIPTION
## Change Overview

- As the title says. Coverage should only be for packages from this repo.

## Testing Done

- CI

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
