### PR TITLE
[EK-32] Add robot command service to Spot ROS 2

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2103,7 +2103,7 @@ class SpotROS(Node):
         if self.spot_wrapper is not None:
             args = (duration.nanoseconds / 1e9,) if duration.nanoseconds else ()
             response.success, response.message, robot_command_id = self.spot_wrapper.robot_command(proto_command, *args)
-            if robot_command_id:
+            if robot_command_id is not None:
                 response.robot_command_id = robot_command_id
         else:
             response.success = True

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -88,7 +88,7 @@ from spot_msgs.action import (  # type: ignore
     NavigateTo,
     Trajectory,
 )
-from spot_msgs.action import (
+from spot_msgs.action import (  # type: ignore
     RobotCommand as RobotCommandAction,
 )
 from spot_msgs.msg import (  # type: ignore
@@ -139,7 +139,7 @@ from spot_msgs.srv import (  # type: ignore
     TagLogpoint,
     UploadAnimation,
 )
-from spot_msgs.srv import (
+from spot_msgs.srv import (  # type: ignore
     RobotCommand as RobotCommandService,
 )
 from spot_wrapper.cam_wrapper import SpotCamCamera, SpotCamWrapper

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import bdai_ros2_wrappers.process as ros_process
 import builtin_interfaces.msg
 import rclpy
+import rclpy.duration
 import rclpy.time
 import tf2_ros
 from bdai_ros2_wrappers.node import Node
@@ -82,7 +83,14 @@ from spot_driver.ros_helpers import (
     get_tf_from_world_objects,
     populate_transform_stamped,
 )
-from spot_msgs.action import Manipulation, NavigateTo, RobotCommand, Trajectory  # type: ignore
+from spot_msgs.action import (  # type: ignore
+    Manipulation,
+    NavigateTo,
+    Trajectory,
+)
+from spot_msgs.action import (
+    RobotCommand as RobotCommandAction,
+)
 from spot_msgs.msg import (  # type: ignore
     Feedback,
     LeaseArray,
@@ -130,6 +138,9 @@ from spot_msgs.srv import (  # type: ignore
     StoreLogpoint,
     TagLogpoint,
     UploadAnimation,
+)
+from spot_msgs.srv import (
+    RobotCommand as RobotCommandService,
 )
 from spot_wrapper.cam_wrapper import SpotCamCamera, SpotCamWrapper
 from spot_wrapper.spot_images import CameraSource
@@ -864,21 +875,43 @@ class SpotROS(Node):
         )
         # spot_ros.trajectory_server.start()
 
+        self.create_service(
+            RobotCommandService,
+            "robot_command",
+            lambda request, response: self.service_wrapper(
+                "robot_command",
+                self.handle_robot_command_service,
+                request,
+                response,
+            ),
+            callback_group=self.group,
+        )
+
         if has_arm:
             # Allows both the "robot command" and the "manipulation" action goal to preempt each other
             self.robot_command_and_manipulation_servers = SingleGoalMultipleActionServers(
                 self,
                 [
-                    (RobotCommand, "robot_command", self.handle_robot_command, None),
-                    (Manipulation, "manipulation", self.handle_manipulation_command, None),
+                    (
+                        RobotCommandAction,
+                        "robot_command",
+                        self.handle_robot_command_action,
+                        None,
+                    ),
+                    (
+                        Manipulation,
+                        "manipulation",
+                        self.handle_manipulation_command,
+                        None,
+                    ),
                 ],
             )
         else:
             self.robot_command_server = SingleGoalActionServer(
                 self,
-                RobotCommand,
+                RobotCommandAction,
                 "robot_command",
-                self.handle_robot_command,
+                self.handle_robot_command_action,
             )
 
         # Register Shutdown Handle
@@ -2061,7 +2094,22 @@ class SpotROS(Node):
                 convert(self.spot_wrapper.get_robot_command_feedback(goal_id).feedback, feedback)
         return feedback
 
-    def handle_robot_command(self, goal_handle: ServerGoalHandle) -> RobotCommand.Result:
+    def handle_robot_command_service(
+        self, request: RobotCommandService.Request, response: RobotCommandService.Response
+    ) -> RobotCommandService.Response:
+        proto_command = robot_command_pb2.RobotCommand()
+        convert(request.command, proto_command)
+        duration = rclpy.duration.Duration.from_msg(request.duration)
+        if self.spot_wrapper is not None:
+            args = (duration.nanoseconds / 1e9,) if duration.nanoseconds else ()
+            response.success, response.message, robot_command_id = self.spot_wrapper.robot_command(proto_command, *args)
+            if robot_command_id:
+                response.robot_command_id = robot_command_id
+        else:
+            response.success = True
+        return response
+
+    def handle_robot_command_action(self, goal_handle: ServerGoalHandle) -> RobotCommandAction.Result:
         ros_command = goal_handle.request.command
         proto_command = robot_command_pb2.RobotCommand()
         convert(ros_command, proto_command)
@@ -2079,7 +2127,7 @@ class SpotROS(Node):
         # preempt is requested and to return success if/when the robot reaches the goal. Also check the is_active to
         # monitor whether the timeout_cb has already aborted the command
         feedback: Optional[RobotCommandFeedback] = None
-        feedback_msg: Optional[RobotCommand.Feedback] = None
+        feedback_msg: Optional[RobotCommandAction.Feedback] = None
         while (
             rclpy.ok()
             and not goal_handle.is_cancel_requested
@@ -2087,12 +2135,12 @@ class SpotROS(Node):
             and goal_handle.is_active
         ):
             feedback = self._get_robot_command_feedback(goal_id)
-            feedback_msg = RobotCommand.Feedback(feedback=feedback)
+            feedback_msg = RobotCommandAction.Feedback(feedback=feedback)
             goal_handle.publish_feedback(feedback_msg)
             time.sleep(0.1)  # don't use rate here because we're already in a single thread
 
         # publish a final feedback
-        result = RobotCommand.Result()
+        result = RobotCommandAction.Result()
         if feedback is not None:
             goal_handle.publish_feedback(feedback_msg)
             result.result = feedback

--- a/spot_driver/test/pytests/test_robot_command.py
+++ b/spot_driver/test/pytests/test_robot_command.py
@@ -14,9 +14,12 @@ from bdai_ros2_wrappers.scope import ROSAwareScope
 from bosdyn.api.basic_command_pb2 import RobotCommandFeedbackStatus, StopCommand
 from bosdyn.api.full_body_command_pb2 import FullBodyCommand
 from bosdyn.api.robot_command_pb2 import RobotCommandFeedback, RobotCommandFeedbackResponse, RobotCommandResponse
+from bosdyn.client.robot_command import RobotCommandBuilder
+from bosdyn_msgs.conversions import convert
 from rclpy.action import ActionClient
 
-from spot_msgs.action import RobotCommand  # type: ignore
+from spot_msgs.action import RobotCommand as RobotCommandAction  # type: ignore
+from spot_msgs.srv import RobotCommand as RobotCommandService  # type: ignore
 from spot_wrapper.testing.fixtures import SpotFixture
 
 
@@ -34,8 +37,8 @@ def test_robot_command(ros: ROSAwareScope, simple_spot: SpotFixture) -> None:
 
     # Send a ROS goal.
 
-    action_client = ActionClient(ros.node, RobotCommand, "robot_command")
-    goal = RobotCommand.Goal()
+    action_client = ActionClient(ros.node, RobotCommandAction, "robot_command")
+    goal = RobotCommandAction.Goal()
     future = action_client.send_goal_async(goal)
 
     # Mock GRPC sever.
@@ -85,8 +88,8 @@ def test_robot_command_failed(ros: ROSAwareScope, simple_spot: SpotFixture) -> N
 
     # Send a ROS goal.
 
-    action_client = ActionClient(ros.node, RobotCommand, "robot_command")
-    goal = RobotCommand.Goal()
+    action_client = ActionClient(ros.node, RobotCommandAction, "robot_command")
+    goal = RobotCommandAction.Goal()
     future = action_client.send_goal_async(goal)
 
     # Mock GRPC sever.
@@ -109,3 +112,81 @@ def test_robot_command_failed(ros: ROSAwareScope, simple_spot: SpotFixture) -> N
 
     action_result = result_future.result()
     assert not action_result.result.success
+
+
+@pytest.mark.usefixtures("spot_node")
+def test_robot_command_starts(ros: ROSAwareScope, simple_spot: SpotFixture) -> None:
+    """
+    This integration test checks if the "robot_command" service infrastructure is
+    setup correctly.
+
+    Args:
+        ros: A ROS2 scope that can be used to create clients.
+        simple_spot: a programmable fake Spot robot running on a local
+            GRPC server.
+    """
+
+    command = RobotCommandBuilder.synchro_velocity_command(v_x=1.0, v_y=2.0, v_rot=3.0)
+
+    # Make a ROS service request.
+    client = ros.node.create_client(RobotCommandService, "robot_command")
+    request = RobotCommandService.Request()
+    convert(command, request.command)
+    request.duration.sec = 1
+    future = client.call_async(request)
+
+    # Mock GRPC sever.
+
+    # Serve robot command.
+    call = simple_spot.api.RobotCommand.serve(timeout=2.0)
+    assert call is not None
+    mobility_command = call.request.command.synchronized_command.mobility_command
+    assert mobility_command.se2_velocity_request.velocity.linear.x == 1.0
+    assert mobility_command.se2_velocity_request.velocity.linear.y == 2.0
+    assert mobility_command.se2_velocity_request.velocity.angular == 3.0
+    assert mobility_command.se2_velocity_request.end_time.seconds != 0
+
+    command_response = RobotCommandResponse()
+    command_response.robot_command_id = 5
+    command_response.status = RobotCommandResponse.Status.STATUS_OK
+    call.returns(command_response)
+
+    # Wait for the response.
+    assert wait_for_future(future, timeout_sec=2.0)
+    response = future.result()
+
+    assert response.success
+    assert response.robot_command_id == 5
+
+
+@pytest.mark.usefixtures("spot_node")
+def test_robot_command_fails_to_start(ros: ROSAwareScope, simple_spot: SpotFixture) -> None:
+    """
+    Test what happens when the "robot command" service request fails.
+
+    Args:
+        ros: A ROS2 scope that can be used to create clients.
+        simple_spot: a programmable fake Spot robot running on a local
+            GRPC server.
+    """
+
+    # Make a ROS service request.
+    client = ros.node.create_client(RobotCommandService, "robot_command")
+    request = RobotCommandService.Request()
+    convert(RobotCommandBuilder.synchro_stand_command(), request.command)
+    future = client.call_async(request)
+
+    # Mock GRPC sever.
+
+    # Serve robot command.
+    call = simple_spot.api.RobotCommand.serve(timeout=2.0)
+    assert call is not None
+    command_response = RobotCommandResponse()
+    command_response.status = RobotCommandResponse.Status.STATUS_NOT_POWERED_ON
+    call.returns(command_response)
+
+    # Wait for the response.
+    assert wait_for_future(future, timeout_sec=2.0)
+    response = future.result()
+
+    assert not response.success

--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -81,6 +81,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/ListCameras.srv"
   "srv/ListLogpoints.srv"
   "srv/RetrieveLogpoint.srv"
+  "srv/RobotCommand.srv"
   "srv/StoreLogpoint.srv"
   "srv/TagLogpoint.srv"
   "srv/GetLEDBrightness.srv"

--- a/spot_msgs/srv/RobotCommand.srv
+++ b/spot_msgs/srv/RobotCommand.srv
@@ -1,0 +1,7 @@
+bosdyn_api_msgs/RobotCommand command
+builtin_interfaces/Duration duration
+---
+bool success
+string message
+
+uint32 robot_command_id


### PR DESCRIPTION
## Change Overview

This patch adds a `RobotCommand` service, alongside the `RobotCommand` action, as a fire-and-forget interface in the Spot ROS 2 node.

## Testing Done

~To be tested manually using teleop functionality.~ Tested through https://github.com/bdaiinstitute/bdai/pull/3211.
