### PR TITLE
Hotfix - Typo in getting spot lease

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -964,7 +964,7 @@ class SpotROS(Node):
             response.message = "spot_ros2 is running in mock mode."
             return response
 
-        have_new_lease, lease = self.spot_wrapper.take_lease()
+        have_new_lease, lease = self.spot_wrapper.takeLease()
         if have_new_lease:
             response.success = True
             response.message = str(lease.lease_proto)


### PR DESCRIPTION
## Change Overview

Fixed typo in call to take lease function in driver

## Testing Done

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
