### PR TITLE
Explicitly define interface class copy and move constructors and mark functions as nodiscard

### DIFF
--- a/spot_driver/include/spot_driver/api/default_image_client.hpp
+++ b/spot_driver/include/spot_driver/api/default_image_client.hpp
@@ -19,7 +19,6 @@ class DefaultImageClient : public ImageClientInterface {
  public:
   DefaultImageClient(::bosdyn::client::ImageClient* image_client, std::shared_ptr<TimeSyncApi> time_sync_api,
                      const std::string& robot_name);
-  ~DefaultImageClient() = default;
 
   tl::expected<GetImagesResult, std::string> getImages(::bosdyn::api::GetImageRequest request) override;
 

--- a/spot_driver/include/spot_driver/api/default_image_client.hpp
+++ b/spot_driver/include/spot_driver/api/default_image_client.hpp
@@ -20,7 +20,7 @@ class DefaultImageClient : public ImageClientInterface {
   DefaultImageClient(::bosdyn::client::ImageClient* image_client, std::shared_ptr<TimeSyncApi> time_sync_api,
                      const std::string& robot_name);
 
-  tl::expected<GetImagesResult, std::string> getImages(::bosdyn::api::GetImageRequest request) override;
+  [[nodiscard]] tl::expected<GetImagesResult, std::string> getImages(::bosdyn::api::GetImageRequest request) override;
 
  private:
   ::bosdyn::client::ImageClient* image_client_;

--- a/spot_driver/include/spot_driver/api/default_kinematic_api.hpp
+++ b/spot_driver/include/spot_driver/api/default_kinematic_api.hpp
@@ -12,11 +12,10 @@ namespace spot_ros2 {
 
 class DefaultKinematicApi : public KinematicApi {
  public:
-  virtual ~DefaultKinematicApi() = default;
   explicit DefaultKinematicApi(bosdyn::client::InverseKinematicsClient* kinematic_client);
 
   /**
-   * Return a solution to the given request.
+   * @brief Return a solution to the given request.
    */
   tl::expected<InverseKinematicsResponse, std::string> getSolutions(InverseKinematicsRequest& request) override;
 

--- a/spot_driver/include/spot_driver/api/default_kinematic_api.hpp
+++ b/spot_driver/include/spot_driver/api/default_kinematic_api.hpp
@@ -17,7 +17,8 @@ class DefaultKinematicApi : public KinematicApi {
   /**
    * @brief Return a solution to the given request.
    */
-  tl::expected<InverseKinematicsResponse, std::string> getSolutions(InverseKinematicsRequest& request) override;
+  [[nodiscard]] tl::expected<InverseKinematicsResponse, std::string> getSolutions(
+      InverseKinematicsRequest& request) override;
 
  private:
   bosdyn::client::InverseKinematicsClient* kinematic_client_;

--- a/spot_driver/include/spot_driver/api/default_spot_api.hpp
+++ b/spot_driver/include/spot_driver/api/default_spot_api.hpp
@@ -19,13 +19,15 @@ class DefaultSpotApi : public SpotApi {
  public:
   explicit DefaultSpotApi(const std::string& sdk_client_name);
 
-  tl::expected<void, std::string> createRobot(const std::string& ip_address, const std::string& robot_name) override;
-  tl::expected<void, std::string> authenticate(const std::string& username, const std::string& password) override;
-  tl::expected<bool, std::string> hasArm() const override;
-  std::shared_ptr<KinematicApi> kinematicApi() const override;
-  std::shared_ptr<ImageClientInterface> image_client_interface() const override;
-  std::shared_ptr<StateClientInterface> stateClientInterface() const override;
-  std::shared_ptr<TimeSyncApi> timeSyncInterface() const override;
+  [[nodiscard]] tl::expected<void, std::string> createRobot(const std::string& ip_address,
+                                                            const std::string& robot_name) override;
+  [[nodiscard]] tl::expected<void, std::string> authenticate(const std::string& username,
+                                                             const std::string& password) override;
+  [[nodiscard]] tl::expected<bool, std::string> hasArm() const override;
+  [[nodiscard]] std::shared_ptr<KinematicApi> kinematicApi() const override;
+  [[nodiscard]] std::shared_ptr<ImageClientInterface> image_client_interface() const override;
+  [[nodiscard]] std::shared_ptr<StateClientInterface> stateClientInterface() const override;
+  [[nodiscard]] std::shared_ptr<TimeSyncApi> timeSyncInterface() const override;
 
  private:
   std::unique_ptr<::bosdyn::client::ClientSdk> client_sdk_;

--- a/spot_driver/include/spot_driver/api/default_state_client.hpp
+++ b/spot_driver/include/spot_driver/api/default_state_client.hpp
@@ -24,7 +24,7 @@ class DefaultStateClient final : public StateClientInterface {
    * @return Returns an expected which contains a RobotState message if the request was completed successfully or an
    * error message if the request could not be completed.
    */
-  tl::expected<bosdyn::api::RobotState, std::string> getRobotState() override;
+  [[nodiscard]] tl::expected<bosdyn::api::RobotState, std::string> getRobotState() override;
 
  private:
   /** @brief A pointer to a RobotStateClient provided to this class during construction. */

--- a/spot_driver/include/spot_driver/api/default_time_sync_api.hpp
+++ b/spot_driver/include/spot_driver/api/default_time_sync_api.hpp
@@ -32,7 +32,7 @@ class DefaultTimeSyncApi : public TimeSyncApi {
   * @return If the Spot SDK's time sync thread was not initialized, return an error message.
   * @return If the Spot SDK's time sync endpoint fails to handle the clock skew request, return an error message.
   */
-  tl::expected<google::protobuf::Duration, std::string> getClockSkew() override;
+  [[nodiscard]] tl::expected<google::protobuf::Duration, std::string> getClockSkew() override;
 
  private:
   std::shared_ptr<::bosdyn::client::TimeSyncThread> time_sync_thread_;

--- a/spot_driver/include/spot_driver/api/kinematic_api.hpp
+++ b/spot_driver/include/spot_driver/api/kinematic_api.hpp
@@ -17,6 +17,13 @@ using ::bosdyn::client::Result;
 
 class KinematicApi {
  public:
+  // KinematicApi is move-only
+  KinematicApi() = default;
+  KinematicApi(KinematicApi&& other) = default;
+  KinematicApi(const KinematicApi&) = delete;
+  KinematicApi& operator=(KinematicApi&& other) = default;
+  KinematicApi& operator=(const KinematicApi&) = delete;
+
   virtual ~KinematicApi() = default;
 
   /**

--- a/spot_driver/include/spot_driver/api/spot_api.hpp
+++ b/spot_driver/include/spot_driver/api/spot_api.hpp
@@ -15,6 +15,13 @@ namespace spot_ros2 {
 
 class SpotApi {
  public:
+  // SpotApi is move-only
+  SpotApi() = default;
+  SpotApi(SpotApi&& other) = default;
+  SpotApi(const SpotApi&) = delete;
+  SpotApi& operator=(SpotApi&& other) = default;
+  SpotApi& operator=(const SpotApi&) = delete;
+
   virtual ~SpotApi() = default;
 
   virtual tl::expected<void, std::string> createRobot(const std::string& ip_address, const std::string& robot_name) = 0;

--- a/spot_driver/include/spot_driver/api/spot_image_sources.hpp
+++ b/spot_driver/include/spot_driver/api/spot_image_sources.hpp
@@ -16,7 +16,7 @@ namespace spot_ros2 {
  * @param image_source Input image source.
  * @return ROS topic name for the input image source.
  */
-std::string toRosTopic(const ImageSource& image_source);
+[[nodiscard]] std::string toRosTopic(const ImageSource& image_source);
 
 /**
  * @brief Create the Spot SDK source name corresponding to an ImageSource.
@@ -24,7 +24,7 @@ std::string toRosTopic(const ImageSource& image_source);
  * @param image_source Input image source.
  * @return Spot SDK source name for the input image source.
  */
-std::string toSpotImageSourceName(const ImageSource& image_source);
+[[nodiscard]] std::string toSpotImageSourceName(const ImageSource& image_source);
 
 /**
  * @brief Create an ImageSource corresponding to a Spot SDK source name.
@@ -33,7 +33,7 @@ std::string toSpotImageSourceName(const ImageSource& image_source);
  * @return If the input source name was successfully parsed, return an ImageSource.
  * @return If the input source name does not match the expected name of any known Spot SDK source, return an error.
  */
-tl::expected<ImageSource, std::string> fromSpotImageSourceName(const std::string& source_name);
+[[nodiscard]] tl::expected<ImageSource, std::string> fromSpotImageSourceName(const std::string& source_name);
 
 /**
  * @brief Create a set of image sources corresponding to the specified image types.
@@ -46,6 +46,7 @@ tl::expected<ImageSource, std::string> fromSpotImageSourceName(const std::string
  * @param has_hand_camera Sets whether to request images from the hand camera.
  * @return A set of ImageSources which represents all requested image and camera types.
  */
-std::set<ImageSource> createImageSources(const bool get_rgb_images, const bool get_depth_images,
-                                         const bool get_depth_registered_images, const bool has_hand_camera);
+[[nodiscard]] std::set<ImageSource> createImageSources(const bool get_rgb_images, const bool get_depth_images,
+                                                       const bool get_depth_registered_images,
+                                                       const bool has_hand_camera);
 }  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/api/spot_image_sources.hpp
+++ b/spot_driver/include/spot_driver/api/spot_image_sources.hpp
@@ -6,10 +6,8 @@
 #include <spot_driver/types.hpp>
 #include <tl_expected/expected.hpp>
 
-#include <map>
 #include <set>
 #include <string>
-#include <vector>
 
 namespace spot_ros2 {
 /**

--- a/spot_driver/include/spot_driver/api/state_client_interface.hpp
+++ b/spot_driver/include/spot_driver/api/state_client_interface.hpp
@@ -14,6 +14,13 @@ namespace spot_ros2 {
  */
 class StateClientInterface {
  public:
+  // StateClientInterface is move-only
+  StateClientInterface() = default;
+  StateClientInterface(StateClientInterface&& other) = default;
+  StateClientInterface(const StateClientInterface&) = delete;
+  StateClientInterface& operator=(StateClientInterface&& other) = default;
+  StateClientInterface& operator=(const StateClientInterface&) = delete;
+
   virtual ~StateClientInterface() = default;
 
   /**

--- a/spot_driver/include/spot_driver/api/time_sync_api.hpp
+++ b/spot_driver/include/spot_driver/api/time_sync_api.hpp
@@ -9,6 +9,13 @@
 namespace spot_ros2 {
 class TimeSyncApi {
  public:
+  // TimeSyncApi is move-only
+  TimeSyncApi() = default;
+  TimeSyncApi(TimeSyncApi&& other) = default;
+  TimeSyncApi(const TimeSyncApi&) = delete;
+  TimeSyncApi& operator=(TimeSyncApi&& other) = default;
+  TimeSyncApi& operator=(const TimeSyncApi&) = delete;
+
   virtual ~TimeSyncApi() = default;
 
   /**

--- a/spot_driver/include/spot_driver/images/spot_image_publisher.hpp
+++ b/spot_driver/include/spot_driver/images/spot_image_publisher.hpp
@@ -80,7 +80,7 @@ class SpotImagePublisher {
    * @return False, if a required user-defined parameter was not set, if the attempt to connect to Spot fails, or if the
    * attempt to authenticate with Spot using the provided credentials fails.
    */
-  bool initialize();
+  [[nodiscard]] bool initialize();
 
  private:
   /**

--- a/spot_driver/include/spot_driver/interfaces/image_client_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/image_client_interface.hpp
@@ -22,6 +22,7 @@ struct GetImagesResult {
  */
 class ImageClientInterface {
  public:
+  virtual ~ImageClientInterface() = default;
   virtual tl::expected<GetImagesResult, std::string> getImages(::bosdyn::api::GetImageRequest request) = 0;
 };
 }  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/interfaces/image_client_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/image_client_interface.hpp
@@ -22,6 +22,12 @@ struct GetImagesResult {
  */
 class ImageClientInterface {
  public:
+  // ImageClientInterface is move-only
+  ImageClientInterface() = default;
+  ImageClientInterface(ImageClientInterface&& other) = default;
+  ImageClientInterface(const ImageClientInterface&) = delete;
+  ImageClientInterface& operator=(ImageClientInterface&& other) = default;
+  ImageClientInterface& operator=(const ImageClientInterface&) = delete;
   virtual ~ImageClientInterface() = default;
   virtual tl::expected<GetImagesResult, std::string> getImages(::bosdyn::api::GetImageRequest request) = 0;
 };

--- a/spot_driver/include/spot_driver/interfaces/logger_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/logger_interface_base.hpp
@@ -10,6 +10,13 @@ namespace spot_ros2 {
  */
 class LoggerInterfaceBase {
  public:
+  // LoggerInterfaceBase is move-only
+  LoggerInterfaceBase() = default;
+  LoggerInterfaceBase(LoggerInterfaceBase&& other) = default;
+  LoggerInterfaceBase(const LoggerInterfaceBase&) = delete;
+  LoggerInterfaceBase& operator=(LoggerInterfaceBase&& other) = default;
+  LoggerInterfaceBase& operator=(const LoggerInterfaceBase&) = delete;
+
   virtual ~LoggerInterfaceBase() = default;
 
   virtual void logDebug(const std::string& message) const = 0;

--- a/spot_driver/include/spot_driver/interfaces/logger_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/logger_interface_base.hpp
@@ -10,7 +10,7 @@ namespace spot_ros2 {
  */
 class LoggerInterfaceBase {
  public:
-  virtual ~LoggerInterfaceBase() {}
+  virtual ~LoggerInterfaceBase() = default;
 
   virtual void logDebug(const std::string& message) const = 0;
   virtual void logInfo(const std::string& message) const = 0;

--- a/spot_driver/include/spot_driver/interfaces/node_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/node_interface_base.hpp
@@ -11,6 +11,13 @@ namespace spot_ros2 {
  */
 class NodeInterfaceBase {
  public:
+  // NodeInterfaceBase is move-only
+  NodeInterfaceBase() = default;
+  NodeInterfaceBase(NodeInterfaceBase&& other) = default;
+  NodeInterfaceBase(const NodeInterfaceBase&) = delete;
+  NodeInterfaceBase& operator=(NodeInterfaceBase&& other) = default;
+  NodeInterfaceBase& operator=(const NodeInterfaceBase&) = delete;
+
   virtual ~NodeInterfaceBase() = default;
 
   virtual std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> getNodeBaseInterface() = 0;

--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -11,6 +11,13 @@ namespace spot_ros2 {
  */
 class ParameterInterfaceBase {
  public:
+  // ParameterInterfaceBase is move-only
+  ParameterInterfaceBase() = default;
+  ParameterInterfaceBase(ParameterInterfaceBase&& other) = default;
+  ParameterInterfaceBase(const ParameterInterfaceBase&) = delete;
+  ParameterInterfaceBase& operator=(ParameterInterfaceBase&& other) = default;
+  ParameterInterfaceBase& operator=(const ParameterInterfaceBase&) = delete;
+
   virtual ~ParameterInterfaceBase() = default;
 
   // These functions retrieve optional parameters, where a default value can be used if the user does not provide a

--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -11,7 +11,7 @@ namespace spot_ros2 {
  */
 class ParameterInterfaceBase {
  public:
-  virtual ~ParameterInterfaceBase() {}
+  virtual ~ParameterInterfaceBase() = default;
 
   // These functions retrieve optional parameters, where a default value can be used if the user does not provide a
   // specific value. If the parameter was set, return the value provided by the user. If the parameter was not set,

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_node_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_node_interface.hpp
@@ -19,7 +19,7 @@ class RclcppNodeInterface final : public NodeInterfaceBase {
    */
   explicit RclcppNodeInterface(const std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>& node_base_interface);
 
-  std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> getNodeBaseInterface() override;
+  [[nodiscard]] std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> getNodeBaseInterface() override;
 
  private:
   std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> node_base_interface_;

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
@@ -19,16 +19,16 @@ class RclcppParameterInterface : public ParameterInterfaceBase {
    * @param node A shared_ptr to a rclcpp node. RclcppParameterInterface shares ownership of the shared_ptr.
    */
   explicit RclcppParameterInterface(const std::shared_ptr<rclcpp::Node>& node);
-  std::string getHostname() const override;
-  std::string getUsername() const override;
-  std::string getPassword() const override;
-  double getRGBImageQuality() const override;
-  bool getHasRGBCameras() const override;
-  bool getPublishRGBImages() const override;
-  bool getPublishDepthImages() const override;
-  bool getPublishDepthRegisteredImages() const override;
-  std::string getPreferredOdomFrame() const override;
-  std::string getSpotName() const override;
+  [[nodiscard]] std::string getHostname() const override;
+  [[nodiscard]] std::string getUsername() const override;
+  [[nodiscard]] std::string getPassword() const override;
+  [[nodiscard]] double getRGBImageQuality() const override;
+  [[nodiscard]] bool getHasRGBCameras() const override;
+  [[nodiscard]] bool getPublishRGBImages() const override;
+  [[nodiscard]] bool getPublishDepthImages() const override;
+  [[nodiscard]] bool getPublishDepthRegisteredImages() const override;
+  [[nodiscard]] std::string getPreferredOdomFrame() const override;
+  [[nodiscard]] std::string getSpotName() const override;
 
  private:
   std::shared_ptr<rclcpp::Node> node_;

--- a/spot_driver/include/spot_driver/interfaces/tf_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/tf_interface_base.hpp
@@ -15,7 +15,7 @@ namespace spot_ros2 {
  */
 class TfInterfaceBase {
  public:
-  virtual ~TfInterfaceBase() {}
+  virtual ~TfInterfaceBase() = default;
 
   virtual void updateStaticTransforms(const std::vector<geometry_msgs::msg::TransformStamped>& transforms) = 0;
 

--- a/spot_driver/include/spot_driver/interfaces/tf_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/tf_interface_base.hpp
@@ -15,6 +15,13 @@ namespace spot_ros2 {
  */
 class TfInterfaceBase {
  public:
+  // TfInterfaceBase is move-only
+  TfInterfaceBase() = default;
+  TfInterfaceBase(TfInterfaceBase&& other) = default;
+  TfInterfaceBase(const TfInterfaceBase&) = delete;
+  TfInterfaceBase& operator=(TfInterfaceBase&& other) = default;
+  TfInterfaceBase& operator=(const TfInterfaceBase&) = delete;
+
   virtual ~TfInterfaceBase() = default;
 
   virtual void updateStaticTransforms(const std::vector<geometry_msgs::msg::TransformStamped>& transforms) = 0;

--- a/spot_driver/include/spot_driver/interfaces/timer_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/timer_interface_base.hpp
@@ -11,7 +11,7 @@ namespace spot_ros2 {
  */
 class TimerInterfaceBase {
  public:
-  virtual ~TimerInterfaceBase() {}
+  virtual ~TimerInterfaceBase() = default;
 
   virtual void setTimer(const std::chrono::duration<double>& period, const std::function<void()>& callback) = 0;
   virtual void clearTimer() = 0;

--- a/spot_driver/include/spot_driver/interfaces/timer_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/timer_interface_base.hpp
@@ -11,6 +11,13 @@ namespace spot_ros2 {
  */
 class TimerInterfaceBase {
  public:
+  // TimerInterfaceBase is move-only
+  TimerInterfaceBase() = default;
+  TimerInterfaceBase(TimerInterfaceBase&& other) = default;
+  TimerInterfaceBase(const TimerInterfaceBase&) = delete;
+  TimerInterfaceBase& operator=(TimerInterfaceBase&& other) = default;
+  TimerInterfaceBase& operator=(const TimerInterfaceBase&) = delete;
+
   virtual ~TimerInterfaceBase() = default;
 
   virtual void setTimer(const std::chrono::duration<double>& period, const std::function<void()>& callback) = 0;

--- a/spot_driver/src/images/spot_image_publisher_node.cpp
+++ b/spot_driver/src/images/spot_image_publisher_node.cpp
@@ -43,7 +43,13 @@ SpotImagePublisherNode::SpotImagePublisherNode(std::unique_ptr<SpotApi> spot_api
 
   internal_ = std::make_unique<SpotImagePublisher>(spot_api_->image_client_interface(), std::move(mw_handle),
                                                    expected_has_arm.value());
-  internal_->initialize();
+
+  // TODO(jschornak): initialize() always returns true -- revise implementation to make it return void
+  if (!internal_->initialize()) {
+    constexpr auto error_msg{"Failed to initialize image publisher."};
+    mw_handle->logger_interface()->logError(error_msg);
+    throw std::runtime_error(error_msg);
+  }
 }
 
 SpotImagePublisherNode::SpotImagePublisherNode(const rclcpp::NodeOptions& node_options)

--- a/spot_driver/test/src/images/test_spot_image_publisher.cpp
+++ b/spot_driver/test/src/images/test_spot_image_publisher.cpp
@@ -110,7 +110,7 @@ TEST_F(TestInitSpotImagePublisher, InitSucceeds) {
 
   // WHEN the SpotImagePublisher is initialized
   // THEN initialization succeeds
-  image_publisher->initialize();
+  EXPECT_THAT(image_publisher->initialize(), testing::IsTrue());
 }
 
 TEST_F(TestRunSpotImagePublisher, PublishCallbackTriggersWithArm) {


### PR DESCRIPTION
## Change Overview

Fixes some things the clangd plugin in my IDE was complaining about:
- Mark member functions in derived classes which return values as being `[[nodiscard]]`. This helps enforce correct usage.
  - Related: fix one place where a return value was being ignored.
- For the base interface classes, delete the copy constructor and explicitly define the default move constructor to indicate that these classes are move-only. This is primarily to enforce a particular pattern of usage, since it matches the way the implementations of these classes are used in the nodes.
- Fix minor doc typos and unused includes.

## Testing Done

If the PR branch compiles and tests pass, then this is all set.
