### PR TITLE
Revise image publisher middleware handle to match pattern used by other driver nodes

### DIFF
--- a/spot_driver/include/spot_driver/images/images_middleware_handle.hpp
+++ b/spot_driver/include/spot_driver/images/images_middleware_handle.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+// Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
 
 #pragma once
 
@@ -26,7 +26,7 @@ class ImagesMiddlewareHandle : public SpotImagePublisher::MiddlewareHandle {
    *
    * @param node  A shared_ptr to an instance of a rclcpp::Node
    */
-  explicit ImagesMiddlewareHandle(std::shared_ptr<rclcpp::Node> node);
+  explicit ImagesMiddlewareHandle(const std::shared_ptr<rclcpp::Node>& node);
 
   /**
    * @brief Constructor for ImagesMiddlewareHandle which creates an instance of an rclcpp::node
@@ -34,8 +34,6 @@ class ImagesMiddlewareHandle : public SpotImagePublisher::MiddlewareHandle {
    * @param node_options Options for rclcpp::node initialization
    */
   explicit ImagesMiddlewareHandle(const rclcpp::NodeOptions& node_options = rclcpp::NodeOptions{});
-
-  ~ImagesMiddlewareHandle() = default;
 
   /**
    * @brief Populates the image_publishgers_ and info_publishers_ members with image and camera info publishers.
@@ -50,23 +48,9 @@ class ImagesMiddlewareHandle : public SpotImagePublisher::MiddlewareHandle {
    */
   tl::expected<void, std::string> publishImages(const std::map<ImageSource, ImageWithCameraInfo>& images) override;
 
-  ParameterInterfaceBase* parameter_interface() override { return parameter_interface_.get(); }
-  LoggerInterfaceBase* logger_interface() override { return logger_interface_.get(); }
-  TfInterfaceBase* tf_interface() override { return tf_interface_.get(); }
-  TimerInterfaceBase* timer_interface() override { return timer_interface_.get(); }
-  std::shared_ptr<rclcpp::Node> node() override { return node_; }
-
  private:
   /** @brief Shared instance of an rclcpp node to create publishers */
   std::shared_ptr<rclcpp::Node> node_;
-  /** @brief instance of ParameterInterfaceBase to get ROS parameters*/
-  std::unique_ptr<RclcppParameterInterface> parameter_interface_;
-  /** @brief instance of LoggerInterfaceBase to send ROS log messages*/
-  std::unique_ptr<RclcppLoggerInterface> logger_interface_;
-  /** @brief instance of TfInterfaceBase to update static transforms*/
-  std::unique_ptr<RclcppTfInterface> tf_interface_;
-  /** @brief instance of TimerInterfaceBase to create callback timer*/
-  std::unique_ptr<RclcppWallTimerInterface> timer_interface_;
 
   /** @brief Map between image topic names and image publishers. */
   std::unordered_map<std::string, std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::Image>>> image_publishers_;

--- a/spot_driver/include/spot_driver/images/spot_image_publisher.hpp
+++ b/spot_driver/include/spot_driver/images/spot_image_publisher.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+// Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
 
 #pragma once
 
@@ -16,8 +16,6 @@
 #include <spot_driver/interfaces/timer_interface_base.hpp>
 #include <spot_driver/types.hpp>
 #include <string>
-#include <unordered_map>
-#include <vector>
 
 namespace spot_ros2::images {
 /**
@@ -47,16 +45,10 @@ class SpotImagePublisher {
    */
   class MiddlewareHandle {
    public:
+    virtual ~MiddlewareHandle() = default;
+
     virtual void createPublishers(const std::set<ImageSource>& image_sources) = 0;
     virtual tl::expected<void, std::string> publishImages(const std::map<ImageSource, ImageWithCameraInfo>& images) = 0;
-
-    virtual ParameterInterfaceBase* parameter_interface() = 0;
-    virtual LoggerInterfaceBase* logger_interface() = 0;
-    virtual TfInterfaceBase* tf_interface() = 0;
-    virtual TimerInterfaceBase* timer_interface() = 0;
-    virtual std::shared_ptr<rclcpp::Node> node() = 0;
-
-    virtual ~MiddlewareHandle() = default;
   };
 
   /**
@@ -70,8 +62,11 @@ class SpotImagePublisher {
    * @param has_arm A flag indicating if the Spot in use has an arm. Needed to generate image sources during
    * initialization.
    */
-  SpotImagePublisher(std::shared_ptr<ImageClientInterface> image_client_interface,
-                     std::unique_ptr<MiddlewareHandle> middleware_handle, bool has_arm = false);
+  SpotImagePublisher(const std::shared_ptr<ImageClientInterface>& image_client_interface,
+                     std::unique_ptr<MiddlewareHandle> middleware_handle,
+                     std::unique_ptr<ParameterInterfaceBase> parameters, std::unique_ptr<LoggerInterfaceBase> logger,
+                     std::unique_ptr<TfInterfaceBase> tf_broadcaster, std::unique_ptr<TimerInterfaceBase> timer,
+                     bool has_arm = false);
 
   /**
    * @brief Connect to Spot and start publishing image data.
@@ -99,6 +94,12 @@ class SpotImagePublisher {
   // Interface classes to interact with Spot and the middleware.
   std::shared_ptr<ImageClientInterface> image_client_interface_;
   std::unique_ptr<MiddlewareHandle> middleware_handle_;
+
+  std::unique_ptr<ParameterInterfaceBase> parameters_;
+  std::unique_ptr<LoggerInterfaceBase> logger_;
+  std::unique_ptr<TfInterfaceBase> tf_broadcaster_;
+  std::unique_ptr<TimerInterfaceBase> timer_;
+
   bool has_arm_;
 };
 }  // namespace spot_ros2::images

--- a/spot_driver/include/spot_driver/images/spot_image_publisher_node.hpp
+++ b/spot_driver/include/spot_driver/images/spot_image_publisher_node.hpp
@@ -1,15 +1,17 @@
-// Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+// Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
 
 #pragma once
 
+#include <memory>
 #include <rclcpp/node_interfaces/node_base_interface.hpp>
 #include <rclcpp/node_options.hpp>
 #include <spot_driver/api/spot_api.hpp>
 #include <spot_driver/images/spot_image_publisher.hpp>
 #include <spot_driver/interfaces/logger_interface_base.hpp>
+#include <spot_driver/interfaces/node_interface_base.hpp>
 #include <spot_driver/interfaces/parameter_interface_base.hpp>
-
-#include <memory>
+#include <spot_driver/interfaces/tf_interface_base.hpp>
+#include <spot_driver/interfaces/timer_interface_base.hpp>
 
 namespace spot_ros2::images {
 /**
@@ -18,7 +20,11 @@ namespace spot_ros2::images {
 class SpotImagePublisherNode {
  public:
   SpotImagePublisherNode(std::unique_ptr<SpotApi> spot_api,
-                         std::unique_ptr<SpotImagePublisher::MiddlewareHandle> mw_handle);
+                         std::unique_ptr<SpotImagePublisher::MiddlewareHandle> mw_handle,
+                         std::unique_ptr<ParameterInterfaceBase> parameters,
+                         std::unique_ptr<LoggerInterfaceBase> logger, std::unique_ptr<TfInterfaceBase> tf_broadcaster,
+                         std::unique_ptr<TimerInterfaceBase> timer,
+                         std::unique_ptr<NodeInterfaceBase> node_base_interface);
 
   explicit SpotImagePublisherNode(const rclcpp::NodeOptions& node_options = rclcpp::NodeOptions{});
 
@@ -32,7 +38,11 @@ class SpotImagePublisherNode {
   std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> get_node_base_interface();
 
  private:
-  std::shared_ptr<rclcpp::Node> node_;
+  void initialize(std::unique_ptr<SpotApi> spot_api, std::unique_ptr<SpotImagePublisher::MiddlewareHandle> mw_handle,
+                  std::unique_ptr<ParameterInterfaceBase> parameters, std::unique_ptr<LoggerInterfaceBase> logger,
+                  std::unique_ptr<TfInterfaceBase> tf_broadcaster, std::unique_ptr<TimerInterfaceBase> timer);
+
+  std::unique_ptr<NodeInterfaceBase> node_base_interface_;
   std::unique_ptr<SpotApi> spot_api_;
   std::unique_ptr<SpotImagePublisher> internal_;
 };

--- a/spot_driver/src/images/images_middleware_handle.cpp
+++ b/spot_driver/src/images/images_middleware_handle.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+// Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
 
 #include <rclcpp/node.hpp>
 #include <spot_driver/api/spot_image_sources.hpp>
@@ -17,12 +17,7 @@ constexpr auto kCameraInfoTopicSuffix = "camera_info";
 
 namespace spot_ros2::images {
 
-ImagesMiddlewareHandle::ImagesMiddlewareHandle(std::shared_ptr<rclcpp::Node> node)
-    : node_{node},
-      parameter_interface_{std::make_unique<RclcppParameterInterface>(node)},
-      logger_interface_{std::make_unique<RclcppLoggerInterface>(node->get_logger())},
-      tf_interface_{std::make_unique<RclcppTfInterface>(node)},
-      timer_interface_{std::make_unique<RclcppWallTimerInterface>(node)} {}
+ImagesMiddlewareHandle::ImagesMiddlewareHandle(const std::shared_ptr<rclcpp::Node>& node) : node_{node} {}
 
 ImagesMiddlewareHandle::ImagesMiddlewareHandle(const rclcpp::NodeOptions& node_options)
     : ImagesMiddlewareHandle(std::make_shared<rclcpp::Node>("image_publisher", node_options)) {}

--- a/spot_driver/src/images/spot_image_publisher_node.cpp
+++ b/spot_driver/src/images/spot_image_publisher_node.cpp
@@ -1,12 +1,16 @@
-// Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+// Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
 
+#include <memory>
 #include <spot_driver/images/spot_image_publisher_node.hpp>
 
 #include <spot_driver/api/default_spot_api.hpp>
 #include <spot_driver/images/images_middleware_handle.hpp>
 #include <spot_driver/images/spot_image_publisher.hpp>
 #include <spot_driver/interfaces/rclcpp_logger_interface.hpp>
+#include <spot_driver/interfaces/rclcpp_node_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_parameter_interface.hpp>
+#include <spot_driver/interfaces/rclcpp_tf_interface.hpp>
+#include <spot_driver/interfaces/rclcpp_wall_timer_interface.hpp>
 
 namespace {
 constexpr auto kSDKClientName = "spot_image_publisher";
@@ -14,44 +18,73 @@ constexpr auto kSDKClientName = "spot_image_publisher";
 
 namespace spot_ros2::images {
 SpotImagePublisherNode::SpotImagePublisherNode(std::unique_ptr<SpotApi> spot_api,
-                                               std::unique_ptr<SpotImagePublisher::MiddlewareHandle> mw_handle)
-    : node_{mw_handle->node()}, spot_api_{std::move(spot_api)} {
-  const auto hostname = mw_handle->parameter_interface()->getHostname();
-  const auto robot_name = mw_handle->parameter_interface()->getSpotName();
-  const auto username = mw_handle->parameter_interface()->getUsername();
-  const auto password = mw_handle->parameter_interface()->getPassword();
+                                               std::unique_ptr<SpotImagePublisher::MiddlewareHandle> mw_handle,
+                                               std::unique_ptr<ParameterInterfaceBase> parameters,
+                                               std::unique_ptr<LoggerInterfaceBase> logger,
+                                               std::unique_ptr<TfInterfaceBase> tf_broadcaster,
+                                               std::unique_ptr<TimerInterfaceBase> timer,
+                                               std::unique_ptr<NodeInterfaceBase> node_base_interface)
+    : node_base_interface_{std::move(node_base_interface)} {
+  initialize(std::move(spot_api), std::move(mw_handle), std::move(parameters), std::move(logger),
+             std::move(tf_broadcaster), std::move(timer));
+}
+
+SpotImagePublisherNode::SpotImagePublisherNode(const rclcpp::NodeOptions& node_options) {
+  const auto node = std::make_shared<rclcpp::Node>("image_publisher", node_options);
+  node_base_interface_ = std::make_unique<RclcppNodeInterface>(node->get_node_base_interface());
+
+  auto spot_api = std::make_unique<DefaultSpotApi>(kSDKClientName);
+  auto mw_handle = std::make_unique<ImagesMiddlewareHandle>(node_options);
+  auto parameters = std::make_unique<RclcppParameterInterface>(node);
+  auto logger = std::make_unique<RclcppLoggerInterface>(node->get_logger());
+  auto tf_broadcaster = std::make_unique<RclcppTfInterface>(node);
+  auto timer = std::make_unique<RclcppWallTimerInterface>(node);
+
+  initialize(std::move(spot_api), std::move(mw_handle), std::move(parameters), std::move(logger),
+             std::move(tf_broadcaster), std::move(timer));
+}
+
+void SpotImagePublisherNode::initialize(std::unique_ptr<SpotApi> spot_api,
+                                        std::unique_ptr<SpotImagePublisher::MiddlewareHandle> mw_handle,
+                                        std::unique_ptr<ParameterInterfaceBase> parameters,
+                                        std::unique_ptr<LoggerInterfaceBase> logger,
+                                        std::unique_ptr<TfInterfaceBase> tf_broadcaster,
+                                        std::unique_ptr<TimerInterfaceBase> timer) {
+  spot_api_ = std::move(spot_api);
+
+  const auto hostname = parameters->getHostname();
+  const auto robot_name = parameters->getSpotName();
+  const auto username = parameters->getUsername();
+  const auto password = parameters->getPassword();
 
   // create and authenticate robot
   if (const auto create_robot_result = spot_api_->createRobot(hostname, robot_name); !create_robot_result) {
     const auto error_msg{std::string{"Failed to create interface to robot: "}.append(create_robot_result.error())};
-    mw_handle->logger_interface()->logError(error_msg);
+    logger->logError(error_msg);
     throw std::runtime_error(error_msg);
   }
 
   if (const auto authentication_result = spot_api_->authenticate(username, password); !authentication_result) {
     const auto error_msg{std::string{"Failed to authenticate robot: "}.append(authentication_result.error())};
-    mw_handle->logger_interface()->logError(error_msg);
+    logger->logError(error_msg);
     throw std::runtime_error(error_msg);
   }
 
   const auto expected_has_arm = spot_api_->hasArm();
   if (!expected_has_arm) {
     const auto error_msg{std::string{"Failed to check availability of spot arm: "}.append(expected_has_arm.error())};
-    mw_handle->logger_interface()->logError(error_msg);
+    logger->logError(error_msg);
     throw std::runtime_error(error_msg);
   }
 
   internal_ = std::make_unique<SpotImagePublisher>(spot_api_->image_client_interface(), std::move(mw_handle),
-                                                   expected_has_arm.value());
+                                                   std::move(parameters), std::move(logger), std::move(tf_broadcaster),
+                                                   std::move(timer), expected_has_arm.value());
   internal_->initialize();
 }
 
-SpotImagePublisherNode::SpotImagePublisherNode(const rclcpp::NodeOptions& node_options)
-    : SpotImagePublisherNode{std::make_unique<DefaultSpotApi>(kSDKClientName),
-                             std::make_unique<ImagesMiddlewareHandle>(node_options)} {}
-
 std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> SpotImagePublisherNode::get_node_base_interface() {
-  return node_->get_node_base_interface();
+  return node_base_interface_->getNodeBaseInterface();
 }
 
 }  // namespace spot_ros2::images

--- a/spot_driver/test/src/images/test_spot_image_publisher.cpp
+++ b/spot_driver/test/src/images/test_spot_image_publisher.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+// Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
 
 #include <gmock/gmock.h>
 
@@ -6,13 +6,15 @@
 #include <spot_driver/images/spot_image_publisher.hpp>
 #include <spot_driver/types.hpp>
 
+#include <spot_driver/fake/fake_parameter_interface.hpp>
 #include <spot_driver/mock/mock_image_client.hpp>
 #include <spot_driver/mock/mock_logger_interface.hpp>
+#include <spot_driver/mock/mock_node_interface.hpp>
+#include <spot_driver/mock/mock_spot_api.hpp>
 #include <spot_driver/mock/mock_tf_interface.hpp>
 #include <spot_driver/mock/mock_timer_interface.hpp>
 
 #include <memory>
-#include <optional>
 #include <tl_expected/expected.hpp>
 
 using ::testing::_;
@@ -23,76 +25,51 @@ using ::testing::Property;
 using ::testing::Return;
 using ::testing::Unused;
 
-namespace spot_ros2::images::test {
-
-constexpr auto kExampleAddress{"192.168.0.10"};
-constexpr auto kExampleUsername{"spot_user"};
-constexpr auto kExamplePassword{"hunter2"};
-
-constexpr auto kSomeErrorMessage = "some error message";
-
-class FakeParameterInterface : public ParameterInterfaceBase {
- public:
-  std::string getHostname() const override { return kExampleAddress; }
-
-  std::string getUsername() const override { return kExampleUsername; }
-
-  std::string getPassword() const override { return kExamplePassword; }
-
-  double getRGBImageQuality() const override { return rgb_image_quality; }
-
-  bool getHasRGBCameras() const override { return has_rgb_cameras; }
-
-  bool getPublishRGBImages() const override { return publish_rgb_images; }
-
-  bool getPublishDepthImages() const override { return publish_depth_images; }
-
-  bool getPublishDepthRegisteredImages() const override { return publish_depth_registered_images; }
-
-  std::string getPreferredOdomFrame() const override { return "odom"; }
-
-  std::string getSpotName() const override { return spot_name; }
-
-  double rgb_image_quality = kDefaultRGBImageQuality;
-  bool has_rgb_cameras = kDefaultHasRGBCameras;
-  bool publish_rgb_images = kDefaultPublishRGBImages;
-  bool publish_depth_images = kDefaultPublishDepthImages;
-  bool publish_depth_registered_images = kDefaultPublishDepthRegisteredImages;
-  std::string spot_name;
-};
-
-class MockMiddlewareHandle : public SpotImagePublisher::MiddlewareHandle {
+namespace spot_ros2::test {
+class MockMiddlewareHandle : public images::SpotImagePublisher::MiddlewareHandle {
  public:
   MOCK_METHOD(void, createPublishers, (const std::set<ImageSource>& image_sources), (override));
   MOCK_METHOD((tl::expected<void, std::string>), publishImages, ((const std::map<ImageSource, ImageWithCameraInfo>&)),
               (override));
-  MOCK_METHOD(std::shared_ptr<rclcpp::Node>, node, (), (override));
-
-  ParameterInterfaceBase* parameter_interface() override { return parameter_interface_.get(); }
-  LoggerInterfaceBase* logger_interface() override { return logger_interface_.get(); }
-  TfInterfaceBase* tf_interface() override { return tf_interface_.get(); }
-  TimerInterfaceBase* timer_interface() override { return timer_interface_.get(); }
-
-  std::unique_ptr<FakeParameterInterface> parameter_interface_ = std::make_unique<FakeParameterInterface>();
-  std::unique_ptr<spot_ros2::test::MockLoggerInterface> logger_interface_ =
-      std::make_unique<spot_ros2::test::MockLoggerInterface>();
-  std::unique_ptr<spot_ros2::test::MockTfInterface> tf_interface_ =
-      std::make_unique<spot_ros2::test::MockTfInterface>();
-  std::unique_ptr<spot_ros2::test::MockTimerInterface> timer_interface_ =
-      std::make_unique<spot_ros2::test::MockTimerInterface>();
 };
 
 class TestInitSpotImagePublisher : public ::testing::Test {
  public:
-  void create_image_publisher(bool has_arm) {
-    image_publisher =
-        std::make_unique<SpotImagePublisher>(image_client_interface, std::move(middleware_handle), has_arm);
+  void SetUp() override {
+    image_client_interface = std::make_shared<spot_ros2::test::MockImageClient>();
+    middleware_handle = std::make_unique<MockMiddlewareHandle>();
+    fake_parameter_interface = std::make_unique<FakeParameterInterface>();
+    mock_logger_interface = std::make_unique<spot_ros2::test::MockLoggerInterface>();
+    mock_tf_interface = std::make_unique<MockTfInterface>();
+    mock_timer_interface = std::make_unique<MockTimerInterface>();
+
+    middleware_handle_ptr = middleware_handle.get();
+    fake_parameter_interface_ptr = fake_parameter_interface.get();
+    mock_logger_interface_ptr = mock_logger_interface.get();
+    mock_tf_interface_ptr = mock_tf_interface.get();
+    mock_timer_interface_ptr = mock_timer_interface.get();
   }
 
-  std::shared_ptr<spot_ros2::test::MockImageClient> image_client_interface =
-      std::make_shared<spot_ros2::test::MockImageClient>();
-  std::unique_ptr<MockMiddlewareHandle> middleware_handle = std::make_unique<MockMiddlewareHandle>();
-  std::unique_ptr<SpotImagePublisher> image_publisher;
+  void createImagePublisher(bool has_arm) {
+    image_publisher = std::make_unique<images::SpotImagePublisher>(
+        image_client_interface, std::move(middleware_handle), std::move(fake_parameter_interface),
+        std::move(mock_logger_interface), std::move(mock_tf_interface), std::move(mock_timer_interface), has_arm);
+  }
+
+  std::unique_ptr<images::SpotImagePublisher> image_publisher;
+
+  std::shared_ptr<spot_ros2::test::MockImageClient> image_client_interface;
+  std::unique_ptr<MockMiddlewareHandle> middleware_handle;
+  std::unique_ptr<FakeParameterInterface> fake_parameter_interface;
+  std::unique_ptr<MockLoggerInterface> mock_logger_interface;
+  std::unique_ptr<spot_ros2::test::MockTfInterface> mock_tf_interface;
+  std::unique_ptr<spot_ros2::test::MockTimerInterface> mock_timer_interface;
+
+  MockMiddlewareHandle* middleware_handle_ptr = nullptr;
+  FakeParameterInterface* fake_parameter_interface_ptr = nullptr;
+  MockLoggerInterface* mock_logger_interface_ptr = nullptr;
+  MockTfInterface* mock_tf_interface_ptr = nullptr;
+  MockTimerInterface* mock_timer_interface_ptr = nullptr;
 };
 
 class TestRunSpotImagePublisher : public TestInitSpotImagePublisher {};
@@ -101,12 +78,12 @@ TEST_F(TestInitSpotImagePublisher, InitSucceeds) {
   // THEN expect createPublishers to be invoked
   EXPECT_CALL(*middleware_handle, createPublishers).Times(1);
   // THEN the timer interface's setTimer function is called once with the expected timer period
-  EXPECT_CALL(*middleware_handle->timer_interface_, setTimer(std::chrono::duration<double>{1.0 / 15.0}, _)).Times(1);
+  EXPECT_CALL(*mock_timer_interface_ptr, setTimer(std::chrono::duration<double>{1.0 / 15.0}, _)).Times(1);
 
   // GIVEN all required parameters are set to correct values
   // GIVEN an image publisher that is expected to publish gripper camera images
-  const auto has_arm{true};
-  create_image_publisher(has_arm);
+  constexpr auto kHasArm{true};
+  createImagePublisher(kHasArm);
 
   // WHEN the SpotImagePublisher is initialized
   // THEN initialization succeeds
@@ -115,17 +92,16 @@ TEST_F(TestInitSpotImagePublisher, InitSucceeds) {
 
 TEST_F(TestRunSpotImagePublisher, PublishCallbackTriggersWithArm) {
   // GIVEN we request all possible image types
-  middleware_handle->parameter_interface_->publish_rgb_images = true;
-  middleware_handle->parameter_interface_->publish_depth_images = true;
-  middleware_handle->parameter_interface_->publish_depth_registered_images = true;
+  fake_parameter_interface_ptr->publish_rgb_images = true;
+  fake_parameter_interface_ptr->publish_depth_images = true;
+  fake_parameter_interface_ptr->publish_depth_registered_images = true;
 
   // THEN expect createPublishers to be invoked
   EXPECT_CALL(*middleware_handle, createPublishers).Times(1);
 
   // THEN the timer interface's setTimer function is called once and the timer_callback is set
-  auto timer_interface_ptr = middleware_handle->timer_interface_.get();
-  EXPECT_CALL(*timer_interface_ptr, setTimer).Times(1).WillOnce([&](Unused, const std::function<void()>& cb) {
-    timer_interface_ptr->onSetTimer(cb);
+  EXPECT_CALL(*mock_timer_interface_ptr, setTimer).Times(1).WillOnce([&](Unused, const std::function<void()>& cb) {
+    mock_timer_interface_ptr->onSetTimer(cb);
   });
 
   {
@@ -136,33 +112,32 @@ TEST_F(TestRunSpotImagePublisher, PublishCallbackTriggersWithArm) {
     InSequence seq;
     EXPECT_CALL(*image_client_interface, getImages(Property(&::bosdyn::api::GetImageRequest::image_requests_size, 18)));
     EXPECT_CALL(*middleware_handle, publishImages);
-    EXPECT_CALL(*middleware_handle->tf_interface_, updateStaticTransforms);
+    EXPECT_CALL(*mock_tf_interface_ptr, updateStaticTransforms);
   }
 
   // GIVEN an image_publisher
-  const auto has_arm{true};
-  create_image_publisher(has_arm);
+  constexpr auto kHasArm{true};
+  createImagePublisher(kHasArm);
 
   // GIVEN the SpotImagePublisher was successfully initialized
   ASSERT_TRUE(image_publisher->initialize());
 
   // WHEN the timer callback is triggered
-  timer_interface_ptr->trigger();
+  mock_timer_interface_ptr->trigger();
 }
 
 TEST_F(TestRunSpotImagePublisher, PublishCallbackTriggersWithNoArm) {
   // GIVEN we request all possible image types
-  middleware_handle->parameter_interface_->publish_rgb_images = true;
-  middleware_handle->parameter_interface_->publish_depth_images = true;
-  middleware_handle->parameter_interface_->publish_depth_registered_images = true;
+  fake_parameter_interface_ptr->publish_rgb_images = true;
+  fake_parameter_interface_ptr->publish_depth_images = true;
+  fake_parameter_interface_ptr->publish_depth_registered_images = true;
 
   // THEN expect createPublishers to be invoked
   EXPECT_CALL(*middleware_handle, createPublishers).Times(1);
 
   // THEN the timer interface's setTimer function is called once and the timer_callback is set
-  auto timer_interface_ptr = middleware_handle->timer_interface_.get();
-  EXPECT_CALL(*timer_interface_ptr, setTimer).Times(1).WillOnce([&](Unused, const std::function<void()>& cb) {
-    timer_interface_ptr->onSetTimer(cb);
+  EXPECT_CALL(*mock_timer_interface_ptr, setTimer).Times(1).WillOnce([&](Unused, const std::function<void()>& cb) {
+    mock_timer_interface_ptr->onSetTimer(cb);
   });
 
   {
@@ -173,17 +148,17 @@ TEST_F(TestRunSpotImagePublisher, PublishCallbackTriggersWithNoArm) {
     InSequence seq;
     EXPECT_CALL(*image_client_interface, getImages(Property(&::bosdyn::api::GetImageRequest::image_requests_size, 15)));
     EXPECT_CALL(*middleware_handle, publishImages);
-    EXPECT_CALL(*middleware_handle->tf_interface_, updateStaticTransforms);
+    EXPECT_CALL(*mock_tf_interface_ptr, updateStaticTransforms);
   }
 
   // GIVEN an image publisher not expected to publish camera data
-  const auto has_arm{false};
-  create_image_publisher(has_arm);
+  constexpr auto kHasArm{false};
+  createImagePublisher(kHasArm);
 
   // GIVEN the SpotImagePublisher was successfully initialized
   ASSERT_TRUE(image_publisher->initialize());
 
   // WHEN the timer callback is triggered
-  timer_interface_ptr->trigger();
+  mock_timer_interface_ptr->trigger();
 }
-}  // namespace spot_ros2::images::test
+}  // namespace spot_ros2::test


### PR DESCRIPTION
## Change Overview

- Revise how `SpotImagePublisher::MiddlewareHandle` and `ImagesMiddlewareHandle` are implemented to move the interface classes out of the middleware handle and instead into `SpotImagePublisher`.
  - This reduces the scope of the middleware handle, since now it's only responsible for publishing images instead of additionally being a container for unrelated functionality that's only used by `SpotImagePublisher`.
- Reduce code duplication in tests by using new test fixtures which were added after the original image publisher features.
- Remove some unused headers.

## Testing Done

- [ ] Test on a real Spot and make sure all image topics are published like before.
  - (@jschornak-bdai's note: I haven't done this step yet)