### PR TITLE
[PN-60] Add node to stitch front camera images

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ros2 launch spot_driver spot_driver.launch.py [config_file:=<path/to/config.yaml
 
 ## Configuration
 
-The Spot login data hostname, username and password can be specified either as ROS parameters or as environment variables.  If using ROS parameters, see `spot_driver/config/spot_ros_example.yaml` for an example of what your file could look like.  If using environment variables, define `BOSDYN_CLIENT_USERNAME`, `BOSDYN_CLIENT_PASSWORD`, and `SPOT_IP`.
+The Spot login data hostname, username and password can be specified either as ROS parameters or as environment variables.  If using ROS parameters, see [`spot_driver/config/spot_ros_example.yaml`](spot_driver/config/spot_ros_example.yaml) for an example of what your file could look like.  If using environment variables, define `BOSDYN_CLIENT_USERNAME`, `BOSDYN_CLIENT_PASSWORD`, and `SPOT_IP`.
 
 ## Simple Robot Commands
 Many simple robot commands can be called as services from the command line once the driver is running. For example:
@@ -94,6 +94,8 @@ By default, the driver will publish RGB images as well as depth maps from the `f
 By default, the driver does not publish point clouds. To enable this, launch the driver with `publish_point_clouds:=True`.
 
 The driver can publish both compressed images (under `/<Robot Name>/camera/<camera location>/compressed`) and uncompressed images (under `/<Robot Name>/camera/<camera location>/image`). By default, it will only publish the uncompressed images. You can turn (un)compressed images on/off by launching the driver with the flags `uncompress_images:=<True|False>` and `publish_compressed_images:=<True|False>`.
+
+The driver also has the option to publish a stitched image created from Spot's front left and front right cameras (similar to what is seen on the tablet). If you wish to enable this, launch the driver with `stitch_front_images:=True`, and the image will be published under `/<Robot Name>/camera/frontmiddle_virtual/image`. In order to receive meaningful stitched images, you will have to specify the parameters `virtual_camera_intrinsics`, `virtual_camera_projection_plane`, `virtual_camera_plane_distance`, and `stitched_image_row_padding` (see [`spot_driver/config/spot_ros_example.yaml`](spot_driver/config/spot_ros_example.yaml) for some default values). 
 
 ## Spot CAM
 Due to known issues with the Spot CAM, it is disabled by default. To enable publishing and usage over the driver, add the following command in your configuration YAML file:

--- a/spot_driver/CMakeLists.txt
+++ b/spot_driver/CMakeLists.txt
@@ -15,9 +15,13 @@ set(THIS_PACKAGE_INCLUDE_ROS_DEPENDS
   bosdyn_spot_api_msgs
   cv_bridge
   geometry_msgs
+  image_transport
+  message_filters
+  OpenCV
   rclcpp
   rclcpp_components
   sensor_msgs
+  tf2_eigen
   tf2_ros
   tl_expected
   spot_msgs
@@ -27,6 +31,7 @@ set(THIS_PACKAGE_INCLUDE_ROS_DEPENDS
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(bosdyn REQUIRED)
+find_package(OpenCV 4 REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_ROS_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
@@ -172,6 +177,26 @@ rclcpp_components_register_node(
   PLUGIN "spot_ros2::kinematic::KinematicNode"
   EXECUTABLE spot_inverse_kinematics_node_component)
 
+add_library(image_stitcher
+  src/image_stitcher/image_stitcher.cpp
+  src/image_stitcher/image_stitcher_node.cpp)
+target_include_directories(image_stitcher
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(image_stitcher PUBLIC spot_api)
+set_property(TARGET image_stitcher PROPERTY POSITION_INDEPENDENT_CODE ON)
+ament_target_dependencies(image_stitcher PUBLIC ${THIS_PACKAGE_INCLUDE_ROS_DEPENDS})
+  
+add_executable(image_stitcher_node src/image_stitcher/image_stitcher_node_main.cpp)
+target_include_directories(image_stitcher_node
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(image_stitcher_node PUBLIC image_stitcher)
+
 ament_python_install_package(${PROJECT_NAME})
 install(
   PROGRAMS
@@ -188,6 +213,7 @@ install(
 # Install Libraries
 install(
   TARGETS
+    image_stitcher
     spot_api
     spot_image_publisher_component
     spot_inverse_kinematics_component
@@ -202,6 +228,7 @@ install(
 # Install Executables
 install(
   TARGETS 
+    image_stitcher_node
     object_synchronizer_node
     spot_image_publisher_node
     spot_image_publisher_node_component

--- a/spot_driver/config/spot_ros_example.yaml
+++ b/spot_driver/config/spot_ros_example.yaml
@@ -2,13 +2,13 @@
 
 /**:
   ros__parameters:
-    robot_state_rate: 20.0
+    robot_state_rate: 30.0
     metrics_rate: 0.04
     lease_rate: 1.0
-    image_rate: 10.0
+    image_rate: 15.0
     auto_claim: False
     auto_power_on: False
-    auto_stand: False
+    auto_stand: True
     deadzone: 0.05
     estop_timeout: 9.0
     username: "user"
@@ -17,6 +17,11 @@
     start_estop: False
     preferred_odom_frame: "odom" # pass either odom/vision. This frame will become the parent of body in tf2 tree and will be used in odometry topic. https://dev.bostondynamics.com/docs/concepts/geometry_and_frames.html?highlight=frame#frames-in-the-spot-robot-world for more info.
     async_tasks_rate: 10.0
-    cmd_duration: 0.125 # Increase if spot stutters while walking
+    cmd_duration: 0.25 # Increase if spot stutters while walking
     rgb_cameras: True
     initialize_spot_cam: False
+    # The following parameters are used in the image stitcher node and can be adjusted if the stitched image looks incorrect.
+    virtual_camera_intrinsics: [385.0, 0.0, 315.0, 0.0, 385.0, 844.0, 0.0, 0.0, 1.0]
+    virtual_camera_projection_plane: [-0.15916, 0.0, 0.987253]
+    virtual_camera_plane_distance: 0.5
+    stitched_image_row_padding: 1182

--- a/spot_driver/config/spot_ros_example.yaml
+++ b/spot_driver/config/spot_ros_example.yaml
@@ -2,13 +2,13 @@
 
 /**:
   ros__parameters:
-    robot_state_rate: 30.0
+    robot_state_rate: 20.0
     metrics_rate: 0.04
     lease_rate: 1.0
-    image_rate: 15.0
+    image_rate: 10.0
     auto_claim: False
     auto_power_on: False
-    auto_stand: True
+    auto_stand: False
     deadzone: 0.05
     estop_timeout: 9.0
     username: "user"
@@ -17,7 +17,7 @@
     start_estop: False
     preferred_odom_frame: "odom" # pass either odom/vision. This frame will become the parent of body in tf2 tree and will be used in odometry topic. https://dev.bostondynamics.com/docs/concepts/geometry_and_frames.html?highlight=frame#frames-in-the-spot-robot-world for more info.
     async_tasks_rate: 10.0
-    cmd_duration: 0.25 # Increase if spot stutters while walking
+    cmd_duration: 0.125 # Increase if spot stutters while walking
     rgb_cameras: True
     initialize_spot_cam: False
 

--- a/spot_driver/config/spot_ros_example.yaml
+++ b/spot_driver/config/spot_ros_example.yaml
@@ -20,8 +20,16 @@
     cmd_duration: 0.25 # Increase if spot stutters while walking
     rgb_cameras: True
     initialize_spot_cam: False
-    # The following parameters are used in the image stitcher node and can be adjusted if the stitched image looks incorrect.
+
+    # The following parameters are used in the image stitcher node and were determined through a lot of manual tuning.
+    # They can be adjusted if the stitched image looks incorrect on your robot.
+
+    # Virtual camera intrinsic matrix [fx, 0, cx, 0, fy, cy, 0, 0, 1]
+    # fx stretches the image left-right, fy zooms in, cx moves the image left-right, cy moves the image up-down.
     virtual_camera_intrinsics: [385.0, 0.0, 315.0, 0.0, 385.0, 844.0, 0.0, 0.0, 1.0]
+    # Plane that the stitched image is projected on with respect to the virtual camera frame. 
     virtual_camera_projection_plane: [-0.15916, 0.0, 0.987253]
+    # The distance from the virtual camera frame to the projection plane
     virtual_camera_plane_distance: 0.5
+    # The stitched image will be of size (<frontleft image width>, <frontleft image height> + row_padding)
     stitched_image_row_padding: 1182

--- a/spot_driver/include/spot_driver/image_stitcher/image_stitcher.hpp
+++ b/spot_driver/include/spot_driver/image_stitcher/image_stitcher.hpp
@@ -1,0 +1,181 @@
+// Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+
+#pragma once
+
+#include <message_filters/subscriber.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <message_filters/synchronizer.h>
+#include <eigen3/Eigen/Dense>
+#include <functional>
+#include <image_transport/camera_publisher.hpp>
+#include <image_transport/image_transport.hpp>
+#include <image_transport/subscriber.hpp>
+#include <image_transport/subscriber_filter.hpp>
+#include <memory>
+#include <opencv2/core/mat.hpp>
+#include <opencv2/core/matx.hpp>
+#include <opencv2/core/types.hpp>
+#include <opencv2/stitching/detail/blenders.hpp>
+#include <opencv2/stitching/detail/exposure_compensate.hpp>
+#include <opencv2/stitching/detail/seam_finders.hpp>
+#include <optional>
+#include <rclcpp/node_interfaces/node_base_interface.hpp>
+#include <rclcpp/node_options.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <spot_driver/interfaces/logger_interface_base.hpp>
+#include <spot_driver/interfaces/rclcpp_tf_broadcaster_interface.hpp>
+#include <spot_driver/interfaces/tf_listener_interface_base.hpp>
+#include <string>
+#include <utility>
+#include <vector>
+
+/**
+virtual camera intrinsics
+{                   //
+ 385.,   0., 315.,  // increasing fx stretches left-right, cx moves image left
+   0., 385., 844.,  // increasing fy zooms in, cy moves image down
+   0.,   0.,   1.};
+
+  ros2 run spot_driver image_stitcher_node --ros-args \
+    -p body_frame:=Lionel/body \
+    -p virtual_camera_frame:=Lionel/virtual_camera \
+    -p virtual_camera_intrinsics:="[385., 0., 315., 0., 385., 844., 0., 0., 1.]" \
+    -p virtual_camera_projection_plane:="[-0.15916, 0., 0.987253]" \
+    -p virtual_camera_plane_distance:=0.5 \
+    -p stitched_image_row_padding:=1182 \
+    --remap virtual_camera/image:=/Lionel/camera/frontmiddle_virtual/image \
+    --remap left/image:=/Lionel/camera/frontleft/image \
+    --remap left/camera_info:=/Lionel/camera/frontleft/camera_info \
+    --remap right/image:=/Lionel/camera/frontright/image \
+    --remap right/camera_info:=/Lionel/camera/frontright/camera_info
+ */
+namespace spot_ros2 {
+using Image = sensor_msgs::msg::Image;
+using CameraInfo = sensor_msgs::msg::CameraInfo;
+using Transform = geometry_msgs::msg::Transform;
+using Time = builtin_interfaces::msg::Time;
+using DualImageCallbackFn =
+    std::function<void(const std::shared_ptr<const Image>&, const std::shared_ptr<const CameraInfo>&,
+                       const std::shared_ptr<const Image>&, const std::shared_ptr<const CameraInfo>&)>;
+
+class CameraSynchronizerBase {
+ public:
+  virtual ~CameraSynchronizerBase() = default;
+  virtual void registerCallback(const DualImageCallbackFn& fn) = 0;
+};
+
+class RclcppCameraSynchronizer : public CameraSynchronizerBase {
+ public:
+  explicit RclcppCameraSynchronizer(const std::shared_ptr<rclcpp::Node>& node);
+
+  void registerCallback(const DualImageCallbackFn& fn) override;
+
+ private:
+  using ApproximateTimePolicy = message_filters::sync_policies::ApproximateTime<Image, CameraInfo, Image, CameraInfo>;
+  using Synchronizer = message_filters::Synchronizer<ApproximateTimePolicy>;
+
+  std::unique_ptr<Synchronizer> sync_;
+
+  image_transport::SubscriberFilter subscriber_image1_;
+  message_filters::Subscriber<CameraInfo> subscriber_info1_;
+  image_transport::SubscriberFilter subscriber_image2_;
+  message_filters::Subscriber<CameraInfo> subscriber_info2_;
+};
+
+/**
+ * Handles side effects and parameters for virtual camera
+ */
+class CameraHandleBase {
+ public:
+  virtual ~CameraHandleBase() = default;
+  virtual void publish(const Image& image, const CameraInfo& info) const = 0;
+  virtual void broadcast(const Transform& tf, const Time& stamp) = 0;
+  virtual std::string getBodyFrame() const = 0;
+  virtual std::string getCameraFrame() const = 0;
+  virtual cv::Matx33d getIntrinsics() const = 0;
+  virtual cv::Vec3d getPlaneNormal() const = 0;
+  virtual double getPlaneDistance() const = 0;
+  virtual int getRowPadding() const = 0;
+};
+
+class RclcppCameraHandle : public CameraHandleBase {
+ public:
+  explicit RclcppCameraHandle(const std::shared_ptr<rclcpp::Node>& node);
+
+  void publish(const Image& image, const CameraInfo& info) const override;
+  void broadcast(const Transform& tf, const Time& stamp) override;
+  std::string getBodyFrame() const override;
+  std::string getCameraFrame() const override;
+  cv::Matx33d getIntrinsics() const override;
+  cv::Vec3d getPlaneNormal() const override;
+  double getPlaneDistance() const override;
+  int getRowPadding() const override;
+
+ private:
+  image_transport::ImageTransport image_transport_;
+  image_transport::CameraPublisher camera_publisher_;
+  RclcppTfBroadcasterInterface tf_broadcaster_;
+  std::string body_frame_;
+  std::string camera_frame_;
+  cv::Matx33d intrinsics_;
+  cv::Vec3d plane_normal_;
+  double plane_distance_;
+  int row_padding_;
+};
+
+struct MiddleCamera {
+  MiddleCamera(const cv::Matx33d& virtual_intrinsics, const cv::Vec3d& plane_normal, double plane_distance,
+               int row_padding, const Transform& body_tform_left, const Transform& body_tform_right,
+               const CameraInfo& info_left, const CameraInfo& info_right);
+  Image::SharedPtr stitch(const std::shared_ptr<const Image>& left, const std::shared_ptr<const Image>& right);
+  Transform getTransform();
+
+ private:
+  /* Transforms used to compute the homographies */
+  cv::Matx44d body_tform_left_;
+  cv::Matx44d body_tform_right_;
+  cv::Matx44d body_tform_virtual_;
+  std::vector<cv::Matx33d> homography_;
+  // Top left corners of each image
+  std::vector<cv::Point> corners_;
+  // These are where the warped images/masks go. They are in vector form because later
+  // they get passed into functions that need them in vector form.
+  std::vector<cv::UMat> warped_images_;
+  // These should have better names
+  std::vector<cv::UMat> warped_images_f_;
+  std::vector<cv::UMat> warped_images_s_;
+
+  std::vector<cv::UMat> warped_masks_;
+  std::vector<std::pair<cv::UMat, uchar>> level_masks_;
+  cv::UMat blend_mask_;
+  cv::UMat result_;
+  cv::Size result_size_;
+  /* Parts of the stitching pipeline that make the images look good */
+  // Color corrects the images between each other
+  cv::detail::BlocksGainCompensator compensator_;
+  // In the default opencv stitching pipeline they use GraphCut for seam finding
+  // which is slower than Dp. In testing, Dp seemed to work well for this use case.
+  cv::detail::DpSeamFinder seamer_;
+  // Final blending of the two images along the seam line
+  cv::detail::MultiBandBlender blender_;
+};
+
+class ImageStitcher {
+ public:
+  ImageStitcher(std::unique_ptr<CameraSynchronizerBase> synchronizer,
+                std::unique_ptr<TfListenerInterfaceBase> tf_listener, std::unique_ptr<CameraHandleBase> camera_handle,
+                std::unique_ptr<LoggerInterfaceBase> logger);
+
+ private:
+  void callback(const std::shared_ptr<const Image>&, const std::shared_ptr<const CameraInfo>&,
+                const std::shared_ptr<const Image>&, const std::shared_ptr<const CameraInfo>&);
+
+  std::unique_ptr<CameraSynchronizerBase> synchronizer_;
+  std::unique_ptr<TfListenerInterfaceBase> tf_listener_;
+  std::unique_ptr<CameraHandleBase> camera_handle_;
+  std::unique_ptr<LoggerInterfaceBase> logger_;
+
+  std::optional<MiddleCamera> camera_;
+};
+}  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/image_stitcher/image_stitcher.hpp
+++ b/spot_driver/include/spot_driver/image_stitcher/image_stitcher.hpp
@@ -142,7 +142,7 @@ struct MiddleCamera {
   // These are where the warped images/masks go. They are in vector form because later
   // they get passed into functions that need them in vector form.
   std::vector<cv::UMat> warped_images_;
-  // These should have better names
+  // Warped images encoded in CV_16S and CV_32F, respectively.
   std::vector<cv::UMat> warped_images_f_;
   std::vector<cv::UMat> warped_images_s_;
 

--- a/spot_driver/include/spot_driver/image_stitcher/image_stitcher_node.hpp
+++ b/spot_driver/include/spot_driver/image_stitcher/image_stitcher_node.hpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+
+#pragma once
+
+#include <memory>
+#include <rclcpp/node.hpp>
+#include <rclcpp/node_interfaces/node_base_interface.hpp>
+#include <spot_driver/image_stitcher/image_stitcher.hpp>
+
+namespace spot_ros2 {
+class ImageStitcherNode {
+ public:
+  explicit ImageStitcherNode(const rclcpp::NodeOptions& options);
+
+  std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> get_node_base_interface();
+
+ private:
+  std::shared_ptr<rclcpp::Node> node_;
+  ImageStitcher stitcher_;
+};
+}  // namespace spot_ros2

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -358,6 +358,11 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     stitcher_params = {
         "body_frame": f"{spot_name}/body" if spot_name else "body",
         "virtual_camera_frame": f"{spot_name}/virtual_camera" if spot_name else "virtual_camera",
+        # TODO: are these next values hardcoded?
+        "virtual_camera_intrinsics": [385.0, 0.0, 315.0, 0.0, 385.0, 844.0, 0.0, 0.0, 1.0],
+        "virtual_camera_projection_plane": [-0.15916, 0.0, 0.987253],
+        "virtual_camera_plane_distance": 0.5,
+        "stitched_image_row_padding": 1182,
     }
     image_stitcher_node = launch_ros.actions.Node(
         package="spot_driver",

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -358,11 +358,6 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     stitcher_params = {
         "body_frame": f"{spot_name}/body" if spot_name else "body",
         "virtual_camera_frame": f"{spot_name}/virtual_camera" if spot_name else "virtual_camera",
-        # TODO: are these next values hardcoded?
-        "virtual_camera_intrinsics": [385.0, 0.0, 315.0, 0.0, 385.0, 844.0, 0.0, 0.0, 1.0],
-        "virtual_camera_projection_plane": [-0.15916, 0.0, 0.987253],
-        "virtual_camera_plane_distance": 0.5,
-        "stitched_image_row_padding": 1182,
     }
     image_stitcher_node = launch_ros.actions.Node(
         package="spot_driver",
@@ -376,7 +371,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
             (f"{stitcher_prefix}/right/camera_info", f"{stitcher_prefix}/camera/frontright/camera_info"),
             (f"{stitcher_prefix}/virtual_camera/image", f"{stitcher_prefix}/camera/frontmiddle_virtual/image"),
         ],
-        parameters=[stitcher_params],
+        parameters=[config_file, stitcher_params],
     )
     ld.add_action(image_stitcher_node)
 

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -354,11 +354,11 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     ld.add_action(container)
 
     # add the image stitcher node
-    stitcher_prefix = f"/{spot_name}" if spot_name else ""
     stitcher_params = {
         "body_frame": f"{spot_name}/body" if spot_name else "body",
         "virtual_camera_frame": f"{spot_name}/virtual_camera" if spot_name else "virtual_camera",
     }
+    stitcher_prefix = f"/{spot_name}" if spot_name else ""
     image_stitcher_node = launch_ros.actions.Node(
         package="spot_driver",
         executable="image_stitcher_node",
@@ -372,6 +372,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
             (f"{stitcher_prefix}/virtual_camera/image", f"{stitcher_prefix}/camera/frontmiddle_virtual/image"),
         ],
         parameters=[config_file, stitcher_params],
+        condition=IfCondition(LaunchConfiguration("stitch_front_images")),
     )
     ld.add_action(image_stitcher_node)
 
@@ -429,7 +430,7 @@ def generate_launch_description() -> launch.LaunchDescription:
             "uncompress_images",
             default_value="True",
             choices=["True", "False"],
-            description="Choose whether to publish uncompressed images from Spot (True by default).",
+            description="Choose whether to publish uncompressed images from Spot.",
         )
     )
     launch_args.append(
@@ -437,7 +438,17 @@ def generate_launch_description() -> launch.LaunchDescription:
             "publish_compressed_images",
             default_value="False",
             choices=["True", "False"],
-            description="Choose whether to publish compressed images from Spot (False by default).",
+            description="Choose whether to publish compressed images from Spot.",
+        )
+    )
+    launch_args.append(
+        DeclareLaunchArgument(
+            "stitch_front_images",
+            default_value="False",
+            choices=["True", "False"],
+            description=(
+                "Choose whether to publish a stitched image constructed from Spot's front left and right cameras."
+            ),
         )
     )
     launch_args.append(DeclareLaunchArgument("spot_name", default_value="", description="Name of Spot"))

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -353,6 +353,28 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     )
     ld.add_action(container)
 
+    # add the image stitcher node
+    stitcher_prefix = f"/{spot_name}" if spot_name else ""
+    stitcher_params = {
+        "body_frame": f"{spot_name}/body" if spot_name else "body",
+        "virtual_camera_frame": f"{spot_name}/virtual_camera" if spot_name else "virtual_camera",
+    }
+    image_stitcher_node = launch_ros.actions.Node(
+        package="spot_driver",
+        executable="image_stitcher_node",
+        namespace=spot_name,
+        output="screen",
+        remappings=[
+            (f"{stitcher_prefix}/left/image", f"{stitcher_prefix}/camera/frontleft/image"),
+            (f"{stitcher_prefix}/left/camera_info", f"{stitcher_prefix}/camera/frontleft/camera_info"),
+            (f"{stitcher_prefix}/right/image", f"{stitcher_prefix}/camera/frontright/image"),
+            (f"{stitcher_prefix}/right/camera_info", f"{stitcher_prefix}/camera/frontright/camera_info"),
+            (f"{stitcher_prefix}/virtual_camera/image", f"{stitcher_prefix}/camera/frontmiddle_virtual/image"),
+        ],
+        parameters=[stitcher_params],
+    )
+    ld.add_action(image_stitcher_node)
+
 
 def generate_launch_description() -> launch.LaunchDescription:
     launch_args = []

--- a/spot_driver/package.xml
+++ b/spot_driver/package.xml
@@ -14,8 +14,12 @@
   <depend>bosdyn</depend>
   <depend>bosdyn_msgs</depend>
   <depend>common_interfaces</depend>
+  <depend>cv_bridge</depend>
   <depend>depth_image_proc</depend>
   <depend>geometry_msgs</depend>
+  <depend>image_transport</depend>
+  <depend>libopencv-dev</depend>
+  <depend>message_filters</depend>
   <depend>nav_msgs</depend>
   <depend>protobuf</depend>
   <depend>rclcpp</depend>
@@ -23,6 +27,7 @@
   <depend>rosidl_default_runtime</depend>
   <depend>sensor_msgs</depend>
   <depend>spot_msgs</depend>
+  <depend>tf2_eigen</depend>
   <depend>tf2_ros</depend>
   <depend>tl_expected</depend>
 

--- a/spot_driver/src/image_stitcher/image_stitcher.cpp
+++ b/spot_driver/src/image_stitcher/image_stitcher.cpp
@@ -1,0 +1,430 @@
+// Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+#include <cv_bridge/cv_bridge.h>
+#include <builtin_interfaces/msg/detail/time__struct.hpp>
+#include <geometry_msgs/msg/detail/transform_stamped__struct.hpp>
+#include <image_transport/subscriber_filter.hpp>
+#include <memory>
+#include <opencv2/core/types.hpp>
+#include <spot_driver/image_stitcher/image_stitcher.hpp>
+
+#include <message_filters/time_synchronizer.h>
+#include <opencv2/core/hal/interface.h>
+
+#include <opencv2/core/mat.hpp>
+#include <opencv2/core/matx.hpp>
+#include <opencv2/core/quaternion.hpp>
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/stitching/detail/camera.hpp>
+#include <std_msgs/msg/detail/header__builder.hpp>
+#include <std_msgs/msg/detail/header__struct.hpp>
+#include <stdexcept>
+#include <string>
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <vector>
+namespace {
+constexpr auto kHistoryDepth = 10;
+
+cv::Vec3d toCvVec3d(const std::vector<double>& flattened) {
+  if (flattened.size() != 3) {
+    const auto message =
+        std::string("Input vector must have exactly 3 elements. Got ") + std::to_string(flattened.size());
+    throw std::domain_error(message);
+  }
+  cv::Vec3d vec;
+  vec(0) = flattened[0];
+  vec(1) = flattened[1];
+  vec(2) = flattened[2];
+  return vec;
+}
+
+cv::Matx33d toCvMatx33d(const std::vector<double>& flattened) {
+  if (flattened.size() != 9) {
+    const auto message =
+        std::string("Input vector must have exactly 9 elements. Got ") + std::to_string(flattened.size());
+    throw std::domain_error(message);
+  }
+  cv::Matx33d mat;
+  mat(0, 0) = flattened[0];
+  mat(0, 1) = flattened[1];
+  mat(0, 2) = flattened[2];
+  mat(1, 0) = flattened[3];
+  mat(1, 1) = flattened[4];
+  mat(1, 2) = flattened[5];
+  mat(2, 0) = flattened[6];
+  mat(2, 1) = flattened[7];
+  mat(2, 2) = flattened[8];
+  return mat;
+}
+
+cv::Matx33d toCvMatx33d(const spot_ros2::CameraInfo& info) {
+  return {info.k[0], info.k[1], info.k[2],   // fx,  0, cx
+          info.k[3], info.k[4], info.k[5],   //  0, fy, cy
+          info.k[6], info.k[7], info.k[8]};  // 0,  0,  1
+}
+
+cv::Matx44d toCvMatx44d(const cv::Quatd& q, const cv::Vec3d& t) {
+  // Initialize to identity for bottom row of homogeneous transform
+  cv::Matx44d transform = cv::Matx44d::eye();
+  // Copy in rotation
+  auto const r = q.toRotMat3x3();
+  transform(0, 0) = r(0, 0);
+  transform(0, 1) = r(0, 1);
+  transform(0, 2) = r(0, 2);
+  transform(1, 0) = r(1, 0);
+  transform(1, 1) = r(1, 1);
+  transform(1, 2) = r(1, 2);
+  transform(2, 0) = r(2, 0);
+  transform(2, 1) = r(2, 1);
+  transform(2, 2) = r(2, 2);
+  // Copy in translation
+  transform(0, 3) = t(0);
+  transform(1, 3) = t(1);
+  transform(2, 3) = t(2);
+
+  return transform;
+}
+
+cv::Matx44d toCvMatx44d(const geometry_msgs::msg::Transform& tf) {
+  const cv::Quatd q{tf.rotation.w, tf.rotation.x, tf.rotation.y, tf.rotation.z};
+  const cv::Vec3d t{tf.translation.x, tf.translation.y, tf.translation.z};
+  return toCvMatx44d(q, t);
+}
+
+sensor_msgs::msg::CameraInfo toCameraInfo(const builtin_interfaces::msg::Time& stamp, const std::string& frame,
+                                          size_t width, size_t height, const cv::Matx33d& K) {
+  sensor_msgs::msg::CameraInfo info;
+  // Set header with new frame
+  info.header.stamp = stamp;
+  info.header.frame_id = frame;
+  // Set dimensions
+  info.width = width;
+  info.height = height;
+  // Set intrinsics
+  info.k = {                            //
+            K(0, 0), K(0, 1), K(0, 2),  //
+            K(1, 0), K(1, 1), K(1, 2),  //
+            K(2, 0), K(2, 1), K(2, 2)};
+  // Set the projection matrix (P)
+  // P is a 3x4 matrix, so we extend the intrinsic matrix with zeros
+  info.p = {                                 //
+            K(0, 0), K(0, 1), K(0, 2), 0.0,  //
+            K(1, 0), K(1, 1), K(1, 2), 0.0,  //
+            K(2, 0), K(2, 1), K(2, 2), 0.0};
+  // Set the distortion coefficients
+  info.d = std::vector<double>(5, 0.);
+  // Typical distortion model
+  info.distortion_model = "plumb_bob";
+
+  return info;
+}
+
+void convertToRos(const cv::Matx44d& transform, geometry_msgs::msg::Transform& ros_msg) {
+  // Extract rotation matrix
+  auto const R = transform.get_minor<3, 3>(0, 0);
+  cv::Quatd const q = cv::Quatd::createFromRotMat(R);
+  ros_msg.rotation.w = q.w;
+  ros_msg.rotation.x = q.x;
+  ros_msg.rotation.y = q.y;
+  ros_msg.rotation.z = q.z;
+  // Extract translation
+  ros_msg.translation.x = transform(0, 3);
+  ros_msg.translation.y = transform(1, 3);
+  ros_msg.translation.z = transform(2, 3);
+}
+
+void assignTranslation(const cv::Matx31d& t, cv::Matx44d& T) {
+  T(0, 3) = t(0);
+  T(1, 3) = t(1);
+  T(2, 3) = t(2);
+}
+
+void assignRotation(const cv::Matx33d& R, cv::Matx44d& T) {
+  T(0, 0) = R(0, 0);
+  T(0, 1) = R(0, 1);
+  T(0, 2) = R(0, 2);
+
+  T(1, 0) = R(1, 0);
+  T(1, 1) = R(1, 1);
+  T(1, 2) = R(1, 2);
+
+  T(2, 0) = R(2, 0);
+  T(2, 1) = R(2, 1);
+  T(2, 2) = R(2, 2);
+}
+
+cv::Matx33d between(const cv::Matx33d& R1, const cv::Matx33d& R2) {
+  // Convert rotation matrices to quaternions
+  const cv::Quatd q1 = cv::Quatd::createFromRotMat(R1);
+  const cv::Quatd q2 = cv::Quatd::createFromRotMat(R2);
+
+  // Average the quaternions and convert back to rotation matrix
+  return cv::Quatd::slerp(q1, q2, 0.5).toRotMat3x3();
+}
+
+cv::Matx44d middle(const cv::Matx44d& T1, const cv::Matx44d& T2) {
+  cv::Matx44d T3 = cv::Matx44d::eye();
+  assignRotation(between(T1.get_minor<3, 3>(0, 0), T2.get_minor<3, 3>(0, 0)), T3);
+  assignTranslation(0.5 * (T1.get_minor<3, 1>(0, 3) + T2.get_minor<3, 1>(0, 3)), T3);
+  return T3;
+}
+
+// https://docs.opencv.org/4.x/d9/dab/tutorial_homography.html#tutorial_homography_Demo3
+cv::Matx33d computeHomography(const cv::Matx33d& Km, const cv::Matx33d& Kc, const cv::Matx44d& cTm,
+                              double plane_distance, const cv::Vec3d& plane_normal) {
+  const double inverse_distance = 1. / plane_distance;
+  //  Compute the amount to skew the rotation according to the plane definition
+  const cv::Matx33d Tt = inverse_distance * cTm.get_minor<3, 1>(0, 3) * plane_normal.t();
+  // Compute the geometric homography
+  const cv::Matx33d Hg = cTm.get_minor<3, 3>(0, 0) + Tt;
+  // Compute the image space homography
+  cv::Matx33d H = Km * Hg * Kc.inv();
+  // Normalize on the scalar element
+  H /= H(2, 2);
+  return H;
+}
+}  // namespace
+
+namespace spot_ros2 {
+
+RclcppCameraSynchronizer::RclcppCameraSynchronizer(const std::shared_ptr<rclcpp::Node>& node) {
+  // Remap these topics onto the actual Spot camera topics in the launch file
+  subscriber_image1_.subscribe(node.get(), "left/image", "raw");
+  subscriber_info1_.subscribe(node, "left/camera_info");
+  subscriber_image2_.subscribe(node.get(), "right/image", "raw");
+  subscriber_info2_.subscribe(node, "right/camera_info");
+
+  sync_ = std::make_unique<Synchronizer>(ApproximateTimePolicy(kHistoryDepth), subscriber_image1_, subscriber_info1_,
+                                         subscriber_image2_, subscriber_info2_);
+}
+
+void RclcppCameraSynchronizer::registerCallback(const DualImageCallbackFn& fn) {
+  // This must be a bind instead of a lambda because of how registerCallback is templated within message_filters.
+  sync_->registerCallback(
+      std::bind(fn, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
+}
+
+RclcppCameraHandle::RclcppCameraHandle(const std::shared_ptr<rclcpp::Node>& node)
+    : image_transport_{node},
+      camera_publisher_{
+          image_transport_.advertiseCamera("virtual_camera/image", 1)},  // Remap to actual topic in launch file
+      tf_broadcaster_{node} {
+  // Name of the frame to relate the virtual camera with respect to
+  body_frame_ = node->declare_parameter("body_frame", "robot/body");
+  // Name of the virtual camera frame to publish
+  camera_frame_ = node->declare_parameter("virtual_camera_frame", "robot/virtual_camera");
+  // Get the virtual camera intrinsics, which could fail if the wrong numner of parameters are specified in the yaml
+  try {
+    intrinsics_ = toCvMatx33d(
+        node->declare_parameter("virtual_camera_intrinsics", std::vector<double>{1., 0., 0., 0., 1., 0., 0., 0., 1.}));
+  } catch (const std::domain_error& e) {
+    RCLCPP_ERROR(node->get_logger(), "Virtual camera intrinsics parameter could not be parsed. Check length. %s",
+                 e.what());
+  }
+  // Definition of the plane to project the images onto
+  try {
+    plane_normal_ =
+        toCvVec3d(node->declare_parameter("virtual_camera_projection_plane", std::vector<double>{0., 0., 1.}));
+  } catch (const std::domain_error& e) {
+    RCLCPP_ERROR(node->get_logger(), "Virtual camera projection plane parameter could not be parsed. Check length. %s",
+                 e.what());
+  }
+  // Distance from the projected plane to the virtual camera
+  plane_distance_ = node->declare_parameter("virtual_camera_plane_distance", 1.);
+  // Amount to increase the size of the stitched image rows from the original camera image rows
+  row_padding_ = node->declare_parameter("stitched_image_row_padding", 0);
+}
+
+void RclcppCameraHandle::publish(const Image& image, const CameraInfo& info) const {
+  camera_publisher_.publish(image, info);
+}
+
+void RclcppCameraHandle::broadcast(const Transform& tf, const Time& stamp) {
+  geometry_msgs::msg::TransformStamped tfstamped;
+  tfstamped.transform = tf;
+  tfstamped.header.stamp = stamp;
+  tfstamped.header.frame_id = body_frame_;
+  tfstamped.child_frame_id = camera_frame_;
+  tf_broadcaster_.updateStaticTransforms({tfstamped});
+}
+
+std::string RclcppCameraHandle::getBodyFrame() const {
+  return body_frame_;
+}
+
+std::string RclcppCameraHandle::getCameraFrame() const {
+  return camera_frame_;
+}
+
+cv::Matx33d RclcppCameraHandle::getIntrinsics() const {
+  return intrinsics_;
+}
+
+cv::Vec3d RclcppCameraHandle::getPlaneNormal() const {
+  return plane_normal_;
+}
+
+double RclcppCameraHandle::getPlaneDistance() const {
+  return plane_distance_;
+}
+
+int RclcppCameraHandle::getRowPadding() const {
+  return row_padding_;
+}
+
+MiddleCamera::MiddleCamera(const cv::Matx33d& virtual_intrinsics, const cv::Vec3d& plane_normal, double plane_distance,
+                           int row_padding, const Transform& body_tform_left, const Transform& body_tform_right,
+                           const CameraInfo& info_left, const CameraInfo& info_right)
+    : body_tform_left_{toCvMatx44d(body_tform_left)},
+      body_tform_right_{toCvMatx44d(body_tform_right)},
+      body_tform_virtual_{middle(toCvMatx44d(body_tform_left), toCvMatx44d(body_tform_right))},
+      homography_(2),
+      corners_{cv::Point{0, 0}, cv::Point{0, 0}},
+      warped_images_(2),
+      warped_images_f_(2),
+      warped_images_s_(2),
+      warped_masks_(2),
+      level_masks_(2),
+      result_size_{static_cast<int>(info_left.width), static_cast<int>(info_left.height) + row_padding} {
+  /**
+   * The math behind these homography computations for the virtual camera can be found here
+   * https://docs.opencv.org/4.x/d9/dab/tutorial_homography.html#tutorial_homography_Demo3
+   * though the link describes projecting one camera image into the frame of another existing
+   * camera image, while here we have to create the transforms for a virtual camera between
+   * the left and right images.
+   */
+  // Note: These computations are very sensitive to significant figures (precision)
+  //       Refactoring this code can lead to changes in the value of the double after
+  //       the fifth decimal point and should be tested incrementally
+  const cv::Matx44d left_tform_virtual = body_tform_left_.inv() * body_tform_virtual_;
+  const cv::Matx44d right_tform_virtual = body_tform_right_.inv() * body_tform_virtual_;
+  const auto left_intrinsics = toCvMatx33d(info_right);
+  const auto right_intrinsics = toCvMatx33d(info_left);
+  homography_[0] =
+      computeHomography(virtual_intrinsics, left_intrinsics, left_tform_virtual, plane_distance, plane_normal);
+  homography_[1] =
+      computeHomography(virtual_intrinsics, right_intrinsics, right_tform_virtual, plane_distance, plane_normal);
+
+  // Warp white masks the size of the image using their homographies
+  const cv::Size input_size{static_cast<int>(info_left.width), static_cast<int>(info_left.height)};
+  for (size_t ndx = 0; ndx < warped_masks_.size(); ++ndx) {
+    cv::warpPerspective(cv::UMat{input_size, CV_8U, 255}, warped_masks_[ndx], homography_[ndx], result_size_);
+  }
+  // Prepare level masks for color compensator
+  for (size_t ndx = 0; ndx < warped_masks_.size(); ++ndx) {
+    level_masks_[ndx] = std::make_pair(warped_masks_[ndx], 255);
+  }
+}
+
+Image::SharedPtr MiddleCamera::stitch(const std::shared_ptr<const Image>& left,
+                                      const std::shared_ptr<const Image>& right) {
+  // Convert the images into a format the can be used by opencv.
+  // While the image is coming from the camera on the left of the robot, it sees the right side
+  // of the scene and vice versa. This may need to be extracted if this code is to be generalized
+  // for something other than the Boston Dynamics Spot Robot, as well as checking the homographies.
+  const auto scene_right = cv_bridge::toCvShare(left);
+  const auto scene_left = cv_bridge::toCvShare(right);
+
+  // Transform the images into the virtual center camera space
+  cv::warpPerspective(scene_left->image, warped_images_[0], homography_[0], result_size_);
+  cv::warpPerspective(scene_right->image, warped_images_[1], homography_[1], result_size_);
+
+  // Color compensate the images so they blend better
+  compensator_.feed(corners_, warped_images_, level_masks_);
+  for (size_t ndx = 0; ndx < warped_images_.size(); ndx++) {
+    compensator_.apply(ndx, corners_[ndx], warped_images_[ndx], warped_masks_);
+  }
+
+  // Create seam masks for the two images to find the best path to blend them
+  // Convert images to a different colorspace for seaming
+  for (size_t ndx = 0; ndx < warped_images_.size(); ndx++) {
+    warped_images_[ndx].convertTo(warped_images_f_[ndx], CV_32F);
+  }
+  // Find optimal seams to cut at
+  seamer_.find(warped_images_f_, corners_, warped_masks_);
+
+  // Blend the images together around the seam
+  // Tell the blender to consider the whole warped image for blending
+  blender_.prepare(cv::Rect{cv::Point{0, 0}, result_size_});
+  // Convert images to a different colorspace for blending
+  for (size_t ndx = 0; ndx < warped_images_.size(); ndx++) {
+    warped_images_[ndx].convertTo(warped_images_s_[ndx], CV_16S);
+  }
+  // Feed the warped images and their masks to the blender
+  blender_.feed(warped_images_s_[0], warped_masks_[0], cv::Point{0, 0});
+  blender_.feed(warped_images_s_[1], warped_masks_[1], cv::Point{0, 0});
+  blender_.blend(result_, blend_mask_);
+
+  // Convert the image back to the BGR color space
+  result_.convertTo(result_, CV_8U);
+  // Return the image in a format that can be published
+  return cv_bridge::CvImage(std_msgs::msg::Header{}, "bgr8", result_.getMat(cv::ACCESS_READ)).toImageMsg();
+}
+
+Transform MiddleCamera::getTransform() {
+  geometry_msgs::msg::Transform msg;
+  convertToRos(body_tform_virtual_, msg);
+  return msg;
+}
+
+ImageStitcher::ImageStitcher(std::unique_ptr<CameraSynchronizerBase> synchronizer,
+                             std::unique_ptr<TfListenerInterfaceBase> tf_listener,
+                             std::unique_ptr<CameraHandleBase> camera_handle,
+                             std::unique_ptr<LoggerInterfaceBase> logger)
+    : synchronizer_{std::move(synchronizer)},
+      tf_listener_{std::move(tf_listener)},
+      camera_handle_{std::move(camera_handle)},
+      logger_{std::move(logger)} {
+  synchronizer_->registerCallback(
+      [this](const std::shared_ptr<const Image>& image_left, const std::shared_ptr<const CameraInfo>& info_left,
+             const std::shared_ptr<const Image>& image_right, const std::shared_ptr<const CameraInfo>& info_right) {
+        callback(image_left, info_left, image_right, info_right);
+      });
+}
+
+void ImageStitcher::callback(const std::shared_ptr<const Image>& image_left,
+                             const std::shared_ptr<const CameraInfo>& info_left,
+                             const std::shared_ptr<const Image>& image_right,
+                             const std::shared_ptr<const CameraInfo>& info_right) {
+  // The transforms and camera info are assumed to be static, so we only need to lookup these
+  // things once, and use them to initialize the stitching camera. It cannot stitch without these
+  // parameters so if we can't get them we have to exit the callback.
+  if (!camera_.has_value()) {
+    const auto body_frame = camera_handle_->getBodyFrame();
+    const auto body_tform_left =
+        tf_listener_->lookupTransform(info_left->header.frame_id, body_frame, info_left->header.stamp);
+    const auto body_tform_right =
+        tf_listener_->lookupTransform(info_right->header.frame_id, body_frame, info_right->header.stamp);
+    if (!body_tform_left || !body_tform_right) {
+      if (!body_tform_left) {
+        logger_->logWarn("Valid transform for image frame " + info_left->header.frame_id + " to " + body_frame +
+                         " could not be found");
+      }
+      if (!body_tform_right) {
+        logger_->logWarn("Valid transform for image frame " + info_right->header.frame_id + " to " + body_frame +
+                         " could not be found");
+      }
+      return;
+    }
+    // Build the stitching camera
+    camera_ = MiddleCamera{camera_handle_->getIntrinsics(),
+                           camera_handle_->getPlaneNormal(),
+                           camera_handle_->getPlaneDistance(),
+                           camera_handle_->getRowPadding(),
+                           body_tform_left->transform,
+                           body_tform_right->transform,
+                           *info_left,
+                           *info_right};
+    // Virtual camera transform only has to be broadcast once since it is static wrt the body
+    camera_handle_->broadcast(camera_->getTransform(), info_left->header.stamp);
+  }
+  // The rest of the time we should just be stitching and publishing
+  const auto image_stitched = camera_->stitch(image_left, image_right);
+  // The only reason we have to remake this every time is to update the time stamp
+  const auto info_stitched =
+      toCameraInfo(info_left->header.stamp, camera_handle_->getCameraFrame(), image_stitched->width,
+                   image_stitched->height, camera_handle_->getIntrinsics());
+  camera_handle_->publish(*image_stitched, info_stitched);
+}
+
+}  // namespace spot_ros2

--- a/spot_driver/src/image_stitcher/image_stitcher.cpp
+++ b/spot_driver/src/image_stitcher/image_stitcher.cpp
@@ -154,15 +154,16 @@ void assignRotation(const cv::Matx33d& R, cv::Matx44d& T) {
 }
 
 cv::Matx33d between(const cv::Matx33d& R1, const cv::Matx33d& R2) {
-  // Convert rotation matrices to quaternions
+  // Get the rotation matrix in between R1 and R2
+  // First convert rotation matrices to quaternions
   const cv::Quatd q1 = cv::Quatd::createFromRotMat(R1);
   const cv::Quatd q2 = cv::Quatd::createFromRotMat(R2);
-
-  // Average the quaternions and convert back to rotation matrix
+  // Then average the quaternions and convert back to rotation matrix
   return cv::Quatd::slerp(q1, q2, 0.5).toRotMat3x3();
 }
 
 cv::Matx44d middle(const cv::Matx44d& T1, const cv::Matx44d& T2) {
+  // Take the left and right image frames and determine the transform in the middle
   cv::Matx44d T3 = cv::Matx44d::eye();
   assignRotation(between(T1.get_minor<3, 3>(0, 0), T2.get_minor<3, 3>(0, 0)), T3);
   assignTranslation(0.5 * (T1.get_minor<3, 1>(0, 3) + T2.get_minor<3, 1>(0, 3)), T3);
@@ -188,7 +189,7 @@ cv::Matx33d computeHomography(const cv::Matx33d& Km, const cv::Matx33d& Kc, cons
 namespace spot_ros2 {
 
 RclcppCameraSynchronizer::RclcppCameraSynchronizer(const std::shared_ptr<rclcpp::Node>& node) {
-  // Remap these topics onto the actual Spot camera topics in the launch file
+  // These topics are remapped onto the actual Spot camera topics in the launch file
   subscriber_image1_.subscribe(node.get(), "left/image", "raw");
   subscriber_info1_.subscribe(node, "left/camera_info");
   subscriber_image2_.subscribe(node.get(), "right/image", "raw");
@@ -213,7 +214,7 @@ RclcppCameraHandle::RclcppCameraHandle(const std::shared_ptr<rclcpp::Node>& node
   body_frame_ = node->declare_parameter("body_frame", "robot/body");
   // Name of the virtual camera frame to publish
   camera_frame_ = node->declare_parameter("virtual_camera_frame", "robot/virtual_camera");
-  // Get the virtual camera intrinsics, which could fail if the wrong numner of parameters are specified in the yaml
+  // Get the virtual camera intrinsics, which could fail if the wrong number of parameters are specified in the yaml
   try {
     intrinsics_ = toCvMatx33d(
         node->declare_parameter("virtual_camera_intrinsics", std::vector<double>{1., 0., 0., 0., 1., 0., 0., 0., 1.}));

--- a/spot_driver/src/image_stitcher/image_stitcher_node.cpp
+++ b/spot_driver/src/image_stitcher/image_stitcher_node.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+
+#include <spot_driver/image_stitcher/image_stitcher_node.hpp>
+
+#include <rclcpp/node.hpp>
+#include <spot_driver/interfaces/rclcpp_logger_interface.hpp>
+#include <spot_driver/interfaces/rclcpp_tf_broadcaster_interface.hpp>
+#include <spot_driver/interfaces/rclcpp_tf_listener_interface.hpp>
+
+namespace spot_ros2 {
+ImageStitcherNode::ImageStitcherNode(const rclcpp::NodeOptions& options)
+    : node_{std::make_shared<rclcpp::Node>("image_stitcher", options)},
+      stitcher_{std::make_unique<RclcppCameraSynchronizer>(node_), std::make_unique<RclcppTfListenerInterface>(node_),
+                std::make_unique<RclcppCameraHandle>(node_),
+                std::make_unique<RclcppLoggerInterface>(node_->get_logger())} {}
+
+std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> ImageStitcherNode::get_node_base_interface() {
+  return node_->get_node_base_interface();
+}
+
+}  // namespace spot_ros2

--- a/spot_driver/src/image_stitcher/image_stitcher_node_main.cpp
+++ b/spot_driver/src/image_stitcher/image_stitcher_node_main.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+
+#include <rclcpp/executors/single_threaded_executor.hpp>
+#include <rclcpp/node_options.hpp>
+#include <spot_driver/image_stitcher/image_stitcher_node.hpp>
+
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+  spot_ros2::ImageStitcherNode node{rclcpp::NodeOptions()};
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node.get_node_base_interface());
+  executor.spin();
+  return 0;
+}


### PR DESCRIPTION
## Change Overview

Adds `image_stitcher_node` to `spot_driver` to stitch together the front camera images and publish the stitched image and the transform to the virtual camera.

This node can get launched now when running `spot_driver.launch.py` with the launch argument `stitch_front_images:=True` (it is disabled by default). Default parameters for the image stitcher node have also been added to the example `spot_ros_example.yaml` configuration file.   Users will need to update their configuration files with these values in order to receive any meaningful stitched images as we do not launch the driver with a default configuration file. 

## Testing Done
On robot testing was successfully able to view the stitched image:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Xynj6CBpA3NqqBFfE8Q9/d07a8a81-4c34-4f30-ab5a-4296494abedb.png)

The stitched image comes in at around 1/2 the speed as the standard camera streams on my system. If this is an issue for users we can address it in a future PR. 

The default parameters for the virtual camera were verified as reasonable on 3 different robots (Opal, Lionel, and Pluto). 