### PR TITLE
[N/A] Fixed typo in the `navigate_to` function called by the graphnav

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2740,7 +2740,7 @@ class SpotROS(Node):
             return response
 
         # run navigate_to
-        resp = self.spot_wrapper.spot_graph_nav.navigate_to(
+        resp = self.spot_wrapper.spot_graph_nav._navigate_to(
             upload_path=goal_handle.request.upload_path,
             navigate_to=goal_handle.request.navigate_to,
             initial_localization_fiducial=goal_handle.request.initial_localization_fiducial,


### PR DESCRIPTION
## Change Overview

SpotWrapper's `graphnav` submodule has a `_navigate_to` function that was being mistaken for a `navigate_to` in `spot_ros2.py`. 

Proof:
https://github.com/bdaiinstitute/spot_wrapper/blob/bbca68b679212d78817e2834aeb9e2f0924b4e20/spot_wrapper/spot_graph_nav.py#L504

## Testing Done

None. Potential to test on hardware.
