### PR TITLE
Rename TfInterface classes to TfBroadcasterInterface

### DIFF
--- a/spot_driver/CMakeLists.txt
+++ b/spot_driver/CMakeLists.txt
@@ -55,7 +55,7 @@ add_library(spot_api
   src/interfaces/rclcpp_logger_interface.cpp
   src/interfaces/rclcpp_node_interface.cpp
   src/interfaces/rclcpp_parameter_interface.cpp
-  src/interfaces/rclcpp_tf_interface.cpp
+  src/interfaces/rclcpp_tf_broadcaster_interface.cpp
   src/interfaces/rclcpp_tf_listener_interface.cpp
   src/interfaces/rclcpp_wall_timer_interface.cpp
   src/kinematic/kinematic_node.cpp

--- a/spot_driver/include/spot_driver/images/images_middleware_handle.hpp
+++ b/spot_driver/include/spot_driver/images/images_middleware_handle.hpp
@@ -9,7 +9,7 @@
 #include <spot_driver/images/spot_image_publisher.hpp>
 #include <spot_driver/interfaces/rclcpp_logger_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_parameter_interface.hpp>
-#include <spot_driver/interfaces/rclcpp_tf_interface.hpp>
+#include <spot_driver/interfaces/rclcpp_tf_broadcaster_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_wall_timer_interface.hpp>
 #include <string>
 #include <tl_expected/expected.hpp>

--- a/spot_driver/include/spot_driver/images/spot_image_publisher.hpp
+++ b/spot_driver/include/spot_driver/images/spot_image_publisher.hpp
@@ -12,7 +12,7 @@
 #include <spot_driver/interfaces/image_client_interface.hpp>
 #include <spot_driver/interfaces/logger_interface_base.hpp>
 #include <spot_driver/interfaces/parameter_interface_base.hpp>
-#include <spot_driver/interfaces/tf_interface_base.hpp>
+#include <spot_driver/interfaces/tf_broadcaster_interface_base.hpp>
 #include <spot_driver/interfaces/timer_interface_base.hpp>
 #include <spot_driver/types.hpp>
 #include <string>
@@ -65,8 +65,8 @@ class SpotImagePublisher {
   SpotImagePublisher(const std::shared_ptr<ImageClientInterface>& image_client_interface,
                      std::unique_ptr<MiddlewareHandle> middleware_handle,
                      std::unique_ptr<ParameterInterfaceBase> parameters, std::unique_ptr<LoggerInterfaceBase> logger,
-                     std::unique_ptr<TfInterfaceBase> tf_broadcaster, std::unique_ptr<TimerInterfaceBase> timer,
-                     bool has_arm = false);
+                     std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster,
+                     std::unique_ptr<TimerInterfaceBase> timer, bool has_arm = false);
 
   /**
    * @brief Connect to Spot and start publishing image data.
@@ -97,7 +97,7 @@ class SpotImagePublisher {
 
   std::unique_ptr<ParameterInterfaceBase> parameters_;
   std::unique_ptr<LoggerInterfaceBase> logger_;
-  std::unique_ptr<TfInterfaceBase> tf_broadcaster_;
+  std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_;
   std::unique_ptr<TimerInterfaceBase> timer_;
 
   bool has_arm_;

--- a/spot_driver/include/spot_driver/images/spot_image_publisher_node.hpp
+++ b/spot_driver/include/spot_driver/images/spot_image_publisher_node.hpp
@@ -10,7 +10,7 @@
 #include <spot_driver/interfaces/logger_interface_base.hpp>
 #include <spot_driver/interfaces/node_interface_base.hpp>
 #include <spot_driver/interfaces/parameter_interface_base.hpp>
-#include <spot_driver/interfaces/tf_interface_base.hpp>
+#include <spot_driver/interfaces/tf_broadcaster_interface_base.hpp>
 #include <spot_driver/interfaces/timer_interface_base.hpp>
 
 namespace spot_ros2::images {
@@ -22,7 +22,8 @@ class SpotImagePublisherNode {
   SpotImagePublisherNode(std::unique_ptr<SpotApi> spot_api,
                          std::unique_ptr<SpotImagePublisher::MiddlewareHandle> mw_handle,
                          std::unique_ptr<ParameterInterfaceBase> parameters,
-                         std::unique_ptr<LoggerInterfaceBase> logger, std::unique_ptr<TfInterfaceBase> tf_broadcaster,
+                         std::unique_ptr<LoggerInterfaceBase> logger,
+                         std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster,
                          std::unique_ptr<TimerInterfaceBase> timer,
                          std::unique_ptr<NodeInterfaceBase> node_base_interface);
 
@@ -40,7 +41,8 @@ class SpotImagePublisherNode {
  private:
   void initialize(std::unique_ptr<SpotApi> spot_api, std::unique_ptr<SpotImagePublisher::MiddlewareHandle> mw_handle,
                   std::unique_ptr<ParameterInterfaceBase> parameters, std::unique_ptr<LoggerInterfaceBase> logger,
-                  std::unique_ptr<TfInterfaceBase> tf_broadcaster, std::unique_ptr<TimerInterfaceBase> timer);
+                  std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster,
+                  std::unique_ptr<TimerInterfaceBase> timer);
 
   std::unique_ptr<NodeInterfaceBase> node_base_interface_;
   std::unique_ptr<SpotApi> spot_api_;

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_tf_broadcaster_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_tf_broadcaster_interface.hpp
@@ -5,7 +5,7 @@
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <rclcpp/node.hpp>
-#include <spot_driver/interfaces/tf_interface_base.hpp>
+#include <spot_driver/interfaces/tf_broadcaster_interface_base.hpp>
 
 #include <memory>
 #include <set>
@@ -14,15 +14,15 @@
 
 namespace spot_ros2 {
 /**
- * @brief Implements TfInterfaceBase to use the rclcpp TF system.
+ * @brief Implements TfBroadcasterInterfaceBase to use the rclcpp TF system.
  */
-class RclcppTfInterface : public TfInterfaceBase {
+class RclcppTfBroadcasterInterface : public TfBroadcasterInterfaceBase {
  public:
   /**
-   * @brief The constructor for RclcppTfInterface.
-   * @param node A shared_ptr to a rclcpp node. RclcppTfInterface shares ownership of the shared_ptr.
+   * @brief The constructor for RclcppTfBroadcasterInterface.
+   * @param node A shared_ptr to a rclcpp node. RclcppTfBroadcasterInterface shares ownership of the shared_ptr.
    */
-  explicit RclcppTfInterface(const std::shared_ptr<rclcpp::Node>& node);
+  explicit RclcppTfBroadcasterInterface(const std::shared_ptr<rclcpp::Node>& node);
 
   /**
    * @brief Add new transforms to the StaticTransformBroadcaster.

--- a/spot_driver/include/spot_driver/interfaces/tf_broadcaster_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/tf_broadcaster_interface_base.hpp
@@ -13,16 +13,16 @@ namespace spot_ros2 {
 /**
  * @brief Defines an interface for classes that broadcast transform data.
  */
-class TfInterfaceBase {
+class TfBroadcasterInterfaceBase {
  public:
-  // TfInterfaceBase is move-only
-  TfInterfaceBase() = default;
-  TfInterfaceBase(TfInterfaceBase&& other) = default;
-  TfInterfaceBase(const TfInterfaceBase&) = delete;
-  TfInterfaceBase& operator=(TfInterfaceBase&& other) = default;
-  TfInterfaceBase& operator=(const TfInterfaceBase&) = delete;
+  // TfBroadcasterInterfaceBase is move-only
+  TfBroadcasterInterfaceBase() = default;
+  TfBroadcasterInterfaceBase(TfBroadcasterInterfaceBase&& other) = default;
+  TfBroadcasterInterfaceBase(const TfBroadcasterInterfaceBase&) = delete;
+  TfBroadcasterInterfaceBase& operator=(TfBroadcasterInterfaceBase&& other) = default;
+  TfBroadcasterInterfaceBase& operator=(const TfBroadcasterInterfaceBase&) = delete;
 
-  virtual ~TfInterfaceBase() = default;
+  virtual ~TfBroadcasterInterfaceBase() = default;
 
   virtual void updateStaticTransforms(const std::vector<geometry_msgs::msg::TransformStamped>& transforms) = 0;
 

--- a/spot_driver/include/spot_driver/object_sync/object_synchronizer.hpp
+++ b/spot_driver/include/spot_driver/object_sync/object_synchronizer.hpp
@@ -12,7 +12,7 @@
 #include <spot_driver/interfaces/clock_interface_base.hpp>
 #include <spot_driver/interfaces/logger_interface_base.hpp>
 #include <spot_driver/interfaces/parameter_interface_base.hpp>
-#include <spot_driver/interfaces/tf_interface_base.hpp>
+#include <spot_driver/interfaces/tf_broadcaster_interface_base.hpp>
 #include <spot_driver/interfaces/tf_listener_interface_base.hpp>
 #include <spot_driver/interfaces/timer_interface_base.hpp>
 #include <spot_driver/types.hpp>
@@ -46,7 +46,7 @@ class ObjectSynchronizer {
                      const std::shared_ptr<TimeSyncApi>& time_sync_api,
                      std::unique_ptr<ParameterInterfaceBase> parameter_interface,
                      std::unique_ptr<LoggerInterfaceBase> logger_interface,
-                     std::unique_ptr<TfInterfaceBase> tf_broadcaster_interface,
+                     std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_interface,
                      std::unique_ptr<TfListenerInterfaceBase> tf_listener_interface,
                      std::unique_ptr<TimerInterfaceBase> world_object_update_timer,
                      std::unique_ptr<TimerInterfaceBase> tf_broadcaster_timer,
@@ -98,7 +98,7 @@ class ObjectSynchronizer {
   std::shared_ptr<TimeSyncApi> time_sync_interface_;
   std::unique_ptr<ParameterInterfaceBase> parameter_interface_;
   std::unique_ptr<LoggerInterfaceBase> logger_interface_;
-  std::unique_ptr<TfInterfaceBase> tf_broadcaster_interface_;
+  std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_interface_;
   std::unique_ptr<TfListenerInterfaceBase> tf_listener_interface_;
   std::unique_ptr<TimerInterfaceBase> world_object_update_timer_;
   std::unique_ptr<TimerInterfaceBase> tf_broadcaster_timer_;

--- a/spot_driver/include/spot_driver/object_sync/object_synchronizer_node.hpp
+++ b/spot_driver/include/spot_driver/object_sync/object_synchronizer_node.hpp
@@ -10,7 +10,7 @@
 #include <spot_driver/interfaces/logger_interface_base.hpp>
 #include <spot_driver/interfaces/node_interface_base.hpp>
 #include <spot_driver/interfaces/parameter_interface_base.hpp>
-#include <spot_driver/interfaces/tf_interface_base.hpp>
+#include <spot_driver/interfaces/tf_broadcaster_interface_base.hpp>
 #include <spot_driver/interfaces/tf_listener_interface_base.hpp>
 #include <spot_driver/interfaces/timer_interface_base.hpp>
 #include <spot_driver/object_sync/object_synchronizer.hpp>
@@ -39,7 +39,7 @@ class ObjectSynchronizerNode {
   ObjectSynchronizerNode(std::unique_ptr<NodeInterfaceBase> node_base_interface, std::unique_ptr<SpotApi> spot_api,
                          std::unique_ptr<ParameterInterfaceBase> parameter_interface,
                          std::unique_ptr<LoggerInterfaceBase> logger_interface,
-                         std::unique_ptr<TfInterfaceBase> tf_broadcaster_interface,
+                         std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_interface,
                          std::unique_ptr<TfListenerInterfaceBase> tf_listener_interface,
                          std::unique_ptr<TimerInterfaceBase> world_object_update_timer,
                          std::unique_ptr<TimerInterfaceBase> tf_broadcaster_timer,
@@ -78,7 +78,7 @@ class ObjectSynchronizerNode {
    */
   void initialize(std::unique_ptr<SpotApi> spot_api, std::unique_ptr<ParameterInterfaceBase> parameter_interface,
                   std::unique_ptr<LoggerInterfaceBase> logger_interface,
-                  std::unique_ptr<TfInterfaceBase> tf_broadcaster_interface,
+                  std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_interface,
                   std::unique_ptr<TfListenerInterfaceBase> tf_listener_interface,
                   std::unique_ptr<TimerInterfaceBase> world_object_update_timer,
                   std::unique_ptr<TimerInterfaceBase> tf_broadcaster_timer,

--- a/spot_driver/include/spot_driver/robot_state/state_publisher.hpp
+++ b/spot_driver/include/spot_driver/robot_state/state_publisher.hpp
@@ -9,7 +9,7 @@
 #include <spot_driver/api/time_sync_api.hpp>
 #include <spot_driver/interfaces/logger_interface_base.hpp>
 #include <spot_driver/interfaces/parameter_interface_base.hpp>
-#include <spot_driver/interfaces/tf_interface_base.hpp>
+#include <spot_driver/interfaces/tf_broadcaster_interface_base.hpp>
 #include <spot_driver/interfaces/timer_interface_base.hpp>
 #include <spot_driver/types.hpp>
 
@@ -42,14 +42,15 @@ class StatePublisher {
    * @param parameter_interface Retrieves runtime-configurable settings, such as the preferred base frame.
    * @param logger_interface Logs error messages if requesting, processing, and publishing the robot state info does not
    * succeed.
-   * @param tf_interface Publishes the dynamic transforms in Spot's robot state to TF.
+   * @param tf_broadcaster_interface Publishes the dynamic transforms in Spot's robot state to TF.
    * @param timer_interface Repeatedly triggers timerCallback() using the middleware's clock.
    *
    */
   StatePublisher(const std::shared_ptr<StateClientInterface>& state_client_interface,
                  const std::shared_ptr<TimeSyncApi>& time_sync_api, std::unique_ptr<MiddlewareHandle> middleware_handle,
                  std::unique_ptr<ParameterInterfaceBase> parameter_interface,
-                 std::unique_ptr<LoggerInterfaceBase> logger_interface, std::unique_ptr<TfInterfaceBase> tf_interface,
+                 std::unique_ptr<LoggerInterfaceBase> logger_interface,
+                 std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_interface,
                  std::unique_ptr<TimerInterfaceBase> timer_interface);
 
  private:
@@ -70,7 +71,7 @@ class StatePublisher {
   std::unique_ptr<MiddlewareHandle> middleware_handle_;
   std::unique_ptr<ParameterInterfaceBase> parameter_interface_;
   std::unique_ptr<LoggerInterfaceBase> logger_interface_;
-  std::unique_ptr<TfInterfaceBase> tf_interface_;
+  std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_interface_;
   std::unique_ptr<TimerInterfaceBase> timer_interface_;
 };
 }  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/robot_state/state_publisher_node.hpp
+++ b/spot_driver/include/spot_driver/robot_state/state_publisher_node.hpp
@@ -7,7 +7,7 @@
 #include <spot_driver/api/spot_api.hpp>
 #include <spot_driver/interfaces/logger_interface_base.hpp>
 #include <spot_driver/interfaces/parameter_interface_base.hpp>
-#include <spot_driver/interfaces/tf_interface_base.hpp>
+#include <spot_driver/interfaces/tf_broadcaster_interface_base.hpp>
 #include <spot_driver/interfaces/timer_interface_base.hpp>
 #include <spot_driver/robot_state/state_publisher.hpp>
 
@@ -32,7 +32,7 @@ class StatePublisherNode {
    * @param parameter_interface Retrieves runtime configuration settings needed to connect to and communicate with Spot.
    * @param logger_interface Logs error messages if requesting, processing, and publishing the robot state info does not
    * succeed.
-   * @param tf_interface Publishes the dynamic transforms in Spot's robot state to TF.
+   * @param tf_broadcaster_interface Publishes the dynamic transforms in Spot's robot state to TF.
    * @param timer_interface Repeatedly triggers timerCallback() using the middleware's clock.
    *
    */
@@ -40,7 +40,7 @@ class StatePublisherNode {
                      std::unique_ptr<StatePublisher::MiddlewareHandle> middleware_handle,
                      std::unique_ptr<ParameterInterfaceBase> parameter_interface,
                      std::unique_ptr<LoggerInterfaceBase> logger_interface,
-                     std::unique_ptr<TfInterfaceBase> tf_interface,
+                     std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_interface,
                      std::unique_ptr<TimerInterfaceBase> timer_interface);
 
   /**
@@ -72,7 +72,7 @@ class StatePublisherNode {
    * @param parameter_interface Retrieves runtime configuration settings needed to connect to and communicate with Spot.
    * @param logger_interface Logs error messages if requesting, processing, and publishing the robot state info does not
    * succeed.
-   * @param tf_interface Publishes the dynamic transforms in Spot's robot state to TF.
+   * @param tf_broadcaster_interface Publishes the dynamic transforms in Spot's robot state to TF.
    * @param timer_interface Repeatedly triggers timerCallback() using the middleware's clock.
    *
    * @throw std::runtime_error if the Spot API fails to create a connection to Spot or fails to authenticate with Spot.
@@ -80,7 +80,8 @@ class StatePublisherNode {
   void initialize(std::unique_ptr<SpotApi> spot_api,
                   std::unique_ptr<StatePublisher::MiddlewareHandle> middleware_handle,
                   std::unique_ptr<ParameterInterfaceBase> parameter_interface,
-                  std::unique_ptr<LoggerInterfaceBase> logger_interface, std::unique_ptr<TfInterfaceBase> tf_interface,
+                  std::unique_ptr<LoggerInterfaceBase> logger_interface,
+                  std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_interface,
                   std::unique_ptr<TimerInterfaceBase> timer_interface);
 
   std::unique_ptr<NodeInterfaceBase> node_base_interface_;

--- a/spot_driver/src/images/images_middleware_handle.cpp
+++ b/spot_driver/src/images/images_middleware_handle.cpp
@@ -5,7 +5,7 @@
 #include <spot_driver/images/images_middleware_handle.hpp>
 #include <spot_driver/interfaces/rclcpp_logger_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_parameter_interface.hpp>
-#include <spot_driver/interfaces/rclcpp_tf_interface.hpp>
+#include <spot_driver/interfaces/rclcpp_tf_broadcaster_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_wall_timer_interface.hpp>
 
 namespace {

--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -11,7 +11,7 @@
 #include <spot_driver/images/images_middleware_handle.hpp>
 #include <spot_driver/interfaces/rclcpp_logger_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_parameter_interface.hpp>
-#include <spot_driver/interfaces/rclcpp_tf_interface.hpp>
+#include <spot_driver/interfaces/rclcpp_tf_broadcaster_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_wall_timer_interface.hpp>
 #include <spot_driver/types.hpp>
 
@@ -65,7 +65,7 @@ SpotImagePublisher::SpotImagePublisher(const std::shared_ptr<ImageClientInterfac
                                        std::unique_ptr<MiddlewareHandle> middleware_handle,
                                        std::unique_ptr<ParameterInterfaceBase> parameters,
                                        std::unique_ptr<LoggerInterfaceBase> logger,
-                                       std::unique_ptr<TfInterfaceBase> tf_broadcaster,
+                                       std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster,
                                        std::unique_ptr<TimerInterfaceBase> timer, bool has_arm)
     : image_client_interface_{image_client_interface},
       middleware_handle_{std::move(middleware_handle)},

--- a/spot_driver/src/images/spot_image_publisher_node.cpp
+++ b/spot_driver/src/images/spot_image_publisher_node.cpp
@@ -9,7 +9,7 @@
 #include <spot_driver/interfaces/rclcpp_logger_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_node_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_parameter_interface.hpp>
-#include <spot_driver/interfaces/rclcpp_tf_interface.hpp>
+#include <spot_driver/interfaces/rclcpp_tf_broadcaster_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_wall_timer_interface.hpp>
 
 namespace {
@@ -21,7 +21,7 @@ SpotImagePublisherNode::SpotImagePublisherNode(std::unique_ptr<SpotApi> spot_api
                                                std::unique_ptr<SpotImagePublisher::MiddlewareHandle> mw_handle,
                                                std::unique_ptr<ParameterInterfaceBase> parameters,
                                                std::unique_ptr<LoggerInterfaceBase> logger,
-                                               std::unique_ptr<TfInterfaceBase> tf_broadcaster,
+                                               std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster,
                                                std::unique_ptr<TimerInterfaceBase> timer,
                                                std::unique_ptr<NodeInterfaceBase> node_base_interface)
     : node_base_interface_{std::move(node_base_interface)} {
@@ -37,7 +37,7 @@ SpotImagePublisherNode::SpotImagePublisherNode(const rclcpp::NodeOptions& node_o
   auto mw_handle = std::make_unique<ImagesMiddlewareHandle>(node_options);
   auto parameters = std::make_unique<RclcppParameterInterface>(node);
   auto logger = std::make_unique<RclcppLoggerInterface>(node->get_logger());
-  auto tf_broadcaster = std::make_unique<RclcppTfInterface>(node);
+  auto tf_broadcaster = std::make_unique<RclcppTfBroadcasterInterface>(node);
   auto timer = std::make_unique<RclcppWallTimerInterface>(node);
 
   initialize(std::move(spot_api), std::move(mw_handle), std::move(parameters), std::move(logger),
@@ -48,7 +48,7 @@ void SpotImagePublisherNode::initialize(std::unique_ptr<SpotApi> spot_api,
                                         std::unique_ptr<SpotImagePublisher::MiddlewareHandle> mw_handle,
                                         std::unique_ptr<ParameterInterfaceBase> parameters,
                                         std::unique_ptr<LoggerInterfaceBase> logger,
-                                        std::unique_ptr<TfInterfaceBase> tf_broadcaster,
+                                        std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster,
                                         std::unique_ptr<TimerInterfaceBase> timer) {
   spot_api_ = std::move(spot_api);
 

--- a/spot_driver/src/interfaces/rclcpp_tf_broadcaster_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_tf_broadcaster_interface.cpp
@@ -1,12 +1,13 @@
 // Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
 
-#include <spot_driver/interfaces/rclcpp_tf_interface.hpp>
+#include <spot_driver/interfaces/rclcpp_tf_broadcaster_interface.hpp>
 
 namespace spot_ros2 {
-RclcppTfInterface::RclcppTfInterface(const std::shared_ptr<rclcpp::Node>& node)
+RclcppTfBroadcasterInterface::RclcppTfBroadcasterInterface(const std::shared_ptr<rclcpp::Node>& node)
     : static_tf_broadcaster_{node}, dynamic_tf_broadcaster_{node} {}
 
-void RclcppTfInterface::updateStaticTransforms(const std::vector<geometry_msgs::msg::TransformStamped>& transforms) {
+void RclcppTfBroadcasterInterface::updateStaticTransforms(
+    const std::vector<geometry_msgs::msg::TransformStamped>& transforms) {
   bool has_new_frame = false;
   for (const auto& transform : transforms) {
     // If one of the transforms is to a new child frame, flag that a new transform needs to be published and add the
@@ -24,7 +25,8 @@ void RclcppTfInterface::updateStaticTransforms(const std::vector<geometry_msgs::
   }
 }
 
-void RclcppTfInterface::sendDynamicTransforms(const std::vector<geometry_msgs::msg::TransformStamped>& transforms) {
+void RclcppTfBroadcasterInterface::sendDynamicTransforms(
+    const std::vector<geometry_msgs::msg::TransformStamped>& transforms) {
   dynamic_tf_broadcaster_.sendTransform(transforms);
 }
 

--- a/spot_driver/src/object_sync/object_synchronizer.cpp
+++ b/spot_driver/src/object_sync/object_synchronizer.cpp
@@ -315,7 +315,7 @@ ObjectSynchronizer::ObjectSynchronizer(const std::shared_ptr<WorldObjectClientIn
                                        const std::shared_ptr<TimeSyncApi>& time_sync_api,
                                        std::unique_ptr<ParameterInterfaceBase> parameter_interface,
                                        std::unique_ptr<LoggerInterfaceBase> logger_interface,
-                                       std::unique_ptr<TfInterfaceBase> tf_broadcaster_interface,
+                                       std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_interface,
                                        std::unique_ptr<TfListenerInterfaceBase> tf_listener_interface,
                                        std::unique_ptr<TimerInterfaceBase> world_object_update_timer,
                                        std::unique_ptr<TimerInterfaceBase> tf_broadcaster_timer,

--- a/spot_driver/src/object_sync/object_synchronizer_node.cpp
+++ b/spot_driver/src/object_sync/object_synchronizer_node.cpp
@@ -8,7 +8,7 @@
 #include <spot_driver/interfaces/rclcpp_logger_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_node_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_parameter_interface.hpp>
-#include <spot_driver/interfaces/rclcpp_tf_interface.hpp>
+#include <spot_driver/interfaces/rclcpp_tf_broadcaster_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_tf_listener_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_wall_timer_interface.hpp>
 #include <spot_driver/object_sync/object_synchronizer.hpp>
@@ -24,7 +24,7 @@ ObjectSynchronizerNode::ObjectSynchronizerNode(std::unique_ptr<NodeInterfaceBase
                                                std::unique_ptr<SpotApi> spot_api,
                                                std::unique_ptr<ParameterInterfaceBase> parameter_interface,
                                                std::unique_ptr<LoggerInterfaceBase> logger_interface,
-                                               std::unique_ptr<TfInterfaceBase> tf_broadcaster_interface,
+                                               std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_interface,
                                                std::unique_ptr<TfListenerInterfaceBase> tf_listener_interface,
                                                std::unique_ptr<TimerInterfaceBase> world_object_update_timer,
                                                std::unique_ptr<TimerInterfaceBase> tf_broadcaster_timer,
@@ -43,7 +43,7 @@ ObjectSynchronizerNode::ObjectSynchronizerNode(const rclcpp::NodeOptions& node_o
   auto mw_handle = std::make_unique<StateMiddlewareHandle>(node);
   auto parameter_interface = std::make_unique<RclcppParameterInterface>(node);
   auto logger_interface = std::make_unique<RclcppLoggerInterface>(node->get_logger());
-  auto tf_broadcaster_interface = std::make_unique<RclcppTfInterface>(node);
+  auto tf_broadcaster_interface = std::make_unique<RclcppTfBroadcasterInterface>(node);
   auto tf_listener_interface = std::make_unique<RclcppTfListenerInterface>(node);
   auto world_object_update_timer = std::make_unique<RclcppWallTimerInterface>(node);
   auto tf_broadcaster_timer = std::make_unique<RclcppWallTimerInterface>(node);
@@ -57,7 +57,7 @@ ObjectSynchronizerNode::ObjectSynchronizerNode(const rclcpp::NodeOptions& node_o
 void ObjectSynchronizerNode::initialize(std::unique_ptr<SpotApi> spot_api,
                                         std::unique_ptr<ParameterInterfaceBase> parameter_interface,
                                         std::unique_ptr<LoggerInterfaceBase> logger_interface,
-                                        std::unique_ptr<TfInterfaceBase> tf_broadcaster_interface,
+                                        std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_interface,
                                         std::unique_ptr<TfListenerInterfaceBase> tf_listener_interface,
                                         std::unique_ptr<TimerInterfaceBase> world_object_update_timer,
                                         std::unique_ptr<TimerInterfaceBase> tf_broadcaster_timer,

--- a/spot_driver/src/robot_state/state_publisher.cpp
+++ b/spot_driver/src/robot_state/state_publisher.cpp
@@ -20,7 +20,7 @@ StatePublisher::StatePublisher(const std::shared_ptr<StateClientInterface>& stat
                                std::unique_ptr<MiddlewareHandle> middleware_handle,
                                std::unique_ptr<ParameterInterfaceBase> parameter_interface,
                                std::unique_ptr<LoggerInterfaceBase> logger_interface,
-                               std::unique_ptr<TfInterfaceBase> tf_interface,
+                               std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_interface,
                                std::unique_ptr<TimerInterfaceBase> timer_interface)
     : is_using_vision_{false},
       state_client_interface_{state_client_interface},
@@ -28,7 +28,7 @@ StatePublisher::StatePublisher(const std::shared_ptr<StateClientInterface>& stat
       middleware_handle_{std::move(middleware_handle)},
       parameter_interface_{std::move(parameter_interface)},
       logger_interface_{std::move(logger_interface)},
-      tf_interface_{std::move(tf_interface)},
+      tf_broadcaster_interface_{std::move(tf_broadcaster_interface)},
       timer_interface_{std::move(timer_interface)} {
   const auto spot_name = parameter_interface_->getSpotName();
   frame_prefix_ = spot_name.empty() ? "" : spot_name + "/";
@@ -79,7 +79,7 @@ void StatePublisher::timerCallback() {
   middleware_handle_->publishRobotState(robot_state_messages);
 
   if (robot_state_messages.maybe_tf) {
-    tf_interface_->sendDynamicTransforms(robot_state_messages.maybe_tf->transforms);
+    tf_broadcaster_interface_->sendDynamicTransforms(robot_state_messages.maybe_tf->transforms);
   }
 }
 

--- a/spot_driver/src/robot_state/state_publisher_node.cpp
+++ b/spot_driver/src/robot_state/state_publisher_node.cpp
@@ -10,7 +10,7 @@
 #include <spot_driver/interfaces/rclcpp_logger_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_node_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_parameter_interface.hpp>
-#include <spot_driver/interfaces/rclcpp_tf_interface.hpp>
+#include <spot_driver/interfaces/rclcpp_tf_broadcaster_interface.hpp>
 #include <spot_driver/interfaces/rclcpp_wall_timer_interface.hpp>
 #include <spot_driver/robot_state/state_middleware_handle.hpp>
 
@@ -25,11 +25,11 @@ StatePublisherNode::StatePublisherNode(std::unique_ptr<NodeInterfaceBase> node_b
                                        std::unique_ptr<StatePublisher::MiddlewareHandle> middleware_handle,
                                        std::unique_ptr<ParameterInterfaceBase> parameter_interface,
                                        std::unique_ptr<LoggerInterfaceBase> logger_interface,
-                                       std::unique_ptr<TfInterfaceBase> tf_interface,
+                                       std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_interface,
                                        std::unique_ptr<TimerInterfaceBase> timer_interface)
     : node_base_interface_{std::move(node_base_interface)} {
   initialize(std::move(spot_api), std::move(middleware_handle), std::move(parameter_interface),
-             std::move(logger_interface), std::move(tf_interface), std::move(timer_interface));
+             std::move(logger_interface), std::move(tf_broadcaster_interface), std::move(timer_interface));
 }
 
 StatePublisherNode::StatePublisherNode(const rclcpp::NodeOptions& node_options) {
@@ -40,18 +40,18 @@ StatePublisherNode::StatePublisherNode(const rclcpp::NodeOptions& node_options) 
   auto mw_handle = std::make_unique<StateMiddlewareHandle>(node);
   auto parameter_interface = std::make_unique<RclcppParameterInterface>(node);
   auto logger_interface = std::make_unique<RclcppLoggerInterface>(node->get_logger());
-  auto tf_interface = std::make_unique<RclcppTfInterface>(node);
+  auto tf_broadcaster_interface = std::make_unique<RclcppTfBroadcasterInterface>(node);
   auto timer_interface = std::make_unique<RclcppWallTimerInterface>(node);
 
   initialize(std::move(spot_api), std::move(mw_handle), std::move(parameter_interface), std::move(logger_interface),
-             std::move(tf_interface), std::move(timer_interface));
+             std::move(tf_broadcaster_interface), std::move(timer_interface));
 }
 
 void StatePublisherNode::initialize(std::unique_ptr<SpotApi> spot_api,
                                     std::unique_ptr<StatePublisher::MiddlewareHandle> middleware_handle,
                                     std::unique_ptr<ParameterInterfaceBase> parameter_interface,
                                     std::unique_ptr<LoggerInterfaceBase> logger_interface,
-                                    std::unique_ptr<TfInterfaceBase> tf_interface,
+                                    std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_interface,
                                     std::unique_ptr<TimerInterfaceBase> timer_interface) {
   spot_api_ = std::move(spot_api);
 
@@ -73,9 +73,10 @@ void StatePublisherNode::initialize(std::unique_ptr<SpotApi> spot_api,
     throw std::runtime_error(error_msg);
   }
 
-  internal_ = std::make_unique<StatePublisher>(
-      spot_api_->stateClientInterface(), spot_api_->timeSyncInterface(), std::move(middleware_handle),
-      std::move(parameter_interface), std::move(logger_interface), std::move(tf_interface), std::move(timer_interface));
+  internal_ = std::make_unique<StatePublisher>(spot_api_->stateClientInterface(), spot_api_->timeSyncInterface(),
+                                               std::move(middleware_handle), std::move(parameter_interface),
+                                               std::move(logger_interface), std::move(tf_broadcaster_interface),
+                                               std::move(timer_interface));
 }
 
 std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface> StatePublisherNode::get_node_base_interface() {

--- a/spot_driver/test/include/spot_driver/mock/mock_tf_broadcaster_interface.hpp
+++ b/spot_driver/test/include/spot_driver/mock/mock_tf_broadcaster_interface.hpp
@@ -5,11 +5,11 @@
 #include <gmock/gmock.h>
 
 #include <geometry_msgs/msg/transform_stamped.hpp>
-#include <spot_driver/interfaces/tf_interface_base.hpp>
+#include <spot_driver/interfaces/tf_broadcaster_interface_base.hpp>
 #include <vector>
 
 namespace spot_ros2::test {
-class MockTfInterface : public TfInterfaceBase {
+class MockTfBroadcasterInterface : public TfBroadcasterInterfaceBase {
  public:
   MOCK_METHOD(void, updateStaticTransforms, (const std::vector<geometry_msgs::msg::TransformStamped>& transforms),
               (override));

--- a/spot_driver/test/src/images/test_spot_image_publisher.cpp
+++ b/spot_driver/test/src/images/test_spot_image_publisher.cpp
@@ -11,7 +11,7 @@
 #include <spot_driver/mock/mock_logger_interface.hpp>
 #include <spot_driver/mock/mock_node_interface.hpp>
 #include <spot_driver/mock/mock_spot_api.hpp>
-#include <spot_driver/mock/mock_tf_interface.hpp>
+#include <spot_driver/mock/mock_tf_broadcaster_interface.hpp>
 #include <spot_driver/mock/mock_timer_interface.hpp>
 
 #include <memory>
@@ -40,20 +40,21 @@ class TestInitSpotImagePublisher : public ::testing::Test {
     middleware_handle = std::make_unique<MockMiddlewareHandle>();
     fake_parameter_interface = std::make_unique<FakeParameterInterface>();
     mock_logger_interface = std::make_unique<spot_ros2::test::MockLoggerInterface>();
-    mock_tf_interface = std::make_unique<MockTfInterface>();
+    mock_tf_broadcaster_interface = std::make_unique<MockTfBroadcasterInterface>();
     mock_timer_interface = std::make_unique<MockTimerInterface>();
 
     middleware_handle_ptr = middleware_handle.get();
     fake_parameter_interface_ptr = fake_parameter_interface.get();
     mock_logger_interface_ptr = mock_logger_interface.get();
-    mock_tf_interface_ptr = mock_tf_interface.get();
+    mock_tf_broadcaster_interface_ptr = mock_tf_broadcaster_interface.get();
     mock_timer_interface_ptr = mock_timer_interface.get();
   }
 
   void createImagePublisher(bool has_arm) {
     image_publisher = std::make_unique<images::SpotImagePublisher>(
         image_client_interface, std::move(middleware_handle), std::move(fake_parameter_interface),
-        std::move(mock_logger_interface), std::move(mock_tf_interface), std::move(mock_timer_interface), has_arm);
+        std::move(mock_logger_interface), std::move(mock_tf_broadcaster_interface), std::move(mock_timer_interface),
+        has_arm);
   }
 
   std::unique_ptr<images::SpotImagePublisher> image_publisher;
@@ -62,13 +63,13 @@ class TestInitSpotImagePublisher : public ::testing::Test {
   std::unique_ptr<MockMiddlewareHandle> middleware_handle;
   std::unique_ptr<FakeParameterInterface> fake_parameter_interface;
   std::unique_ptr<MockLoggerInterface> mock_logger_interface;
-  std::unique_ptr<spot_ros2::test::MockTfInterface> mock_tf_interface;
+  std::unique_ptr<spot_ros2::test::MockTfBroadcasterInterface> mock_tf_broadcaster_interface;
   std::unique_ptr<spot_ros2::test::MockTimerInterface> mock_timer_interface;
 
   MockMiddlewareHandle* middleware_handle_ptr = nullptr;
   FakeParameterInterface* fake_parameter_interface_ptr = nullptr;
   MockLoggerInterface* mock_logger_interface_ptr = nullptr;
-  MockTfInterface* mock_tf_interface_ptr = nullptr;
+  MockTfBroadcasterInterface* mock_tf_broadcaster_interface_ptr = nullptr;
   MockTimerInterface* mock_timer_interface_ptr = nullptr;
 };
 
@@ -112,7 +113,7 @@ TEST_F(TestRunSpotImagePublisher, PublishCallbackTriggersWithArm) {
     InSequence seq;
     EXPECT_CALL(*image_client_interface, getImages(Property(&::bosdyn::api::GetImageRequest::image_requests_size, 18)));
     EXPECT_CALL(*middleware_handle, publishImages);
-    EXPECT_CALL(*mock_tf_interface_ptr, updateStaticTransforms);
+    EXPECT_CALL(*mock_tf_broadcaster_interface_ptr, updateStaticTransforms);
   }
 
   // GIVEN an image_publisher
@@ -148,7 +149,7 @@ TEST_F(TestRunSpotImagePublisher, PublishCallbackTriggersWithNoArm) {
     InSequence seq;
     EXPECT_CALL(*image_client_interface, getImages(Property(&::bosdyn::api::GetImageRequest::image_requests_size, 15)));
     EXPECT_CALL(*middleware_handle, publishImages);
-    EXPECT_CALL(*mock_tf_interface_ptr, updateStaticTransforms);
+    EXPECT_CALL(*mock_tf_broadcaster_interface_ptr, updateStaticTransforms);
   }
 
   // GIVEN an image publisher not expected to publish camera data

--- a/spot_driver/test/src/images/test_spot_image_publisher_node.cpp
+++ b/spot_driver/test/src/images/test_spot_image_publisher_node.cpp
@@ -11,7 +11,7 @@
 #include <spot_driver/mock/mock_logger_interface.hpp>
 #include <spot_driver/mock/mock_node_interface.hpp>
 #include <spot_driver/mock/mock_spot_api.hpp>
-#include <spot_driver/mock/mock_tf_interface.hpp>
+#include <spot_driver/mock/mock_tf_broadcaster_interface.hpp>
 #include <spot_driver/mock/mock_timer_interface.hpp>
 
 #include <rclcpp/node.hpp>
@@ -41,7 +41,7 @@ class SpotImagePubNodeTestFixture : public ::testing::Test {
 
     fake_parameter_interface = std::make_unique<FakeParameterInterface>();
     mock_logger_interface = std::make_unique<spot_ros2::test::MockLoggerInterface>();
-    mock_tf_interface = std::make_unique<MockTfInterface>();
+    mock_tf_broadcaster_interface = std::make_unique<MockTfBroadcasterInterface>();
     mock_timer_interface = std::make_unique<MockTimerInterface>();
     mock_node_interface = std::make_unique<MockNodeInterface>();
   }
@@ -51,7 +51,7 @@ class SpotImagePubNodeTestFixture : public ::testing::Test {
 
   std::unique_ptr<FakeParameterInterface> fake_parameter_interface;
   std::unique_ptr<MockLoggerInterface> mock_logger_interface;
-  std::unique_ptr<spot_ros2::test::MockTfInterface> mock_tf_interface;
+  std::unique_ptr<spot_ros2::test::MockTfBroadcasterInterface> mock_tf_broadcaster_interface;
   std::unique_ptr<spot_ros2::test::MockTimerInterface> mock_timer_interface;
   std::unique_ptr<MockNodeInterface> mock_node_interface;
 };
@@ -75,8 +75,8 @@ TEST_F(SpotImagePubNodeTestFixture, ConstructionSuccess) {
   std::unique_ptr<images::SpotImagePublisherNode> node;
   ASSERT_NO_THROW(node = std::make_unique<images::SpotImagePublisherNode>(
                       std::move(mock_spot_api), std::move(mock_middleware_handle), std::move(fake_parameter_interface),
-                      std::move(mock_logger_interface), std::move(mock_tf_interface), std::move(mock_timer_interface),
-                      std::move(mock_node_interface)));
+                      std::move(mock_logger_interface), std::move(mock_tf_broadcaster_interface),
+                      std::move(mock_timer_interface), std::move(mock_node_interface)));
 
   // WHEN we get the underlying node base interface
   // THEN no exception is thrown
@@ -96,7 +96,7 @@ TEST_F(SpotImagePubNodeTestFixture, ConstructionCreateRobotFailure) {
   // THEN the constructor throws
   EXPECT_THROW(images::SpotImagePublisherNode(std::move(mock_spot_api), std::move(mock_middleware_handle),
                                               std::move(fake_parameter_interface), std::move(mock_logger_interface),
-                                              std::move(mock_tf_interface), std::move(mock_timer_interface),
+                                              std::move(mock_tf_broadcaster_interface), std::move(mock_timer_interface),
                                               std::move(mock_node_interface)),
                std::runtime_error);
 }
@@ -116,7 +116,7 @@ TEST_F(SpotImagePubNodeTestFixture, ConstructionAuthenticationFailure) {
   // THEN the constructor throws
   EXPECT_THROW(images::SpotImagePublisherNode(std::move(mock_spot_api), std::move(mock_middleware_handle),
                                               std::move(fake_parameter_interface), std::move(mock_logger_interface),
-                                              std::move(mock_tf_interface), std::move(mock_timer_interface),
+                                              std::move(mock_tf_broadcaster_interface), std::move(mock_timer_interface),
                                               std::move(mock_node_interface)),
                std::runtime_error);
 }
@@ -134,7 +134,7 @@ TEST_F(SpotImagePubNodeTestFixture, ConstructionHasArmFailure) {
   // THEN the constructor throws
   EXPECT_THROW(images::SpotImagePublisherNode(std::move(mock_spot_api), std::move(mock_middleware_handle),
                                               std::move(fake_parameter_interface), std::move(mock_logger_interface),
-                                              std::move(mock_tf_interface), std::move(mock_timer_interface),
+                                              std::move(mock_tf_broadcaster_interface), std::move(mock_timer_interface),
                                               std::move(mock_node_interface)),
                std::runtime_error);
 }

--- a/spot_driver/test/src/robot_state/test_state_publisher.cpp
+++ b/spot_driver/test/src/robot_state/test_state_publisher.cpp
@@ -12,7 +12,7 @@
 #include <spot_driver/mock/mock_node_interface.hpp>
 #include <spot_driver/mock/mock_state_client.hpp>
 #include <spot_driver/mock/mock_state_publisher_middleware_handle.hpp>
-#include <spot_driver/mock/mock_tf_interface.hpp>
+#include <spot_driver/mock/mock_tf_broadcaster_interface.hpp>
 #include <spot_driver/mock/mock_time_sync_api.hpp>
 #include <spot_driver/mock/mock_timer_interface.hpp>
 #include <spot_driver/robot_state/state_publisher.hpp>
@@ -43,14 +43,14 @@ class StatePublisherTest : public ::testing::Test {
 
     fake_parameter_interface = std::make_unique<FakeParameterInterface>();
     mock_logger_interface = std::make_unique<spot_ros2::test::MockLoggerInterface>();
-    mock_tf_interface = std::make_unique<spot_ros2::test::MockTfInterface>();
+    mock_tf_broadcaster_interface = std::make_unique<spot_ros2::test::MockTfBroadcasterInterface>();
     mock_timer_interface = std::make_unique<spot_ros2::test::MockTimerInterface>();
   }
 
   std::unique_ptr<MockNodeInterface> mock_node_interface;
   std::unique_ptr<FakeParameterInterface> fake_parameter_interface;
   std::unique_ptr<MockLoggerInterface> mock_logger_interface;
-  std::unique_ptr<MockTfInterface> mock_tf_interface;
+  std::unique_ptr<MockTfBroadcasterInterface> mock_tf_broadcaster_interface;
   std::unique_ptr<MockTimerInterface> mock_timer_interface;
 
   std::shared_ptr<spot_ros2::test::MockStateClient> mock_state_client_interface =
@@ -86,7 +86,7 @@ TEST_F(StatePublisherTest, InitSucceeds) {
   // WHEN a robot state publisher is constructed
   robot_state_publisher = std::make_unique<StatePublisher>(
       mock_state_client_interface, mock_time_sync_api, std::move(mock_middleware_handle),
-      std::move(fake_parameter_interface), std::move(mock_logger_interface), std::move(mock_tf_interface),
+      std::move(fake_parameter_interface), std::move(mock_logger_interface), std::move(mock_tf_broadcaster_interface),
       std::move(mock_timer_interface));
 }
 
@@ -108,13 +108,13 @@ TEST_F(StatePublisherTest, PublishCallbackTriggers) {
     // AND THEN we publish the robot state to the appropriate topics
     EXPECT_CALL(*mock_middleware_handle, publishRobotState).Times(1);
     // AND THEN the robot transforms are published to TF
-    EXPECT_CALL(*mock_tf_interface, sendDynamicTransforms).Times(1);
+    EXPECT_CALL(*mock_tf_broadcaster_interface, sendDynamicTransforms).Times(1);
   }
 
   // GIVEN a robot_state_publisher
   robot_state_publisher = std::make_unique<StatePublisher>(
       mock_state_client_interface, mock_time_sync_api, std::move(mock_middleware_handle),
-      std::move(fake_parameter_interface), std::move(mock_logger_interface), std::move(mock_tf_interface),
+      std::move(fake_parameter_interface), std::move(mock_logger_interface), std::move(mock_tf_broadcaster_interface),
       std::move(mock_timer_interface));
 
   // WHEN the timer callback is triggered
@@ -141,12 +141,12 @@ TEST_F(StatePublisherTest, PublishCallbackTriggersNoTfData) {
   }
 
   // THEN no transforms are published to TF
-  EXPECT_CALL(*mock_tf_interface, sendDynamicTransforms).Times(0);
+  EXPECT_CALL(*mock_tf_broadcaster_interface, sendDynamicTransforms).Times(0);
 
   // GIVEN a robot_state_publisher
   robot_state_publisher = std::make_unique<StatePublisher>(
       mock_state_client_interface, mock_time_sync_api, std::move(mock_middleware_handle),
-      std::move(fake_parameter_interface), std::move(mock_logger_interface), std::move(mock_tf_interface),
+      std::move(fake_parameter_interface), std::move(mock_logger_interface), std::move(mock_tf_broadcaster_interface),
       std::move(mock_timer_interface));
 
   // WHEN the timer callback is triggered
@@ -178,12 +178,12 @@ TEST_F(StatePublisherTest, PublishCallbackTriggersFailGetRobotState) {
   // THEN we do not publish a robot state
   EXPECT_CALL(*mock_middleware_handle, publishRobotState).Times(0);
   // THEN we do not publish to TF
-  EXPECT_CALL(*mock_tf_interface, sendDynamicTransforms).Times(0);
+  EXPECT_CALL(*mock_tf_broadcaster_interface, sendDynamicTransforms).Times(0);
 
   // GIVEN a robot_state_publisher
   robot_state_publisher = std::make_unique<StatePublisher>(
       mock_state_client_interface, mock_time_sync_api, std::move(mock_middleware_handle),
-      std::move(fake_parameter_interface), std::move(mock_logger_interface), std::move(mock_tf_interface),
+      std::move(fake_parameter_interface), std::move(mock_logger_interface), std::move(mock_tf_broadcaster_interface),
       std::move(mock_timer_interface));
 
   // WHEN the timer callback is triggered
@@ -210,12 +210,12 @@ TEST_F(StatePublisherTest, PublishCallbackTriggersFailGetClockSkew) {
   // THEN we do not publish a robot state
   EXPECT_CALL(*mock_middleware_handle, publishRobotState).Times(0);
   // THEN we do not publish to TF
-  EXPECT_CALL(*mock_tf_interface, sendDynamicTransforms).Times(0);
+  EXPECT_CALL(*mock_tf_broadcaster_interface, sendDynamicTransforms).Times(0);
 
   // GIVEN a robot_state_publisher
   robot_state_publisher = std::make_unique<StatePublisher>(
       mock_state_client_interface, mock_time_sync_api, std::move(mock_middleware_handle),
-      std::move(fake_parameter_interface), std::move(mock_logger_interface), std::move(mock_tf_interface),
+      std::move(fake_parameter_interface), std::move(mock_logger_interface), std::move(mock_tf_broadcaster_interface),
       std::move(mock_timer_interface));
 
   // WHEN the timer callback is triggered

--- a/spot_driver/test/src/robot_state/test_state_publisher_node.cpp
+++ b/spot_driver/test/src/robot_state/test_state_publisher_node.cpp
@@ -12,7 +12,7 @@
 #include <spot_driver/mock/mock_spot_api.hpp>
 #include <spot_driver/mock/mock_state_client.hpp>
 #include <spot_driver/mock/mock_state_publisher_middleware_handle.hpp>
-#include <spot_driver/mock/mock_tf_interface.hpp>
+#include <spot_driver/mock/mock_tf_broadcaster_interface.hpp>
 #include <spot_driver/mock/mock_time_sync_api.hpp>
 #include <spot_driver/mock/mock_timer_interface.hpp>
 #include <spot_driver/robot_state/state_publisher_node.hpp>
@@ -33,7 +33,7 @@ class StatePublisherNodeTest : public ::testing::Test {
 
     fake_parameter_interface = std::make_unique<FakeParameterInterface>();
     mock_logger_interface = std::make_unique<MockLoggerInterface>();
-    mock_tf_interface = std::make_unique<MockTfInterface>();
+    mock_tf_broadcaster_interface = std::make_unique<MockTfBroadcasterInterface>();
     mock_timer_interface = std::make_unique<MockTimerInterface>();
 
     mock_spot_api = std::make_unique<MockSpotApi>();
@@ -44,7 +44,7 @@ class StatePublisherNodeTest : public ::testing::Test {
   std::unique_ptr<MockNodeInterface> mock_node_interface;
   std::unique_ptr<FakeParameterInterface> fake_parameter_interface;
   std::unique_ptr<MockLoggerInterface> mock_logger_interface;
-  std::unique_ptr<MockTfInterface> mock_tf_interface;
+  std::unique_ptr<MockTfBroadcasterInterface> mock_tf_broadcaster_interface;
   std::unique_ptr<MockTimerInterface> mock_timer_interface;
 
   std::unique_ptr<MockSpotApi> mock_spot_api;
@@ -73,7 +73,7 @@ TEST_F(StatePublisherNodeTest, ConstructionSuccessful) {
   // WHEN constructing a StatePublisherNodeTest
   EXPECT_NO_THROW(StatePublisherNode(std::move(mock_node_interface), std::move(mock_spot_api),
                                      std::move(mock_middleware_handle), std::move(fake_parameter_interface),
-                                     std::move(mock_logger_interface), std::move(mock_tf_interface),
+                                     std::move(mock_logger_interface), std::move(mock_tf_broadcaster_interface),
                                      std::move(mock_timer_interface)));
 }
 
@@ -99,7 +99,7 @@ TEST_F(StatePublisherNodeTest, ConstructionFailedCreateRobotFailure) {
   EXPECT_THROW(
       StatePublisherNode(std::move(mock_node_interface), std::move(mock_spot_api), std::move(mock_middleware_handle),
                          std::move(fake_parameter_interface), std::move(mock_logger_interface),
-                         std::move(mock_tf_interface), std::move(mock_timer_interface)),
+                         std::move(mock_tf_broadcaster_interface), std::move(mock_timer_interface)),
       std::exception);
 }
 
@@ -125,7 +125,7 @@ TEST_F(StatePublisherNodeTest, ConstructionFailedAuthenticateFailure) {
   EXPECT_THROW(
       StatePublisherNode(std::move(mock_node_interface), std::move(mock_spot_api), std::move(mock_middleware_handle),
                          std::move(fake_parameter_interface), std::move(mock_logger_interface),
-                         std::move(mock_tf_interface), std::move(mock_timer_interface)),
+                         std::move(mock_tf_broadcaster_interface), std::move(mock_timer_interface)),
       std::exception);
 }
 

--- a/spot_driver/test/src/test_object_synchronization.cpp
+++ b/spot_driver/test/src/test_object_synchronization.cpp
@@ -21,7 +21,7 @@
 #include <spot_driver/mock/mock_node_interface.hpp>
 #include <spot_driver/mock/mock_state_client.hpp>
 #include <spot_driver/mock/mock_state_publisher_middleware_handle.hpp>
-#include <spot_driver/mock/mock_tf_interface.hpp>
+#include <spot_driver/mock/mock_tf_broadcaster_interface.hpp>
 #include <spot_driver/mock/mock_tf_listener_interface.hpp>
 #include <spot_driver/mock/mock_time_sync_api.hpp>
 #include <spot_driver/mock/mock_timer_interface.hpp>
@@ -114,7 +114,7 @@ class ObjectSynchronizerForTesting : public ObjectSynchronizer {
                                const std::shared_ptr<TimeSyncApi>& time_sync_api,
                                std::unique_ptr<ParameterInterfaceBase> parameter_interface,
                                std::unique_ptr<LoggerInterfaceBase> logger_interface,
-                               std::unique_ptr<TfInterfaceBase> tf_broadcaster_interface,
+                               std::unique_ptr<TfBroadcasterInterfaceBase> tf_broadcaster_interface,
                                std::unique_ptr<TfListenerInterfaceBase> tf_listener_interface,
                                std::unique_ptr<TimerInterfaceBase> world_object_update_timer,
                                std::unique_ptr<TimerInterfaceBase> tf_broadcaster_timer,
@@ -142,7 +142,7 @@ class ObjectSynchronizerTest : public ::testing::Test {
     fake_parameter_interface->spot_name = "MyRobot";
 
     mock_logger_interface = std::make_unique<MockLoggerInterface>();
-    mock_tf_broadcaster_interface = std::make_unique<MockTfInterface>();
+    mock_tf_broadcaster_interface = std::make_unique<MockTfBroadcasterInterface>();
     mock_tf_listener_interface = std::make_unique<MockTfListenerInterface>();
     mock_world_object_update_timer = std::make_unique<MockTimerInterface>();
     mock_tf_broadcaster_timer = std::make_unique<MockTimerInterface>();
@@ -181,7 +181,7 @@ class ObjectSynchronizerTest : public ::testing::Test {
 
   // Don't attempt to access these after createObjectSynchronizer() is called, since they get moved in that function
   std::unique_ptr<MockLoggerInterface> mock_logger_interface;
-  std::unique_ptr<MockTfInterface> mock_tf_broadcaster_interface;
+  std::unique_ptr<MockTfBroadcasterInterface> mock_tf_broadcaster_interface;
   std::unique_ptr<MockTfListenerInterface> mock_tf_listener_interface;
   std::unique_ptr<MockTimerInterface> mock_world_object_update_timer;
   std::unique_ptr<MockTimerInterface> mock_tf_broadcaster_timer;
@@ -189,7 +189,7 @@ class ObjectSynchronizerTest : public ::testing::Test {
 
   // Use these pointers to interact with the mocks during tests
   MockLoggerInterface* mock_logger_interface_ptr = nullptr;
-  MockTfInterface* mock_tf_broadcaster_interface_ptr = nullptr;
+  MockTfBroadcasterInterface* mock_tf_broadcaster_interface_ptr = nullptr;
   MockTfListenerInterface* mock_tf_listener_interface_ptr = nullptr;
   MockTimerInterface* mock_world_object_update_timer_ptr = nullptr;
   MockTimerInterface* mock_tf_broadcaster_timer_ptr = nullptr;


### PR DESCRIPTION
## Change Overview

#312 added a TfListenerInterface, so this renames existing classes that publish TF data to clearly explain their purpose.

## Testing Done

- [ ] Double-check that I didn't miss anything.
- [ ] It should be sufficient for CI to build and tests to pass in order to verify that these changes are OK.
