### PR TITLE
Set that RclcppTfListenerInterface's TF buffer is using a separate thread to monitor TF data

### DIFF
--- a/spot_driver/include/spot_driver/interfaces/rclcpp_tf_listener_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_tf_listener_interface.hpp
@@ -16,6 +16,7 @@
 namespace spot_ros2 {
 /**
  * @brief Implements TfListenerInterfaceBase to use the rclcpp TF system.
+ * @details The node passed to the constructor of this class MUST be spun by a MultiThreadedExecutor.
  */
 class RclcppTfListenerInterface : public TfListenerInterfaceBase {
  public:

--- a/spot_driver/src/interfaces/rclcpp_tf_listener_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_tf_listener_interface.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+// Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
 
 #include <tf2/exceptions.h>
 #include <tf2/time.h>

--- a/spot_driver/src/interfaces/rclcpp_tf_listener_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_tf_listener_interface.cpp
@@ -10,7 +10,9 @@
 
 namespace spot_ros2 {
 RclcppTfListenerInterface::RclcppTfListenerInterface(const std::shared_ptr<rclcpp::Node>& node)
-    : buffer_{node->get_clock()}, listener_{buffer_, node, false} {}
+    : buffer_{node->get_clock()}, listener_{buffer_, node, false} {
+  buffer_.setUsingDedicatedThread(true);
+}
 
 std::vector<std::string> RclcppTfListenerInterface::getAllFrameNames() const {
   // Note: this seems to get all past frames, in addition to all currently-published frames.


### PR DESCRIPTION
## Change Overview

There is a noisy warning message from the TF buffer cautioning that `lookupTransform` should not be called with a timeout unless a separate thread is used to listen to TF data. We are indeed using a separate thread (since we require that RclcppTfListenerInterface be spun by a multithreaded executor) and we're not using the timeout duration when looking up transforms, so we can set that the buffer is using a separate thread to quiet this warning.

This also fixes an incorrect copyright year for a file added in #312.

## Testing Done

- [x] Run driver nodes, confirm absence of warning message.
