### PR TITLE
[SW-758] Make SpotCamWrapper authenticate with same robot instance as SpotWrapper

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -436,8 +436,9 @@ class SpotROS(Node):
             if self.initialize_spot_cam:
                 try:
                     self.cam_logger = rcutils_logger.RcutilsLogger(name=f"{name_with_dot}spot_cam_wrapper")
-                    self.spot_cam_wrapper = SpotCamWrapper(self.ip, self.username, self.password, self.cam_logger)
-                except SystemError:
+                    self.spot_cam_wrapper = self.spot_wrapper.init_camera_wrapper(self.cam_logger)
+                except SystemError as e:
+                    self.get_logger().warn("Error making camera wrapper: " + str(e))
                     self.spot_cam_wrapper = None
 
             if self.frame_prefix != self.spot_wrapper.frame_prefix:


### PR DESCRIPTION
## Change Overview

modified so that `SpotCamWrapper` will use the same instance of robot as `SpotWrapper`

Linked to https://github.com/bdaiinstitute/spot_wrapper/pull/102

Currently having some errors during testing

## Testing Done

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
