### PR TITLE
Special handling of the hand camera format such that it always has RGB format

### DIFF
--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -36,7 +36,7 @@ namespace spot_ros2::images {
       image_request->set_image_source_name(source_name);
       // RGB images can have a user-configurable image quality setting.
       image_request->set_quality_percent(rgb_image_quality);
-      if (has_rgb_cameras) {
+      if (source.camera == SpotCamera::HAND || has_rgb_cameras) {
         image_request->set_pixel_format(bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_RGB_U8);
       } else {
         image_request->set_pixel_format(bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_GREYSCALE_U8);

--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -36,6 +36,7 @@ namespace spot_ros2::images {
       image_request->set_image_source_name(source_name);
       // RGB images can have a user-configurable image quality setting.
       image_request->set_quality_percent(rgb_image_quality);
+      // The hand camera always provides RGB images
       if (source.camera == SpotCamera::HAND || has_rgb_cameras) {
         image_request->set_pixel_format(bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_RGB_U8);
       } else {


### PR DESCRIPTION
We assume the hand camera to always have rgb format, independent of the parameter "has_rgb_cameras"

We tested it on our spot, which has grayscale body cameras, tests on an rgb-spot would be required.

This PR is related to https://github.com/bdaiinstitute/spot_ros2/pull/193 and slightly adapts the simplified approach mentioned there.

