### PR TITLE
[SW-940] Add arm stow, carry, and ready services to spot_ros2

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -572,24 +572,25 @@ class SpotROS(Node):
             callback_group=self.group,
         )
 
-        self.create_service(
-            Trigger,
-            "stow_arm",
-            lambda request, response: self.service_wrapper("stow_arm", self.handle_stow_arm, request, response),
-            callback_group=self.group,
-        )
-        self.create_service(
-            Trigger,
-            "ready_arm",
-            lambda request, response: self.service_wrapper("ready_arm", self.handle_ready_arm, request, response),
-            callback_group=self.group,
-        )
-        self.create_service(
-            Trigger,
-            "carry",
-            lambda request, response: self.service_wrapper("carry", self.handle_carry, request, response),
-            callback_group=self.group,
-        )
+        if has_arm:
+            self.create_service(
+                Trigger,
+                "stow_arm",
+                lambda request, response: self.service_wrapper("stow_arm", self.handle_stow_arm, request, response),
+                callback_group=self.group,
+            )
+            self.create_service(
+                Trigger,
+                "ready_arm",
+                lambda request, response: self.service_wrapper("ready_arm", self.handle_ready_arm, request, response),
+                callback_group=self.group,
+            )
+            self.create_service(
+                Trigger,
+                "carry",
+                lambda request, response: self.service_wrapper("carry", self.handle_carry, request, response),
+                callback_group=self.group,
+            )
 
         self.create_service(
             SetBool,
@@ -1280,7 +1281,7 @@ class SpotROS(Node):
             return response
         response.success, response.message = self.spot_wrapper.spot_docking.undock()
         return response
-    
+
     def handle_stow_arm(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
         """ROS service handler to stow the arm on the robot."""
         if self.spot_wrapper is None:
@@ -1298,7 +1299,7 @@ class SpotROS(Node):
             return response
         response.success, response.message = self.spot_wrapper.spot_arm.arm_unstow()
         return response
-    
+
     def handle_carry(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
         """ROS service handler to carry an object the robot has already grasped."""
         if self.spot_wrapper is None:

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -572,7 +572,6 @@ class SpotROS(Node):
             callback_group=self.group,
         )
 
-        # ARM STOW STUFF
         self.create_service(
             Trigger,
             "stow_arm",

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -572,6 +572,26 @@ class SpotROS(Node):
             callback_group=self.group,
         )
 
+        # ARM STOW STUFF
+        self.create_service(
+            Trigger,
+            "stow_arm",
+            lambda request, response: self.service_wrapper("stow_arm", self.handle_stow_arm, request, response),
+            callback_group=self.group,
+        )
+        self.create_service(
+            Trigger,
+            "ready_arm",
+            lambda request, response: self.service_wrapper("ready_arm", self.handle_ready_arm, request, response),
+            callback_group=self.group,
+        )
+        self.create_service(
+            Trigger,
+            "carry",
+            lambda request, response: self.service_wrapper("carry", self.handle_carry, request, response),
+            callback_group=self.group,
+        )
+
         self.create_service(
             SetBool,
             "stair_mode",
@@ -1260,6 +1280,33 @@ class SpotROS(Node):
             response.message = "Spot wrapper is undefined"
             return response
         response.success, response.message = self.spot_wrapper.spot_docking.undock()
+        return response
+    
+    def handle_stow_arm(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        """ROS service handler to stow the arm on the robot."""
+        if self.spot_wrapper is None:
+            response.success = False
+            response.message = "Spot wrapper is undefined"
+            return response
+        response.success, response.message = self.spot_wrapper.spot_arm.stow_arm()
+        return response
+
+    def handle_ready_arm(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        """ROS service handler to ready (unstow) the arm on the robot."""
+        if self.spot_wrapper is None:
+            response.success = False
+            response.message = "Spot wrapper is undefined"
+            return response
+        response.success, response.message = self.spot_wrapper.spot_arm.arm_unstow()
+        return response
+    
+    def handle_carry(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        """ROS service handler to carry an object the robot has already grasped."""
+        if self.spot_wrapper is None:
+            response.success = False
+            response.message = "Spot wrapper is undefined"
+            return response
+        response.success, response.message = self.spot_wrapper.spot_arm.arm_carry()
         return response
 
     def handle_clear_behavior_fault(


### PR DESCRIPTION
## Change Overview

Added services for `stow_arm`, `ready_arm`, and `carry` to `spot_ros2`

## Testing Done

Ran the driver and tested the new services

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
