### PR TITLE
[SW-951] Add gripper open and close services to spot_ros2

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -593,6 +593,19 @@ class SpotROS(Node):
             )
 
         self.create_service(
+            Trigger,
+            "open_gripper",
+            lambda request, response: self.service_wrapper("open_gripper", self.handle_open_gripper, request, response),
+            callback_group=self.group,
+        )
+        self.create_service(
+            Trigger,
+            "close_gripper",
+            lambda request, response: self.service_wrapper("close_gripper", self.handle_close_gripper, request, response),
+            callback_group=self.group,
+        )
+
+        self.create_service(
             SetBool,
             "stair_mode",
             lambda request, response: self.service_wrapper("stair_mode", self.handle_stair_mode, request, response),
@@ -1307,6 +1320,24 @@ class SpotROS(Node):
             response.message = "Spot wrapper is undefined"
             return response
         response.success, response.message = self.spot_wrapper.spot_arm.arm_carry()
+        return response
+    
+    def handle_open_gripper(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        """ROS service handler to open the gripper."""
+        if self.spot_wrapper is None:
+            response.success = False
+            response.message = "Spot wrapper is undefined"
+            return response
+        response.success, response.message = self.spot_wrapper.spot_arm.gripper_open()
+        return response
+    
+    def handle_close_gripper(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        """ROS service handler to close the gripper."""
+        if self.spot_wrapper is None:
+            response.success = False
+            response.message = "Spot wrapper is undefined"
+            return response
+        response.success, response.message = self.spot_wrapper.spot_arm.gripper_close()
         return response
 
     def handle_stow_arm(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -592,18 +592,22 @@ class SpotROS(Node):
                 callback_group=self.group,
             )
 
-        self.create_service(
-            Trigger,
-            "open_gripper",
-            lambda request, response: self.service_wrapper("open_gripper", self.handle_open_gripper, request, response),
-            callback_group=self.group,
-        )
-        self.create_service(
-            Trigger,
-            "close_gripper",
-            lambda request, response: self.service_wrapper("close_gripper", self.handle_close_gripper, request, response),
-            callback_group=self.group,
-        )
+            self.create_service(
+                Trigger,
+                "open_gripper",
+                lambda request, response: self.service_wrapper(
+                    "open_gripper", self.handle_open_gripper, request, response
+                ),
+                callback_group=self.group,
+            )
+            self.create_service(
+                Trigger,
+                "close_gripper",
+                lambda request, response: self.service_wrapper(
+                    "close_gripper", self.handle_close_gripper, request, response
+                ),
+                callback_group=self.group,
+            )
 
         self.create_service(
             SetBool,
@@ -1321,7 +1325,7 @@ class SpotROS(Node):
             return response
         response.success, response.message = self.spot_wrapper.spot_arm.arm_carry()
         return response
-    
+
     def handle_open_gripper(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
         """ROS service handler to open the gripper."""
         if self.spot_wrapper is None:
@@ -1330,7 +1334,7 @@ class SpotROS(Node):
             return response
         response.success, response.message = self.spot_wrapper.spot_arm.gripper_open()
         return response
-    
+
     def handle_close_gripper(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
         """ROS service handler to close the gripper."""
         if self.spot_wrapper is None:

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1344,33 +1344,6 @@ class SpotROS(Node):
         response.success, response.message = self.spot_wrapper.spot_arm.gripper_close()
         return response
 
-    def handle_stow_arm(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler to stow the arm on the robot."""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.spot_arm.stow_arm()
-        return response
-
-    def handle_ready_arm(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler to ready (unstow) the arm on the robot."""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.spot_arm.arm_unstow()
-        return response
-
-    def handle_carry(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler to carry an object the robot has already grasped."""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.spot_arm.arm_carry()
-        return response
-
     def handle_clear_behavior_fault(
         self, request: ClearBehaviorFault.Request, response: ClearBehaviorFault.Response
     ) -> ClearBehaviorFault.Response:

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -572,24 +572,25 @@ class SpotROS(Node):
             callback_group=self.group,
         )
 
-        self.create_service(
-            Trigger,
-            "stow_arm",
-            lambda request, response: self.service_wrapper("stow_arm", self.handle_stow_arm, request, response),
-            callback_group=self.group,
-        )
-        self.create_service(
-            Trigger,
-            "ready_arm",
-            lambda request, response: self.service_wrapper("ready_arm", self.handle_ready_arm, request, response),
-            callback_group=self.group,
-        )
-        self.create_service(
-            Trigger,
-            "carry",
-            lambda request, response: self.service_wrapper("carry", self.handle_carry, request, response),
-            callback_group=self.group,
-        )
+        if has_arm:
+            self.create_service(
+                Trigger,
+                "stow_arm",
+                lambda request, response: self.service_wrapper("stow_arm", self.handle_stow_arm, request, response),
+                callback_group=self.group,
+            )
+            self.create_service(
+                Trigger,
+                "ready_arm",
+                lambda request, response: self.service_wrapper("ready_arm", self.handle_ready_arm, request, response),
+                callback_group=self.group,
+            )
+            self.create_service(
+                Trigger,
+                "carry",
+                lambda request, response: self.service_wrapper("carry", self.handle_carry, request, response),
+                callback_group=self.group,
+            )
 
         self.create_service(
             SetBool,
@@ -1280,7 +1281,7 @@ class SpotROS(Node):
             return response
         response.success, response.message = self.spot_wrapper.spot_docking.undock()
         return response
-    
+
     def handle_stow_arm(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
         """ROS service handler to stow the arm on the robot."""
         if self.spot_wrapper is None:
@@ -1298,7 +1299,7 @@ class SpotROS(Node):
             return response
         response.success, response.message = self.spot_wrapper.spot_arm.arm_unstow()
         return response
-    
+
     def handle_carry(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
         """ROS service handler to carry an object the robot has already grasped."""
         if self.spot_wrapper is None:

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -572,7 +572,6 @@ class SpotROS(Node):
             callback_group=self.group,
         )
 
-        # ARM STOW STUFF
         self.create_service(
             Trigger,
             "stow_arm",

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -572,25 +572,25 @@ class SpotROS(Node):
             callback_group=self.group,
         )
 
-        if has_arm:
-            self.create_service(
-                Trigger,
-                "stow_arm",
-                lambda request, response: self.service_wrapper("stow_arm", self.handle_stow_arm, request, response),
-                callback_group=self.group,
-            )
-            self.create_service(
-                Trigger,
-                "ready_arm",
-                lambda request, response: self.service_wrapper("ready_arm", self.handle_ready_arm, request, response),
-                callback_group=self.group,
-            )
-            self.create_service(
-                Trigger,
-                "carry",
-                lambda request, response: self.service_wrapper("carry", self.handle_carry, request, response),
-                callback_group=self.group,
-            )
+        # ARM STOW STUFF
+        self.create_service(
+            Trigger,
+            "stow_arm",
+            lambda request, response: self.service_wrapper("stow_arm", self.handle_stow_arm, request, response),
+            callback_group=self.group,
+        )
+        self.create_service(
+            Trigger,
+            "ready_arm",
+            lambda request, response: self.service_wrapper("ready_arm", self.handle_ready_arm, request, response),
+            callback_group=self.group,
+        )
+        self.create_service(
+            Trigger,
+            "carry",
+            lambda request, response: self.service_wrapper("carry", self.handle_carry, request, response),
+            callback_group=self.group,
+        )
 
         self.create_service(
             SetBool,
@@ -1280,6 +1280,33 @@ class SpotROS(Node):
             response.message = "Spot wrapper is undefined"
             return response
         response.success, response.message = self.spot_wrapper.spot_docking.undock()
+        return response
+    
+    def handle_stow_arm(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        """ROS service handler to stow the arm on the robot."""
+        if self.spot_wrapper is None:
+            response.success = False
+            response.message = "Spot wrapper is undefined"
+            return response
+        response.success, response.message = self.spot_wrapper.spot_arm.stow_arm()
+        return response
+
+    def handle_ready_arm(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        """ROS service handler to ready (unstow) the arm on the robot."""
+        if self.spot_wrapper is None:
+            response.success = False
+            response.message = "Spot wrapper is undefined"
+            return response
+        response.success, response.message = self.spot_wrapper.spot_arm.arm_unstow()
+        return response
+    
+    def handle_carry(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        """ROS service handler to carry an object the robot has already grasped."""
+        if self.spot_wrapper is None:
+            response.success = False
+            response.message = "Spot wrapper is undefined"
+            return response
+        response.success, response.message = self.spot_wrapper.spot_arm.arm_carry()
         return response
 
     def handle_stow_arm(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:


### PR DESCRIPTION
## Change Overview

Added services `open_gripper` and `close_gripper` to `spot_ros2`

## Testing Done

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
