### PR TITLE
[SW-947] Add support for custom port and certificate

### DIFF
--- a/spot_driver/include/spot_driver/api/default_spot_api.hpp
+++ b/spot_driver/include/spot_driver/api/default_spot_api.hpp
@@ -19,10 +19,12 @@ namespace spot_ros2 {
 
 class DefaultSpotApi : public SpotApi {
  public:
-  explicit DefaultSpotApi(const std::string& sdk_client_name);
+  explicit DefaultSpotApi(const std::string& sdk_client_name,
+                          const std::optional<std::string>& certificate = std::nullopt);
 
-  [[nodiscard]] tl::expected<void, std::string> createRobot(const std::string& ip_address,
-                                                            const std::string& robot_name) override;
+  [[nodiscard]] tl::expected<void, std::string> createRobot(const std::string& robot_name,
+                                                            const std::string& ip_address,
+                                                            const std::optional<int>& port = std::nullopt) override;
   [[nodiscard]] tl::expected<void, std::string> authenticate(const std::string& username,
                                                              const std::string& password) override;
   [[nodiscard]] tl::expected<bool, std::string> hasArm() const override;

--- a/spot_driver/include/spot_driver/api/spot_api.hpp
+++ b/spot_driver/include/spot_driver/api/spot_api.hpp
@@ -26,7 +26,8 @@ class SpotApi {
 
   virtual ~SpotApi() = default;
 
-  virtual tl::expected<void, std::string> createRobot(const std::string& ip_address, const std::string& robot_name) = 0;
+  virtual tl::expected<void, std::string> createRobot(const std::string& robot_name, const std::string& ip_address,
+                                                      const std::optional<int>& port = std::nullopt) = 0;
   virtual tl::expected<void, std::string> authenticate(const std::string& username, const std::string& password) = 0;
   virtual tl::expected<bool, std::string> hasArm() const = 0;
   /**

--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -24,6 +24,8 @@ class ParameterInterfaceBase {
   // specific value. If the parameter was set, return the value provided by the user. If the parameter was not set,
   // return the default value.
   virtual std::string getHostname() const = 0;
+  virtual std::optional<int> getPort() const = 0;
+  virtual std::optional<std::string> getCertificate() const = 0;
   virtual std::string getUsername() const = 0;
   virtual std::string getPassword() const = 0;
   virtual double getRGBImageQuality() const = 0;

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
@@ -6,6 +6,7 @@
 #include <spot_driver/interfaces/parameter_interface_base.hpp>
 
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace spot_ros2 {
@@ -20,6 +21,8 @@ class RclcppParameterInterface : public ParameterInterfaceBase {
    */
   explicit RclcppParameterInterface(const std::shared_ptr<rclcpp::Node>& node);
   [[nodiscard]] std::string getHostname() const override;
+  [[nodiscard]] std::optional<int> getPort() const override;
+  [[nodiscard]] std::optional<std::string> getCertificate() const override;
   [[nodiscard]] std::string getUsername() const override;
   [[nodiscard]] std::string getPassword() const override;
   [[nodiscard]] double getRGBImageQuality() const override;

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -3,7 +3,7 @@
 import logging
 import os
 from enum import Enum
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import launch
 import launch_ros
@@ -105,14 +105,17 @@ def create_point_cloud_nodelets(
     return composable_node_descriptions
 
 
-def get_login_parameters(context: LaunchContext) -> Tuple[str, str, str, int]:
+def get_login_parameters(context: LaunchContext) -> Tuple[str, str, str, Optional[int], Optional[str]]:
     """Obtain the username, password, hostname, and port of Spot from the environment variables or, if they are not
     set, the configuration file yaml."""
     # Get value from environment variables
     username = os.getenv("BOSDYN_CLIENT_USERNAME")
     password = os.getenv("BOSDYN_CLIENT_PASSWORD")
     hostname = os.getenv("SPOT_IP")
-    port = int(os.getenv("SPOT_PORT", "0"))  # TODO should the user be able to specify a port via config file?
+    portnum = os.getenv("SPOT_PORT")
+    port = int(portnum) if portnum else None
+    certificate = os.getenv("SPOT_CERTIFICATE")
+
     # parse the yaml to determine if login information is set there
     config_file_path = LaunchConfiguration("config_file").perform(context)
     if os.path.isfile(config_file_path):
@@ -128,6 +131,10 @@ def get_login_parameters(context: LaunchContext) -> Tuple[str, str, str, int]:
                         password = ros_params["password"]
                     if (not hostname) and ("hostname" in ros_params):
                         hostname = ros_params["hostname"]
+                    if not port and "port" in ros_params:
+                        port = ros_params["port"]
+                    if not certificate and "certificate" in ros_params:
+                        certificate = ros_params["certificate"]
             except yaml.YAMLError as exc:
                 print("Parsing config_file yaml failed with: {}".format(exc))
     if (not username) or (not password) or (not hostname):
@@ -136,16 +143,22 @@ def get_login_parameters(context: LaunchContext) -> Tuple[str, str, str, int]:
             "[Username: '{}' Password: '{}' Hostname: '{}']. Ensure that your environment variables are set or "
             "update your config_file yaml.".format(username, password, hostname)
         )
-    return username, password, hostname, port
+    return username, password, hostname, port, certificate
 
 
 def spot_has_arm(context: LaunchContext) -> bool:
     """Check if Spot has an arm by logging in and instantiating a SpotWrapper"""
     spot_name = LaunchConfiguration("spot_name").perform(context)
     logger = logging.getLogger("spot_driver_launch")
-    username, password, hostname, port = get_login_parameters(context)
+    username, password, hostname, port, certificate = get_login_parameters(context)
     spot_wrapper = SpotWrapper(
-        username=username, password=password, hostname=hostname, port=port, robot_name=spot_name, logger=logger
+        username=username,
+        password=password,
+        hostname=hostname,
+        port=port,
+        cert_resource_glob=certificate,
+        robot_name=spot_name,
+        logger=logger,
     )
     return spot_wrapper.has_arm()
 

--- a/spot_driver/package.xml
+++ b/spot_driver/package.xml
@@ -38,6 +38,10 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>python3-pytest-cov</test_depend>
+  <test_depend>python3-yaml</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_pytest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -352,6 +352,9 @@ class SpotROS(Node):
 
         self.ip: str = get_from_env_and_fall_back_to_param("SPOT_IP", self, "hostname", "10.0.0.3")
         self.port: int = get_from_env_and_fall_back_to_param("SPOT_PORT", self, "port", 0)
+        self.certificate: Optional[str] = (
+            get_from_env_and_fall_back_to_param("SPOT_CERTIFICATE", self, "certificate", "") or None
+        )
 
         self.camera_static_transform_broadcaster: tf2_ros.StaticTransformBroadcaster = (
             tf2_ros.StaticTransformBroadcaster(self)
@@ -428,6 +431,7 @@ class SpotROS(Node):
                 get_lease_on_action=self.get_lease_on_action.value,
                 continually_try_stand=self.continually_try_stand.value,
                 rgb_cameras=self.rgb_cameras.value,
+                cert_resource_glob=self.certificate,
             )
             if not self.spot_wrapper.is_valid:
                 return

--- a/spot_driver/src/api/default_spot_api.cpp
+++ b/spot_driver/src/api/default_spot_api.cpp
@@ -32,7 +32,7 @@ tl::expected<void, std::string> DefaultSpotApi::createRobot(const std::string& r
                                                             const std::optional<int>& port) {
   robot_name_ = robot_name;
 
-  auto create_robot_result = client_sdk_->CreateRobot(ip_address);
+  auto create_robot_result = client_sdk_->CreateRobot(ip_address, ::bosdyn::client::USE_PROXY);
   if (!create_robot_result.status) {
     return tl::make_unexpected("Received error result when creating SDK robot interface: " +
                                create_robot_result.status.DebugString());
@@ -50,7 +50,8 @@ tl::expected<void, std::string> DefaultSpotApi::createRobot(const std::string& r
 tl::expected<void, std::string> DefaultSpotApi::authenticate(const std::string& username, const std::string& password) {
   const auto authenticate_result = robot_->Authenticate(username, password);
   if (!authenticate_result) {
-    return tl::make_unexpected("Authentication with provided username and password did not succeed.");
+    return tl::make_unexpected("Authentication with provided username and password did not succeed: " +
+                               authenticate_result.DebugString());
   }
   // Start time synchronization between the robot and the client system.
   // This must be done only after a successful authentication.

--- a/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
+++ b/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
@@ -4,12 +4,17 @@
 
 #include <spot_driver/interfaces/parameter_interface_base.hpp>
 
+#include <optional>
 #include <string>
 
 namespace spot_ros2::test {
 class FakeParameterInterface : public ParameterInterfaceBase {
  public:
   std::string getHostname() const override { return kExampleHostname; }
+
+  std::optional<int> getPort() const override { return std::nullopt; }
+
+  std::optional<std::string> getCertificate() const override { return std::nullopt; }
 
   std::string getUsername() const override { return kExampleUsername; }
 

--- a/spot_driver/test/include/spot_driver/mock/mock_spot_api.hpp
+++ b/spot_driver/test/include/spot_driver/mock/mock_spot_api.hpp
@@ -18,7 +18,8 @@
 namespace spot_ros2::test {
 class MockSpotApi : public SpotApi {
  public:
-  MOCK_METHOD((tl::expected<void, std::string>), createRobot, (const std::string&, const std::string&), (override));
+  MOCK_METHOD((tl::expected<void, std::string>), createRobot,
+              (const std::string&, const std::string&, const std::optional<int>&), (override));
   MOCK_METHOD((tl::expected<void, std::string>), authenticate, (const std::string&, const std::string&), (override));
   MOCK_METHOD((tl::expected<bool, std::string>), hasArm, (), (const, override));
   MOCK_METHOD(std::shared_ptr<KinematicApi>, kinematicInterface, (), (const, override));

--- a/spot_driver/test/pytests/conftest.py
+++ b/spot_driver/test/pytests/conftest.py
@@ -88,6 +88,7 @@ def spot_node(ros: ROSAwareScope, simple_spot: SpotFixture) -> typing.Iterator[S
         rclpy.parameter.Parameter("password", rclpy.Parameter.Type.STRING, "spot"),
         rclpy.parameter.Parameter("hostname", rclpy.Parameter.Type.STRING, simple_spot.address),
         rclpy.parameter.Parameter("port", rclpy.Parameter.Type.INTEGER, simple_spot.port),
+        rclpy.parameter.Parameter("certificate", rclpy.Parameter.Type.STRING, str(simple_spot.certificate_path)),
         rclpy.parameter.Parameter("spot_name", rclpy.Parameter.Type.STRING, simple_spot.api.name),
         # disable camera publishing for now
         rclpy.parameter.Parameter("publish_rgb", rclpy.Parameter.Type.BOOL, False),

--- a/spot_driver/test/pytests/conftest.py
+++ b/spot_driver/test/pytests/conftest.py
@@ -120,9 +120,6 @@ def spot_node(ros: ROSAwareScope, simple_spot: SpotFixture) -> typing.Iterator[S
 
 @launch_pytest.fixture
 def spot_graph_description(simple_spot: SpotFixture, domain_id: int) -> typing.Iterator[launch.LaunchDescription]:
-    import time
-
-    time.sleep(5.0)
     with tempfile.NamedTemporaryFile(mode="w", suffix="config.yaml") as temp:
         data = {
             "username": "user",

--- a/spot_driver/test/pytests/conftest.py
+++ b/spot_driver/test/pytests/conftest.py
@@ -14,13 +14,22 @@ Pytest automatically discovers all fixtures defined in the file "conftest.py".
 # warning that we want disabled.
 # pylint: disable=redefined-outer-name
 
+import tempfile
 import typing
 
 import bdai_ros2_wrappers.scope as ros_scope
 import domain_coordinator
 import grpc
+import launch
+import launch.actions
+import launch.substitutions
+import launch_pytest
+import launch_pytest.actions
+import launch_ros
+import launch_ros.substitutions
 import pytest
 import rclpy
+import yaml
 from bdai_ros2_wrappers.scope import ROSAwareScope
 from bosdyn.api.power_pb2 import PowerCommandRequest, PowerCommandResponse, PowerCommandStatus
 from bosdyn.api.robot_command_pb2 import RobotCommandResponse
@@ -65,14 +74,19 @@ class simple_spot(MockSpot):
 
 
 @pytest.fixture
-def ros() -> typing.Iterator[ROSAwareScope]:
+def domain_id() -> typing.Iterator[int]:
+    with domain_coordinator.domain_id() as domain_id:
+        yield domain_id
+
+
+@pytest.fixture
+def ros(simple_spot: SpotFixture, domain_id: int) -> typing.Iterator[ROSAwareScope]:
     """
     This method is a generator function that returns a different ROS2 scope
     each time it is invoked, to handle a ROS2 context lifecycle.
     """
-    with domain_coordinator.domain_id() as domain_id:  # to ensure node isolation
-        with ros_scope.top(global_=True, namespace="fixture", domain_id=domain_id) as top:
-            yield top
+    with ros_scope.top(global_=True, namespace=simple_spot.api.name, domain_id=domain_id) as top:
+        yield top
 
 
 @pytest.fixture
@@ -102,3 +116,45 @@ def spot_node(ros: ROSAwareScope, simple_spot: SpotFixture) -> typing.Iterator[S
             response = RobotCommandResponse()
             response.status = RobotCommandResponse.Status.STATUS_OK  # pylint: disable=no-member
             simple_spot.api.RobotCommand.future.returns(response)
+
+
+@launch_pytest.fixture
+def spot_graph_description(simple_spot: SpotFixture, domain_id: int) -> typing.Iterator[launch.LaunchDescription]:
+    import time
+
+    time.sleep(5.0)
+    with tempfile.NamedTemporaryFile(mode="w", suffix="config.yaml") as temp:
+        data = {
+            "username": "user",
+            "password": "pass",
+            "hostname": simple_spot.address,
+            "port": simple_spot.port,
+            "certificate": str(simple_spot.certificate_path),
+            "spot_name": simple_spot.api.name,
+            "rgb_cameras": False,
+        }
+        yaml.dump({"/**": {"ros__parameters": data}}, temp.file)
+        temp.file.close()
+
+        yield launch.LaunchDescription(
+            [
+                launch.actions.SetEnvironmentVariable("ROS_DOMAIN_ID", str(domain_id)),
+                launch.actions.IncludeLaunchDescription(
+                    launch.launch_description_sources.PythonLaunchDescriptionSource(
+                        launch.substitutions.PathJoinSubstitution(
+                            [
+                                launch_ros.substitutions.FindPackageShare("spot_driver"),
+                                "launch",
+                                "spot_driver.launch.py",
+                            ]
+                        )
+                    ),
+                    launch_arguments=[("config_file", temp.file.name), ("spot_name", simple_spot.api.name)],
+                ),
+                launch_pytest.actions.ReadyToTest(),
+            ],
+        )
+
+
+def pytest_configure() -> None:
+    pytest.spot_graph_description = spot_graph_description

--- a/spot_driver/test/pytests/test_robot_state.py
+++ b/spot_driver/test/pytests/test_robot_state.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2024 Boston Dynamics AI Institute LLC. See LICENSE file for more info.
+
+import typing
+
+import pytest
+from bdai_ros2_wrappers.futures import wait_for_future
+from bdai_ros2_wrappers.scope import ROSAwareScope
+from bdai_ros2_wrappers.subscription import Subscription
+from bdai_ros2_wrappers.utilities import namespace_with
+from sensor_msgs.msg import JointState
+
+from spot_wrapper.testing.fixtures import SpotFixture
+
+
+@pytest.mark.launch(fixture=pytest.spot_graph_description)
+def test_joint_states(simple_spot: SpotFixture, ros: ROSAwareScope) -> None:
+    """Asserts that robot joint states are exposed over the joint_states topic."""
+    kinematic_state = simple_spot.api.robot_state.kinematic_state
+    for name, position in (("arm0.sh0", 0.1), ("arm0.sh1", -0.1)):
+        joint_state = kinematic_state.joint_states.add()
+        joint_state.name = name
+        joint_state.position.value = position
+
+    joint_states = Subscription(JointState, "joint_states", node=ros.node)
+    assert wait_for_future(joint_states.update, timeout_sec=10.0)
+    message = typing.cast(JointState, joint_states.latest)
+
+    expected_joint_positions = {
+        namespace_with(simple_spot.api.name, "arm_sh0"): 0.1,
+        namespace_with(simple_spot.api.name, "arm_sh1"): -0.1,
+    }
+    joint_positions = {name: position for name, position in zip(message.name, message.position)}
+    assert expected_joint_positions == joint_positions


### PR DESCRIPTION
## Change Overview

Precisely what the title says. This patch restores tests after https://github.com/bdaiinstitute/spot_wrapper/pull/103 and opens the door to (`launch_`)`pytest` driven C++ integration tests, as both PRs combined effectively enable the Spot ROS 2 driver to run against a mock Spot over secure gRPC channels.

## Testing Done

- [x] Integrations tests passed
- [x] Examples ran with no issues
