### PR TITLE
[SW-730] Add service in spot_ros2 to call spot check

### DIFF
--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -156,7 +156,6 @@ def spot_has_arm(context: LaunchContext) -> bool:
         password=password,
         hostname=hostname,
         port=port,
-        cert_resource_glob=certificate,
         robot_name=spot_name,
         logger=logger,
     )

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -156,6 +156,7 @@ def spot_has_arm(context: LaunchContext) -> bool:
         password=password,
         hostname=hostname,
         port=port,
+        cert_resource_glob=certificate,
         robot_name=spot_name,
         logger=logger,
     )

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -576,6 +576,13 @@ class SpotROS(Node):
             callback_group=self.group,
         )
 
+        self.create_service(
+            Trigger,
+            "spot_check",
+            lambda request, response: self.service_wrapper("spot_check", self.handle_spot_check, request, response),
+            callback_group=self.group,
+        )
+
         if has_arm:
             self.create_service(
                 Trigger,
@@ -1301,6 +1308,15 @@ class SpotROS(Node):
             response.message = "Spot wrapper is undefined"
             return response
         response.success, response.message = self.spot_wrapper.spot_docking.undock()
+        return response
+    
+    def handle_spot_check(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        """ROS service handler to run spot check on the robot."""
+        if self.spot_wrapper is None:
+            response.success = False
+            response.message = "Spot wrapper is undefined"
+            return response
+        response.success, response.message = self.spot_wrapper.spot_check.start_check()
         return response
 
     def handle_stow_arm(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1309,7 +1309,7 @@ class SpotROS(Node):
             return response
         response.success, response.message = self.spot_wrapper.spot_docking.undock()
         return response
-    
+
     def handle_spot_check(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
         """ROS service handler to run spot check on the robot."""
         if self.spot_wrapper is None:


### PR DESCRIPTION
## Change Overview

Added a service `spot_check` to run the spot check in `spot_ros2.py`

## Testing Done

Ran the driver with no issues  
ran the `spot_check` service 

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
