### PR TITLE
Handle Greyscale images correctly

### DIFF
--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -31,6 +31,7 @@ class ParameterInterfaceBase {
   virtual double getRGBImageQuality() const = 0;
   virtual bool getHasRGBCameras() const = 0;
   virtual bool getPublishRGBImages() const = 0;
+  virtual bool getPublishRawRGBCameras() const = 0;
   virtual bool getPublishDepthImages() const = 0;
   virtual bool getPublishDepthRegisteredImages() const = 0;
   virtual std::string getPreferredOdomFrame() const = 0;
@@ -44,6 +45,7 @@ class ParameterInterfaceBase {
   static constexpr double kDefaultRGBImageQuality{70.0};
   static constexpr bool kDefaultHasRGBCameras{true};
   static constexpr bool kDefaultPublishRGBImages{true};
+  static constexpr bool kDefaultPublishRawRGBCameras{false};
   static constexpr bool kDefaultPublishDepthImages{true};
   static constexpr bool kDefaultPublishDepthRegisteredImages{true};
   static constexpr auto kDefaultPreferredOdomFrame = "odom";

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
@@ -27,6 +27,7 @@ class RclcppParameterInterface : public ParameterInterfaceBase {
   [[nodiscard]] std::string getPassword() const override;
   [[nodiscard]] double getRGBImageQuality() const override;
   [[nodiscard]] bool getHasRGBCameras() const override;
+  [[nodiscard]] bool getPublishRawRGBCameras() const override;
   [[nodiscard]] bool getPublishRGBImages() const override;
   [[nodiscard]] bool getPublishDepthImages() const override;
   [[nodiscard]] bool getPublishDepthRegisteredImages() const override;

--- a/spot_driver/src/images/images_middleware_handle.cpp
+++ b/spot_driver/src/images/images_middleware_handle.cpp
@@ -9,7 +9,7 @@
 #include <spot_driver/interfaces/rclcpp_wall_timer_interface.hpp>
 
 namespace {
-constexpr auto kPublisherHistoryDepth = 1;
+constexpr auto kPublisherHistoryDepth = 10;
 
 constexpr auto kImageTopicSuffix = "image";
 constexpr auto kCameraInfoTopicSuffix = "camera_info";

--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -34,17 +34,18 @@ namespace spot_ros2::images {
     if (source.type == SpotImageType::RGB) {
       bosdyn::api::ImageRequest* image_request = request_message.add_image_requests();
       image_request->set_image_source_name(source_name);
-      // RGB images can have a user-configurable image quality setting.
+      // JPEG images can have a user-configurable image quality setting.
       image_request->set_quality_percent(rgb_image_quality);
       // The hand camera always provides RGB images
       if (source.camera == SpotCamera::HAND || has_rgb_cameras) {
         image_request->set_pixel_format(bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_RGB_U8);
+        // RGB images can be either raw or JPEG-compressed.
+        image_request->set_image_format(get_raw_rgb_images ? bosdyn::api::Image_Format_FORMAT_RAW
+                                                           : bosdyn::api::Image_Format_FORMAT_JPEG);
       } else {
+        // Grey images are always JPEG-compressed, so selection of RAW has no effect
         image_request->set_pixel_format(bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_GREYSCALE_U8);
       }
-      // RGB images can be either raw or JPEG-compressed.
-      image_request->set_image_format(get_raw_rgb_images ? bosdyn::api::Image_Format_FORMAT_RAW
-                                                         : bosdyn::api::Image_Format_FORMAT_JPEG);
     } else if (source.type == SpotImageType::DEPTH) {
       bosdyn::api::ImageRequest* image_request = request_message.add_image_requests();
       image_request->set_image_source_name(source_name);
@@ -83,13 +84,14 @@ bool SpotImagePublisher::initialize() {
   const auto publish_depth_images = parameters_->getPublishDepthImages();
   const auto publish_depth_registered_images = parameters_->getPublishDepthRegisteredImages();
   const auto has_rgb_cameras = parameters_->getHasRGBCameras();
+  const auto publish_raw_rgb_cameras = parameters_->getPublishRawRGBCameras();
 
   // Generate the set of image sources based on which cameras the user has requested that we publish
   const auto sources =
       createImageSources(publish_rgb_images, publish_depth_images, publish_depth_registered_images, has_arm_);
 
   // Generate the image request message to capture the data from the specified image sources
-  image_request_message_ = createImageRequest(sources, has_rgb_cameras, rgb_image_quality, false);
+  image_request_message_ = createImageRequest(sources, has_rgb_cameras, rgb_image_quality, publish_raw_rgb_cameras);
 
   // Create a publisher for each image source
   middleware_handle_->createPublishers(sources);

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -19,6 +19,7 @@ constexpr auto kParameterNamePassword = "password";
 constexpr auto kParameterNameRGBImageQuality = "image_quality";
 constexpr auto kParameterNameHasRGBCameras = "rgb_cameras";
 constexpr auto kParameterNamePublishRGBImages = "publish_rgb";
+constexpr auto kParameterNamePublishRawRGBCameras = "publish_raw_rgb_cameras";
 constexpr auto kParameterNamePublishDepthImages = "publish_depth";
 constexpr auto kParameterNamePublishDepthRegisteredImages = "publish_depth_registered";
 constexpr auto kParameterPreferredOdomFrame = "preferred_odom_frame";
@@ -159,6 +160,10 @@ bool RclcppParameterInterface::getHasRGBCameras() const {
 
 bool RclcppParameterInterface::getPublishRGBImages() const {
   return declareAndGetParameter<bool>(node_, kParameterNamePublishRGBImages, kDefaultPublishRGBImages);
+}
+
+bool RclcppParameterInterface::getPublishRawRGBCameras() const {
+  return declareAndGetParameter<bool>(node_, kParameterNamePublishRawRGBCameras, kDefaultPublishRawRGBCameras);
 }
 
 bool RclcppParameterInterface::getPublishDepthImages() const {

--- a/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
+++ b/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
@@ -24,6 +24,8 @@ class FakeParameterInterface : public ParameterInterfaceBase {
 
   bool getHasRGBCameras() const override { return has_rgb_cameras; }
 
+  bool getPublishRawRGBCameras() const override { return publish_raw_rgb_cameras; }
+
   bool getPublishRGBImages() const override { return publish_rgb_images; }
 
   bool getPublishDepthImages() const override { return publish_depth_images; }
@@ -40,6 +42,7 @@ class FakeParameterInterface : public ParameterInterfaceBase {
 
   double rgb_image_quality = ParameterInterfaceBase::kDefaultRGBImageQuality;
   bool has_rgb_cameras = ParameterInterfaceBase::kDefaultHasRGBCameras;
+  bool publish_raw_rgb_cameras = ParameterInterfaceBase::kDefaultPublishRawRGBCameras;
   bool publish_rgb_images = ParameterInterfaceBase::kDefaultPublishRGBImages;
   bool publish_depth_images = ParameterInterfaceBase::kDefaultPublishDepthImages;
   bool publish_depth_registered_images = ParameterInterfaceBase::kDefaultPublishDepthRegisteredImages;

--- a/spot_driver/test/src/test_parameter_interface.cpp
+++ b/spot_driver/test/src/test_parameter_interface.cpp
@@ -183,6 +183,8 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromParameters) {
   node_->declare_parameter("image_quality", rgb_image_quality_parameter);
   constexpr auto has_rgb_cameras_parameter = false;
   node_->declare_parameter("rgb_cameras", has_rgb_cameras_parameter);
+  constexpr auto publish_raw_rgb_cameras = true;
+  node_->declare_parameter("publish_raw_rgb_cameras", publish_raw_rgb_cameras);
   constexpr auto publish_rgb_images_parameter = false;
   node_->declare_parameter("publish_rgb", publish_rgb_images_parameter);
   constexpr auto publish_depth_images_parameter = false;
@@ -202,6 +204,7 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromParameters) {
   EXPECT_THAT(parameter_interface.getPassword(), StrEq(password_parameter));
   EXPECT_THAT(parameter_interface.getRGBImageQuality(), Eq(rgb_image_quality_parameter));
   EXPECT_THAT(parameter_interface.getHasRGBCameras(), Eq(has_rgb_cameras_parameter));
+  EXPECT_THAT(parameter_interface.getPublishRawRGBCameras(), Eq(publish_raw_rgb_cameras));
   EXPECT_THAT(parameter_interface.getPublishRGBImages(), Eq(publish_rgb_images_parameter));
   EXPECT_THAT(parameter_interface.getPublishDepthImages(), Eq(publish_depth_images_parameter));
   EXPECT_THAT(parameter_interface.getPublishDepthRegisteredImages(), Eq(publish_depth_registered_images_parameter));
@@ -259,6 +262,7 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetConfigDefaults) {
   EXPECT_THAT(parameter_interface.getPassword(), StrEq("password"));
   EXPECT_THAT(parameter_interface.getRGBImageQuality(), Eq(70.0));
   EXPECT_THAT(parameter_interface.getHasRGBCameras(), IsTrue());
+  EXPECT_THAT(parameter_interface.getPublishRawRGBCameras(), false);
   EXPECT_THAT(parameter_interface.getPublishRGBImages(), IsTrue());
   EXPECT_THAT(parameter_interface.getPublishDepthImages(), IsTrue());
   EXPECT_THAT(parameter_interface.getPublishDepthRegisteredImages(), IsTrue());


### PR DESCRIPTION
- Fix: do not decode greyscale camera images as color image
- Pass the (already implemented) option to NOT decompress the images to the user parameter interface as "publish_raw_rgb_cameras" to let the user decide if the decompression should be performed or not; parameter was hard coded as false previously
- increase the publisher's history depth to support slower receivers

## Change Overview

Please include a summary of the changes made and the relevant ticket or issue.
This is the part on fixing the greyscale processing from #316

## Testing Done

The unit test for the parameter input was added in the commit and unit tests run successfully.
No CI-test extensions planned in addition. To actually test the greyscale changes one would require hardware in the loop tests...