### PR TITLE
Fix duplicated ros_node creation

### DIFF
--- a/spot_driver/src/images/spot_image_publisher_node.cpp
+++ b/spot_driver/src/images/spot_image_publisher_node.cpp
@@ -33,7 +33,7 @@ SpotImagePublisherNode::SpotImagePublisherNode(const rclcpp::NodeOptions& node_o
   const auto node = std::make_shared<rclcpp::Node>("image_publisher", node_options);
   node_base_interface_ = std::make_unique<RclcppNodeInterface>(node->get_node_base_interface());
 
-  auto mw_handle = std::make_unique<ImagesMiddlewareHandle>(node_options);
+  auto mw_handle = std::make_unique<ImagesMiddlewareHandle>(node);
   auto parameters = std::make_unique<RclcppParameterInterface>(node);
   auto logger = std::make_unique<RclcppLoggerInterface>(node->get_logger());
   auto tf_broadcaster = std::make_unique<RclcppTfBroadcasterInterface>(node);


### PR DESCRIPTION
## Change Overview

If the ImagesMiddlewareHandle is constructed using the node_options, it's creating it's own ros-node.
But when initialized from within SpotImagePublisherNode, the already existing ros-node must be used. Otherwhise it results in two ros-nodes with identical names and corresponding ROS2 warnings.

## Testing Done
Compiles and runs now with only one /image_publisher node ;-)