### PR TITLE
Default images to compressed with option to decompress

### DIFF
--- a/spot_driver/include/spot_driver/conversions/decompress_images.hpp
+++ b/spot_driver/include/spot_driver/conversions/decompress_images.hpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2024 The AI Institute LLC. All rights reserved.
+
+#pragma once
+
+#include <std_msgs/msg/header.hpp>
+#include <tl_expected/expected.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <bosdyn/api/directory.pb.h>
+#include <bosdyn/api/image.pb.h>
+#include <spot_driver/api/spot_image_sources.hpp>
+#include <google/protobuf/duration.pb.h>
+
+namespace spot_ros2 {
+
+tl::expected<int, std::string> getCvPixelFormat(const bosdyn::api::Image_PixelFormat& format);
+std_msgs::msg::Header createImageHeader(const bosdyn::api::ImageCapture& image_capture, const std::string& robot_name,
+                                      const google::protobuf::Duration& clock_skew);
+tl::expected<sensor_msgs::msg::Image, std::string> getDecompressImageMsg(const bosdyn::api::ImageCapture& image_capture,
+                                                            const std::string& robot_name,
+                                                            const google::protobuf::Duration& clock_skew);
+
+} // namespace

--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -31,6 +31,7 @@ class ParameterInterfaceBase {
   virtual double getRGBImageQuality() const = 0;
   virtual bool getHasRGBCameras() const = 0;
   virtual bool getPublishRGBImages() const = 0;
+  virtual bool getPublishRawRGBCameras() const = 0;
   virtual bool getPublishDepthImages() const = 0;
   virtual bool getPublishDepthRegisteredImages() const = 0;
   virtual std::string getPreferredOdomFrame() const = 0;
@@ -44,6 +45,7 @@ class ParameterInterfaceBase {
   static constexpr double kDefaultRGBImageQuality{70.0};
   static constexpr bool kDefaultHasRGBCameras{true};
   static constexpr bool kDefaultPublishRGBImages{true};
+  static constexpr bool kDefaultPublishRawRGBCameras{false};
   static constexpr bool kDefaultPublishDepthImages{true};
   static constexpr bool kDefaultPublishDepthRegisteredImages{true};
   static constexpr auto kDefaultPreferredOdomFrame = "odom";

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
@@ -27,6 +27,7 @@ class RclcppParameterInterface : public ParameterInterfaceBase {
   [[nodiscard]] std::string getPassword() const override;
   [[nodiscard]] double getRGBImageQuality() const override;
   [[nodiscard]] bool getHasRGBCameras() const override;
+  [[nodiscard]] bool getPublishRawRGBCameras() const override;
   [[nodiscard]] bool getPublishRGBImages() const override;
   [[nodiscard]] bool getPublishDepthImages() const override;
   [[nodiscard]] bool getPublishDepthRegisteredImages() const override;

--- a/spot_driver/src/api/default_image_client.cpp
+++ b/spot_driver/src/api/default_image_client.cpp
@@ -18,6 +18,7 @@
 #include <spot_driver/api/spot_image_sources.hpp>
 #include <spot_driver/conversions/geometry.hpp>
 #include <spot_driver/conversions/time.hpp>
+#include <spot_driver/conversions/decompress_images.hpp>
 #include <spot_driver/types.hpp>
 #include <std_msgs/msg/header.hpp>
 #include <tl_expected/expected.hpp>
@@ -43,29 +44,6 @@ static const std::set<std::string> kExcludedStaticTfFrames{
     // on the arm's position and a static transform would fix it to its initial position.
     "arm0.link_wr1",
 };
-
-tl::expected<int, std::string> getCvPixelFormat(const bosdyn::api::Image_PixelFormat& format) {
-  switch (format) {
-    case bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_RGB_U8: {
-      return CV_8UC3;
-    }
-    case bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_RGBA_U8: {
-      return CV_8UC4;
-    }
-    case bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_GREYSCALE_U8: {
-      return CV_8UC1;
-    }
-    case bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_GREYSCALE_U16: {
-      return CV_16UC1;
-    }
-    case bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_DEPTH_U16: {
-      return CV_16UC1;
-    }
-    default: {
-      return tl::make_unexpected("Unknown pixel format.");
-    }
-  }
-}
 
 tl::expected<sensor_msgs::msg::CameraInfo, std::string> toCameraInfoMsg(
     const bosdyn::api::ImageResponse& image_response, const std::string& robot_name,
@@ -122,55 +100,6 @@ std_msgs::msg::Header createImageHeader(const bosdyn::api::ImageCapture& image_c
   return header;
 }
 
-tl::expected<sensor_msgs::msg::Image, std::string> toImageMsg(const bosdyn::api::ImageCapture& image_capture,
-                                                              const std::string& robot_name,
-                                                              const google::protobuf::Duration& clock_skew) {
-  const auto& image = image_capture.image();
-  auto data = image.data();
-
-  const auto header = createImageHeader(image_capture, robot_name, clock_skew);
-  const auto pixel_format_cv = getCvPixelFormat(image.pixel_format());
-  if (!pixel_format_cv) {
-    return tl::make_unexpected("Failed to determine pixel format: " + pixel_format_cv.error());
-  }
-
-  if (image.format() == bosdyn::api::Image_Format_FORMAT_JPEG) {
-    // When the image is JPEG-compressed, it is represented as a 1 x (width * height) row of bytes.
-    // First we create a cv::Mat which contains the compressed image data...
-    const cv::Mat img_compressed{1, image.rows() * image.cols(), CV_8UC1, &data.front()};
-    // Then we decode it to extract the raw image into a new cv::Mat.
-    if (image.pixel_format() == bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_GREYSCALE_U8) {
-      const cv::Mat img_grey = cv::imdecode(img_compressed, cv::IMREAD_GRAYSCALE);
-      if (!img_grey.data) {
-        return tl::make_unexpected("Failed to decode JPEG-compressed image.");
-      }
-      const auto image = cv_bridge::CvImage{header, "mono8", img_grey}.toImageMsg();
-      return *image;
-    } else {
-      const cv::Mat img_bgr = cv::imdecode(img_compressed, cv::IMREAD_COLOR);
-      if (!img_bgr.data) {
-        return tl::make_unexpected("Failed to decode JPEG-compressed image.");
-      }
-      const auto image = cv_bridge::CvImage{header, "bgr8", img_bgr}.toImageMsg();
-      return *image;
-    }
-  } else if (image.format() == bosdyn::api::Image_Format_FORMAT_RAW) {
-    // Note: as currently implemented, this assumes that the only images which will be provided as raw data will be
-    // 16UC1 depth images.
-    // TODO(jschornak-bdai): handle converting raw RGB and grayscale images as well.
-    const cv::Mat img = cv::Mat(image.rows(), image.cols(), pixel_format_cv.value(), &data.front());
-    if (!img.data) {
-      return tl::make_unexpected("Failed to decode raw-formatted image.");
-    }
-    const auto image = cv_bridge::CvImage{header, sensor_msgs::image_encodings::TYPE_16UC1, img}.toImageMsg();
-    return *image;
-  } else if (image.format() == bosdyn::api::Image_Format_FORMAT_RLE) {
-    return tl::make_unexpected("Conversion from FORMAT_RLE is not yet implemented.");
-  } else {
-    return tl::make_unexpected("Unknown image format.");
-  }
-}
-
 tl::expected<std::vector<geometry_msgs::msg::TransformStamped>, std::string> getImageTransforms(
     const bosdyn::api::ImageResponse& image_response, const std::string& robot_name,
     const google::protobuf::Duration& clock_skew) {
@@ -196,6 +125,22 @@ tl::expected<std::vector<geometry_msgs::msg::TransformStamped>, std::string> get
     out.push_back(tform_msg);
   }
   return out;
+}
+
+tl::expected<sensor_msgs::msg::CompressedImage, std::string> toCompressedImageMsg(
+    const bosdyn::api::ImageCapture& image_capture, const std::string& robot_name,
+    const google::protobuf::Duration& clock_skew) {
+  const auto& image = image_capture.image();
+  if (image.format() != bosdyn::api::Image_Format_FORMAT_JPEG) {
+    return tl::make_unexpected("Only JPEG image cannot be sent as ROS2-compressed image.");
+  }
+
+  auto data = image.data();
+  sensor_msgs::msg::CompressedImage compressed_image;
+  compressed_image.header = createImageHeader(image_capture, robot_name, clock_skew);
+  compressed_image.format = "jpeg";
+  compressed_image.data.insert(compressed_image.data.begin(), data.begin(), data.end());
+  return compressed_image;
 }
 }  // namespace
 
@@ -224,7 +169,7 @@ tl::expected<GetImagesResult, std::string> DefaultImageClient::getImages(::bosdy
     const auto& image = image_response.shot().image();
     auto data = image.data();
 
-    const auto image_msg = toImageMsg(image_response.shot(), robot_name_, clock_skew_result.value());
+    const auto image_msg = toCompressedImageMsg(image_response.shot(), robot_name_, clock_skew_result.value());
     if (!image_msg) {
       return tl::make_unexpected("Failed to convert SDK image response to ROS Image message: " + image_msg.error());
     }
@@ -236,9 +181,7 @@ tl::expected<GetImagesResult, std::string> DefaultImageClient::getImages(::bosdy
 
     const auto& camera_name = image_response.source().name();
     const auto get_source_name_result = fromSpotImageSourceName(camera_name);
-    if (get_source_name_result.has_value()) {
-      out.images_.try_emplace(get_source_name_result.value(), ImageWithCameraInfo{image_msg.value(), info_msg.value()});
-    } else {
+    if (!get_source_name_result.has_value()) {
       return tl::make_unexpected("Failed to convert API image source name to ImageSource: " +
                                  get_source_name_result.error());
     }

--- a/spot_driver/src/conversions/decompress_images.cpp
+++ b/spot_driver/src/conversions/decompress_images.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2024 The AI Institute LLC. All rights reserved.
+
+#include <std_msgs/msg/header.hpp>
+#include <tl_expected/expected.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <cv_bridge/cv_bridge.h>
+#include <bosdyn/api/directory.pb.h>
+#include <bosdyn/api/image.pb.h>
+#include <spot_driver/api/default_time_sync_api.hpp>
+#include <spot_driver/api/spot_image_sources.hpp>
+#include <spot_driver/conversions/geometry.hpp>
+#include <spot_driver/conversions/time.hpp>
+#include <spot_driver/conversions/decompress_images.hpp>
+#include <spot_driver/types.hpp>
+#include <google/protobuf/duration.pb.h>
+
+
+namespace spot_ros2 {
+
+  tl::expected<int, std::string> getCvPixelFormat(const bosdyn::api::Image_PixelFormat& format) {
+    switch (format) {
+      case bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_RGB_U8: {
+        return CV_8UC3;
+      }
+      case bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_RGBA_U8: {
+        return CV_8UC4;
+      }
+      case bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_GREYSCALE_U8: {
+        return CV_8UC1;
+      }
+      case bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_GREYSCALE_U16: {
+        return CV_16UC1;
+      }
+      case bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_DEPTH_U16: {
+        return CV_16UC1;
+      }
+      default: {
+        return tl::make_unexpected("Unknown pixel format.");
+      }
+    }
+  }
+
+  std_msgs::msg::Header createImageHeader(const bosdyn::api::ImageCapture& image_capture, const std::string& robot_name,
+                                      const google::protobuf::Duration& clock_skew) {
+    std_msgs::msg::Header header;
+    // Omit leading `/` from frame ID if robot_name is empty
+    header.frame_id = (robot_name.empty() ? "" : robot_name + "/") + image_capture.frame_name_image_sensor();
+    header.stamp = spot_ros2::robotTimeToLocalTime(image_capture.acquisition_time(), clock_skew);
+    return header;
+  }
+
+  tl::expected<sensor_msgs::msg::Image, std::string> getDecompressImageMsg(const bosdyn::api::ImageCapture& image_capture,
+                                                            const std::string& robot_name,
+                                                            const google::protobuf::Duration& clock_skew) {
+    const auto& image = image_capture.image();
+    auto data = image.data();
+
+    const auto header = createImageHeader(image_capture, robot_name, clock_skew);
+    const auto pixel_format_cv = getCvPixelFormat(image.pixel_format());
+    if (!pixel_format_cv) {
+      return tl::make_unexpected("Failed to determine pixel format: " + pixel_format_cv.error());
+    }
+
+    if (image.format() == bosdyn::api::Image_Format_FORMAT_JPEG) {
+      // When the image is JPEG-compressed, it is represented as a 1 x (width * height) row of bytes.
+      // First we create a cv::Mat which contains the compressed image data...
+      const cv::Mat img_compressed{1, image.rows() * image.cols(), CV_8UC1, &data.front()};
+      // Then we decode it to extract the raw image into a new cv::Mat.
+      if (image.pixel_format() == bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_GREYSCALE_U8) {
+        const cv::Mat img_grey = cv::imdecode(img_compressed, cv::IMREAD_GRAYSCALE);
+        if (!img_grey.data) {
+          return tl::make_unexpected("Failed to decode JPEG-compressed image.");
+        }
+        const auto image = cv_bridge::CvImage{header, "mono8", img_grey}.getDecompressImageMsg();
+        return *image;
+      } else {
+        const cv::Mat img_bgr = cv::imdecode(img_compressed, cv::IMREAD_COLOR);
+        if (!img_bgr.data) {
+          return tl::make_unexpected("Failed to decode JPEG-compressed image.");
+        }
+        const auto image = cv_bridge::CvImage{header, "bgr8", img_bgr}.getDecompressImageMsg();
+        return *image;
+      }
+    } else if (image.format() == bosdyn::api::Image_Format_FORMAT_RAW) {
+      const cv::Mat img = cv::Mat(image.rows(), image.cols(), pixel_format_cv.value(), &data.front());
+      if (!img.data) {
+        return tl::make_unexpected("Failed to decode raw-formatted image.");
+      }
+      const auto image = cv_bridge::CvImage{header, sensor_msgs::image_encodings::TYPE_16UC1, img}.getDecompressImageMsg();
+      return *image;
+    } else if (image.format() == bosdyn::api::Image_Format_FORMAT_RLE) {
+      return tl::make_unexpected("Conversion from FORMAT_RLE is not yet implemented.");
+    } else {
+      return tl::make_unexpected("Unknown image format.");
+    }
+  }
+}

--- a/spot_driver/src/images/images_middleware_handle.cpp
+++ b/spot_driver/src/images/images_middleware_handle.cpp
@@ -9,7 +9,7 @@
 #include <spot_driver/interfaces/rclcpp_wall_timer_interface.hpp>
 
 namespace {
-constexpr auto kPublisherHistoryDepth = 1;
+constexpr auto kPublisherHistoryDepth = 10;
 
 constexpr auto kImageTopicSuffix = "image";
 constexpr auto kCameraInfoTopicSuffix = "camera_info";

--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -34,17 +34,18 @@ namespace spot_ros2::images {
     if (source.type == SpotImageType::RGB) {
       bosdyn::api::ImageRequest* image_request = request_message.add_image_requests();
       image_request->set_image_source_name(source_name);
-      // RGB images can have a user-configurable image quality setting.
+      // JPEG images can have a user-configurable image quality setting.
       image_request->set_quality_percent(rgb_image_quality);
       // The hand camera always provides RGB images
       if (source.camera == SpotCamera::HAND || has_rgb_cameras) {
         image_request->set_pixel_format(bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_RGB_U8);
+        // RGB images can be either raw or JPEG-compressed.
+        image_request->set_image_format(get_raw_rgb_images ? bosdyn::api::Image_Format_FORMAT_RAW
+                                                           : bosdyn::api::Image_Format_FORMAT_JPEG);
       } else {
+        // Grey images are always JPEG-compressed, so selection of RAW has no effect
         image_request->set_pixel_format(bosdyn::api::Image_PixelFormat_PIXEL_FORMAT_GREYSCALE_U8);
       }
-      // RGB images can be either raw or JPEG-compressed.
-      image_request->set_image_format(get_raw_rgb_images ? bosdyn::api::Image_Format_FORMAT_RAW
-                                                         : bosdyn::api::Image_Format_FORMAT_JPEG);
     } else if (source.type == SpotImageType::DEPTH) {
       bosdyn::api::ImageRequest* image_request = request_message.add_image_requests();
       image_request->set_image_source_name(source_name);
@@ -83,13 +84,14 @@ bool SpotImagePublisher::initialize() {
   const auto publish_depth_images = parameters_->getPublishDepthImages();
   const auto publish_depth_registered_images = parameters_->getPublishDepthRegisteredImages();
   const auto has_rgb_cameras = parameters_->getHasRGBCameras();
+  const auto publish_raw_rgb_cameras = parameters_->getPublishRawRGBCameras();
 
   // Generate the set of image sources based on which cameras the user has requested that we publish
   const auto sources =
       createImageSources(publish_rgb_images, publish_depth_images, publish_depth_registered_images, has_arm_);
 
   // Generate the image request message to capture the data from the specified image sources
-  image_request_message_ = createImageRequest(sources, has_rgb_cameras, rgb_image_quality, false);
+  image_request_message_ = createImageRequest(sources, has_rgb_cameras, rgb_image_quality, publish_raw_rgb_cameras);
 
   // Create a publisher for each image source
   middleware_handle_->createPublishers(sources);

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -19,6 +19,7 @@ constexpr auto kParameterNamePassword = "password";
 constexpr auto kParameterNameRGBImageQuality = "image_quality";
 constexpr auto kParameterNameHasRGBCameras = "rgb_cameras";
 constexpr auto kParameterNamePublishRGBImages = "publish_rgb";
+constexpr auto kParameterNamePublishRawRGBCameras = "publish_raw_rgb_cameras";
 constexpr auto kParameterNamePublishDepthImages = "publish_depth";
 constexpr auto kParameterNamePublishDepthRegisteredImages = "publish_depth_registered";
 constexpr auto kParameterPreferredOdomFrame = "preferred_odom_frame";
@@ -159,6 +160,10 @@ bool RclcppParameterInterface::getHasRGBCameras() const {
 
 bool RclcppParameterInterface::getPublishRGBImages() const {
   return declareAndGetParameter<bool>(node_, kParameterNamePublishRGBImages, kDefaultPublishRGBImages);
+}
+
+bool RclcppParameterInterface::getPublishRawRGBCameras() const {
+  return declareAndGetParameter<bool>(node_, kParameterNamePublishRawRGBCameras, kDefaultPublishRawRGBCameras);
 }
 
 bool RclcppParameterInterface::getPublishDepthImages() const {

--- a/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
+++ b/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
@@ -24,6 +24,8 @@ class FakeParameterInterface : public ParameterInterfaceBase {
 
   bool getHasRGBCameras() const override { return has_rgb_cameras; }
 
+  bool getPublishRawRGBCameras() const override { return publish_raw_rgb_cameras; }
+
   bool getPublishRGBImages() const override { return publish_rgb_images; }
 
   bool getPublishDepthImages() const override { return publish_depth_images; }
@@ -40,6 +42,7 @@ class FakeParameterInterface : public ParameterInterfaceBase {
 
   double rgb_image_quality = ParameterInterfaceBase::kDefaultRGBImageQuality;
   bool has_rgb_cameras = ParameterInterfaceBase::kDefaultHasRGBCameras;
+  bool publish_raw_rgb_cameras = ParameterInterfaceBase::kDefaultPublishRawRGBCameras;
   bool publish_rgb_images = ParameterInterfaceBase::kDefaultPublishRGBImages;
   bool publish_depth_images = ParameterInterfaceBase::kDefaultPublishDepthImages;
   bool publish_depth_registered_images = ParameterInterfaceBase::kDefaultPublishDepthRegisteredImages;

--- a/spot_driver/test/src/test_parameter_interface.cpp
+++ b/spot_driver/test/src/test_parameter_interface.cpp
@@ -183,6 +183,8 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromParameters) {
   node_->declare_parameter("image_quality", rgb_image_quality_parameter);
   constexpr auto has_rgb_cameras_parameter = false;
   node_->declare_parameter("rgb_cameras", has_rgb_cameras_parameter);
+  constexpr auto publish_raw_rgb_cameras = true;
+  node_->declare_parameter("publish_raw_rgb_cameras", publish_raw_rgb_cameras);
   constexpr auto publish_rgb_images_parameter = false;
   node_->declare_parameter("publish_rgb", publish_rgb_images_parameter);
   constexpr auto publish_depth_images_parameter = false;
@@ -202,6 +204,7 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromParameters) {
   EXPECT_THAT(parameter_interface.getPassword(), StrEq(password_parameter));
   EXPECT_THAT(parameter_interface.getRGBImageQuality(), Eq(rgb_image_quality_parameter));
   EXPECT_THAT(parameter_interface.getHasRGBCameras(), Eq(has_rgb_cameras_parameter));
+  EXPECT_THAT(parameter_interface.getPublishRawRGBCameras(), Eq(publish_raw_rgb_cameras));
   EXPECT_THAT(parameter_interface.getPublishRGBImages(), Eq(publish_rgb_images_parameter));
   EXPECT_THAT(parameter_interface.getPublishDepthImages(), Eq(publish_depth_images_parameter));
   EXPECT_THAT(parameter_interface.getPublishDepthRegisteredImages(), Eq(publish_depth_registered_images_parameter));
@@ -259,6 +262,7 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetConfigDefaults) {
   EXPECT_THAT(parameter_interface.getPassword(), StrEq("password"));
   EXPECT_THAT(parameter_interface.getRGBImageQuality(), Eq(70.0));
   EXPECT_THAT(parameter_interface.getHasRGBCameras(), IsTrue());
+  EXPECT_THAT(parameter_interface.getPublishRawRGBCameras(), false);
   EXPECT_THAT(parameter_interface.getPublishRGBImages(), IsTrue());
   EXPECT_THAT(parameter_interface.getPublishDepthImages(), IsTrue());
   EXPECT_THAT(parameter_interface.getPublishDepthRegisteredImages(), IsTrue());


### PR DESCRIPTION
## Change Overview

WIP 

Defaulting all images to compressed and having the option to decompress when needed.

Based off of #316 and #358

## Testing Done

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
