### PR TITLE
Skip sit for shutdown Spot on driver node destruction

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -3049,8 +3049,8 @@ class SpotROS(Node):
     def destroy_node(self) -> None:
         self.get_logger().info("Shutting down ROS driver for Spot")
         if self.spot_wrapper is not None:
-            self.spot_wrapper.sit()
-        if self.spot_wrapper is not None:
+            if self.spot_wrapper.check_is_powered_on():
+                self.spot_wrapper.sit()
             self.spot_wrapper.disconnect()
         super().destroy_node()
 


### PR DESCRIPTION
## Change Overview

Precisely what the title says. If Spot is powered off before the driver is torn down, the driver will fail to sit.

## Testing Done

Manually started the driver, powered off motors, stopped the driver.