### PR TITLE
Prevent from duplicated camera_info msgs

### DIFF
--- a/spot_driver/include/spot_driver/images/images_middleware_handle.hpp
+++ b/spot_driver/include/spot_driver/images/images_middleware_handle.hpp
@@ -43,18 +43,13 @@ class ImagesMiddlewareHandle : public SpotImagePublisher::MiddlewareHandle {
                         bool publish_compressed_images) override;
 
   /**
-   * @brief Publishes image and camera info messages to ROS 2 topics.
+   * @brief Publishes (compressed) images and camera info messages to ROS 2 topics.
    * @param images Map of image sources to image and camera info data.
+   * @param compressed_images Map of image sources to compressed image and camera info data.
    * @return If all images were published successfully, returns void. If there was an error, returns an error message.
    */
-  tl::expected<void, std::string> publishImages(const std::map<ImageSource, ImageWithCameraInfo>& images) override;
-
-  /**
-   * @brief Publishes compressed image and camera info messages to ROS 2 topics.
-   * @param images Map of image sources to compressed image and camera info data.
-   * @return If all images were published successfully, returns void. If there was an error, returns an error message.
-   */
-  tl::expected<void, std::string> publishCompressedImages(
+  tl::expected<void, std::string> publishImages(
+      const std::map<ImageSource, ImageWithCameraInfo>& images,
       const std::map<ImageSource, CompressedImageWithCameraInfo>& compressed_images) override;
 
  private:

--- a/spot_driver/include/spot_driver/images/spot_image_publisher.hpp
+++ b/spot_driver/include/spot_driver/images/spot_image_publisher.hpp
@@ -50,8 +50,8 @@ class SpotImagePublisher {
 
     virtual void createPublishers(const std::set<ImageSource>& image_sources, bool uncompress_images,
                                   bool publish_compressed_images) = 0;
-    virtual tl::expected<void, std::string> publishImages(const std::map<ImageSource, ImageWithCameraInfo>& images) = 0;
-    virtual tl::expected<void, std::string> publishCompressedImages(
+    virtual tl::expected<void, std::string> publishImages(
+        const std::map<ImageSource, ImageWithCameraInfo>& images,
         const std::map<ImageSource, CompressedImageWithCameraInfo>& compressed_images) = 0;
   };
 

--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -121,9 +121,7 @@ void SpotImagePublisher::timerCallback(bool uncompress_images, bool publish_comp
     return;
   }
 
-  middleware_handle_->publishImages(image_result.value().images_);
-  middleware_handle_->publishCompressedImages(image_result.value().compressed_images_);
-
+  middleware_handle_->publishImages(image_result.value().images_, image_result.value().compressed_images_);
   tf_broadcaster_->updateStaticTransforms(image_result.value().transforms_);
 }
 }  // namespace spot_ros2::images

--- a/spot_driver/test/src/images/test_spot_image_publisher.cpp
+++ b/spot_driver/test/src/images/test_spot_image_publisher.cpp
@@ -29,10 +29,10 @@ namespace spot_ros2::test {
 class MockMiddlewareHandle : public images::SpotImagePublisher::MiddlewareHandle {
  public:
   MOCK_METHOD(void, createPublishers, (const std::set<ImageSource>& image_sources, bool, bool), (override));
-  MOCK_METHOD((tl::expected<void, std::string>), publishImages, ((const std::map<ImageSource, ImageWithCameraInfo>&)),
+  MOCK_METHOD((tl::expected<void, std::string>), publishImages,
+              ((const std::map<ImageSource, ImageWithCameraInfo>&),
+               (const std::map<ImageSource, CompressedImageWithCameraInfo>&)),
               (override));
-  MOCK_METHOD((tl::expected<void, std::string>), publishCompressedImages,
-              ((const std::map<ImageSource, CompressedImageWithCameraInfo>&)), (override));
 };
 
 class TestInitSpotImagePublisher : public ::testing::Test {
@@ -116,7 +116,6 @@ TEST_F(TestRunSpotImagePublisher, PublishCallbackTriggersWithArm) {
     EXPECT_CALL(*image_client_interface,
                 getImages(Property(&::bosdyn::api::GetImageRequest::image_requests_size, 18), true, false));
     EXPECT_CALL(*middleware_handle, publishImages);
-    EXPECT_CALL(*middleware_handle, publishCompressedImages);
     EXPECT_CALL(*mock_tf_broadcaster_interface_ptr, updateStaticTransforms);
   }
 

--- a/spot_driver/test/src/images/test_spot_image_publisher_node.cpp
+++ b/spot_driver/test/src/images/test_spot_image_publisher_node.cpp
@@ -29,10 +29,10 @@ namespace spot_ros2::test {
 class MockMiddlewareHandle : public images::SpotImagePublisher::MiddlewareHandle {
  public:
   MOCK_METHOD(void, createPublishers, (const std::set<ImageSource>& image_sources, bool, bool), (override));
-  MOCK_METHOD((tl::expected<void, std::string>), publishImages, ((const std::map<ImageSource, ImageWithCameraInfo>&)),
+  MOCK_METHOD((tl::expected<void, std::string>), publishImages,
+              ((const std::map<ImageSource, ImageWithCameraInfo>&),
+               (const std::map<ImageSource, CompressedImageWithCameraInfo>&)),
               (override));
-  MOCK_METHOD((tl::expected<void, std::string>), publishCompressedImages,
-              ((const std::map<ImageSource, CompressedImageWithCameraInfo>&)), (override));
 };
 
 class SpotImagePubNodeTestFixture : public ::testing::Test {


### PR DESCRIPTION
## Change Overview

By sending both, the compressed image and the image within same function.

## Testing Done

unit test run
image transport rotation nodes used for rotating the frontcameras for Rviz don't complain (too often) on mismatches between image and camera_info topics.