### PR TITLE
[N/A] make install script fully automatic

### DIFF
--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -34,7 +34,7 @@ sudo pip3 install --force-reinstall -v "setuptools==59.6.0"
 # Install bosdyn_msgs - automatic conversions of BD protobufs to ROS messages
 wget -q -O /tmp/ros-humble-bosdyn_msgs_${MSG_VERSION}-jammy_${ARCH}.run https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/${MSG_VERSION}/ros-humble-bosdyn_msgs_${MSG_VERSION}-jammy_${ARCH}.run
 chmod +x /tmp/ros-humble-bosdyn_msgs_${MSG_VERSION}-jammy_${ARCH}.run
-sudo /tmp/ros-humble-bosdyn_msgs_${MSG_VERSION}-jammy_${ARCH}.run
+yes | sudo /tmp/ros-humble-bosdyn_msgs_${MSG_VERSION}-jammy_${ARCH}.run
 rm /tmp/ros-humble-bosdyn_msgs_${MSG_VERSION}-jammy_${ARCH}.run
 
 # Install spot-cpp-sdk

--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -34,7 +34,7 @@ sudo pip3 install --force-reinstall -v "setuptools==59.6.0"
 # Install bosdyn_msgs - automatic conversions of BD protobufs to ROS messages
 wget -q -O /tmp/ros-humble-bosdyn_msgs_${MSG_VERSION}-jammy_${ARCH}.run https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/${MSG_VERSION}/ros-humble-bosdyn_msgs_${MSG_VERSION}-jammy_${ARCH}.run
 chmod +x /tmp/ros-humble-bosdyn_msgs_${MSG_VERSION}-jammy_${ARCH}.run
-yes | sudo /tmp/ros-humble-bosdyn_msgs_${MSG_VERSION}-jammy_${ARCH}.run
+yes | sudo /tmp/ros-humble-bosdyn_msgs_${MSG_VERSION}-jammy_${ARCH}.run  --nox11
 rm /tmp/ros-humble-bosdyn_msgs_${MSG_VERSION}-jammy_${ARCH}.run
 
 # Install spot-cpp-sdk


### PR DESCRIPTION
## Change Overview

Resolves https://github.com/bdaiinstitute/spot_ros2/issues/381. Now no user input is needed during the portion of the install script that installs `bosdyn_msgs`. 

## Testing Done

- [x] uninstalled `bosdyn_msgs` packages locally and verified that when running the install script on main I was prompted for a `y`
- [x] running the install script on this branch does not prompt me for `y` and successfully installs `bosdyn_msgs` packages

I needed the `--nox11` flag as when piping in the `yes`, as by default this opens another terminal session that doesn't register anything before the pipe. 