### PR TITLE
[SW-1065] uncompress images using image transport

### DIFF
--- a/spot_driver/include/spot_driver/api/default_image_client.hpp
+++ b/spot_driver/include/spot_driver/api/default_image_client.hpp
@@ -21,7 +21,6 @@ class DefaultImageClient : public ImageClientInterface {
                      const std::string& robot_name);
 
   [[nodiscard]] tl::expected<GetImagesResult, std::string> getImages(::bosdyn::api::GetImageRequest request,
-                                                                     bool uncompress_images,
                                                                      bool publish_compressed_images) override;
 
  private:

--- a/spot_driver/include/spot_driver/images/images_middleware_handle.hpp
+++ b/spot_driver/include/spot_driver/images/images_middleware_handle.hpp
@@ -39,8 +39,7 @@ class ImagesMiddlewareHandle : public SpotImagePublisher::MiddlewareHandle {
    * @brief Populates the image_publishgers_ and info_publishers_ members with image and camera info publishers.
    * @param image_sources Set of ImageSources. A publisher will be created for each ImageSource.
    */
-  void createPublishers(const std::set<ImageSource>& image_sources, bool uncompress_images,
-                        bool publish_compressed_images) override;
+  void createPublishers(const std::set<ImageSource>& image_sources, bool publish_compressed_images) override;
 
   /**
    * @brief Publishes (compressed) images and camera info messages to ROS 2 topics.

--- a/spot_driver/include/spot_driver/images/spot_image_publisher.hpp
+++ b/spot_driver/include/spot_driver/images/spot_image_publisher.hpp
@@ -48,8 +48,7 @@ class SpotImagePublisher {
    public:
     virtual ~MiddlewareHandle() = default;
 
-    virtual void createPublishers(const std::set<ImageSource>& image_sources, bool uncompress_images,
-                                  bool publish_compressed_images) = 0;
+    virtual void createPublishers(const std::set<ImageSource>& image_sources, bool publish_compressed_images) = 0;
     virtual tl::expected<void, std::string> publishImages(
         const std::map<ImageSource, ImageWithCameraInfo>& images,
         const std::map<ImageSource, CompressedImageWithCameraInfo>& compressed_images) = 0;
@@ -86,7 +85,7 @@ class SpotImagePublisher {
    * @brief Callback function which is called through timer_interface_.
    * @details Requests image data from Spot, and then publishes the images and static camera transforms.
    */
-  void timerCallback(bool uncompress_images, bool publish_compressed_images);
+  void timerCallback(bool publish_compressed_images);
 
   /**
    * @brief Image request message which is set when SpotImagePublisher::initialize() is called.

--- a/spot_driver/include/spot_driver/interfaces/image_client_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/image_client_interface.hpp
@@ -33,7 +33,6 @@ class ImageClientInterface {
   ImageClientInterface& operator=(const ImageClientInterface&) = delete;
   virtual ~ImageClientInterface() = default;
   virtual tl::expected<GetImagesResult, std::string> getImages(::bosdyn::api::GetImageRequest request,
-                                                               bool uncompress_images,
                                                                bool publish_compressed_images) = 0;
 };
 }  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -31,7 +31,6 @@ class ParameterInterfaceBase {
   virtual double getRGBImageQuality() const = 0;
   virtual bool getHasRGBCameras() const = 0;
   virtual bool getPublishRGBImages() const = 0;
-  virtual bool getUncompressImages() const = 0;
   virtual bool getPublishCompressedImages() const = 0;
   virtual bool getPublishDepthImages() const = 0;
   virtual bool getPublishDepthRegisteredImages() const = 0;
@@ -46,7 +45,6 @@ class ParameterInterfaceBase {
   static constexpr double kDefaultRGBImageQuality{70.0};
   static constexpr bool kDefaultHasRGBCameras{true};
   static constexpr bool kDefaultPublishRGBImages{true};
-  static constexpr bool kDefaultUncompressImages{true};
   static constexpr bool kDefaultPublishCompressedImages{false};
   static constexpr bool kDefaultPublishDepthImages{true};
   static constexpr bool kDefaultPublishDepthRegisteredImages{true};

--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -45,7 +45,7 @@ class ParameterInterfaceBase {
   static constexpr double kDefaultRGBImageQuality{70.0};
   static constexpr bool kDefaultHasRGBCameras{true};
   static constexpr bool kDefaultPublishRGBImages{true};
-  static constexpr bool kDefaultPublishCompressedImages{false};
+  static constexpr bool kDefaultPublishCompressedImages{true};
   static constexpr bool kDefaultPublishDepthImages{true};
   static constexpr bool kDefaultPublishDepthRegisteredImages{true};
   static constexpr auto kDefaultPreferredOdomFrame = "odom";

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
@@ -27,7 +27,6 @@ class RclcppParameterInterface : public ParameterInterfaceBase {
   [[nodiscard]] std::string getPassword() const override;
   [[nodiscard]] double getRGBImageQuality() const override;
   [[nodiscard]] bool getHasRGBCameras() const override;
-  [[nodiscard]] bool getUncompressImages() const override;
   [[nodiscard]] bool getPublishCompressedImages() const override;
   [[nodiscard]] bool getPublishRGBImages() const override;
   [[nodiscard]] bool getPublishDepthImages() const override;

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -105,25 +105,6 @@ def create_point_cloud_nodelets(
     return composable_node_descriptions
 
 
-def create_uncompressed_image_publishers(spot_name: LaunchConfiguration, has_arm: bool, ld: LaunchDescription) -> None:
-    """Create image transport nodes to uncompress the compressed images from the driver."""
-    prefix = f"/{spot_name}" if spot_name else ""
-    for camera in get_camera_sources(has_arm):
-        ld.add_action(
-            launch_ros.actions.Node(
-                package="image_transport",
-                executable="republish",
-                arguments=["compressed", "raw"],
-                name=f"uncompress_{camera}",
-                namespace=spot_name,
-                remappings=[
-                    (f"{prefix}/in/compressed", f"{prefix}/camera/{camera}/compressed"),
-                    (f"{prefix}/out", f"{prefix}/camera/{camera}/image"),
-                ],
-            ),
-        )
-
-
 def get_login_parameters(context: LaunchContext) -> Tuple[str, str, str, Optional[int], Optional[str]]:
     """Obtain the username, password, hostname, and port of Spot from the environment variables or, if they are not
     set, the configuration file yaml."""
@@ -371,7 +352,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     ld.add_action(container)
 
     # conditionally uncompress the images
-    prefix = f"/{spot_name}" if spot_name else ""
+    image_prefix = f"/{spot_name}" if spot_name else ""
     for camera in get_camera_sources(has_arm):
         ld.add_action(
             launch_ros.actions.Node(
@@ -381,8 +362,8 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
                 name=f"uncompress_{camera}",
                 namespace=spot_name,
                 remappings=[
-                    (f"{prefix}/in/compressed", f"{prefix}/camera/{camera}/compressed"),
-                    (f"{prefix}/out", f"{prefix}/camera/{camera}/image"),
+                    (f"{image_prefix}/in/compressed", f"{image_prefix}/camera/{camera}/compressed"),
+                    (f"{image_prefix}/out", f"{image_prefix}/camera/{camera}/image"),
                 ],
                 condition=IfCondition(LaunchConfiguration("uncompress_images")),
             ),

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -116,10 +116,11 @@ def create_uncompressed_image_publishers(
                 package="image_transport",
                 executable="republish",
                 arguments=["compressed", "raw"],
-                name=f"{camera}_uncompresser",
+                name=f"uncompress_{camera}",
+                namespace=spot_name,
                 remappings=[
-                    ("/in/compressed", f"/{spot_name}/camera/{camera}/compressed"),
-                    ("/out", f"/{spot_name}/camera/{camera}/uncompressed"),
+                    (f"/{spot_name}/in/compressed", f"/{spot_name}/camera/{camera}/compressed"),
+                    (f"/{spot_name}/out", f"/{spot_name}/camera/{camera}/uncompressed"),
                 ],
             ),
         )
@@ -430,15 +431,15 @@ def generate_launch_description() -> launch.LaunchDescription:
             "uncompress_images",
             default_value="True",
             choices=["True", "False"],
-            description="Choose whether to publish uncompressed images from Spot (True by default).",
+            description="Choose whether to publish uncompressed images from Spot.",
         )
     )
     launch_args.append(
         DeclareLaunchArgument(
             "publish_compressed_images",
-            default_value="False",
+            default_value="True",
             choices=["True", "False"],
-            description="Choose whether to publish compressed images from Spot (False by default).",
+            description="Choose whether to publish compressed images from Spot.",
         )
     )
     launch_args.append(DeclareLaunchArgument("spot_name", default_value="", description="Name of Spot"))

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -105,11 +105,9 @@ def create_point_cloud_nodelets(
     return composable_node_descriptions
 
 
-def create_uncompressed_image_publishers(
-    context: launch.LaunchContext, spot_name: LaunchConfiguration, has_arm: bool, ld: LaunchDescription
-) -> None:
+def create_uncompressed_image_publishers(spot_name: LaunchConfiguration, has_arm: bool, ld: LaunchDescription) -> None:
     """Create image transport nodes to uncompress the compressed images from the driver."""
-
+    prefix = f"/{spot_name}" if spot_name else ""
     for camera in get_camera_sources(has_arm):
         ld.add_action(
             launch_ros.actions.Node(
@@ -119,8 +117,8 @@ def create_uncompressed_image_publishers(
                 name=f"uncompress_{camera}",
                 namespace=spot_name,
                 remappings=[
-                    (f"/{spot_name}/in/compressed", f"/{spot_name}/camera/{camera}/compressed"),
-                    (f"/{spot_name}/out", f"/{spot_name}/camera/{camera}/image"),
+                    (f"{prefix}/in/compressed", f"{prefix}/camera/{camera}/compressed"),
+                    (f"{prefix}/out", f"{prefix}/camera/{camera}/image"),
                 ],
             ),
         )
@@ -375,7 +373,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
 
     # uncompress the images
     if uncompress_images:
-        create_uncompressed_image_publishers(context, spot_name, has_arm, ld)
+        create_uncompressed_image_publishers(spot_name, has_arm, ld)
 
 
 def generate_launch_description() -> launch.LaunchDescription:

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -120,7 +120,7 @@ def create_uncompressed_image_publishers(
                 namespace=spot_name,
                 remappings=[
                     (f"/{spot_name}/in/compressed", f"/{spot_name}/camera/{camera}/compressed"),
-                    (f"/{spot_name}/out", f"/{spot_name}/camera/{camera}/uncompressed"),
+                    (f"/{spot_name}/out", f"/{spot_name}/camera/{camera}/image"),
                 ],
             ),
         )

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -104,11 +104,9 @@ def create_point_cloud_nodelets(
         )
     return composable_node_descriptions
 
+
 def create_uncompressed_image_publishers(
-    context: launch.LaunchContext,
-    spot_name: LaunchConfiguration,
-    has_arm: bool,
-    ld: LaunchDescription
+    context: launch.LaunchContext, spot_name: LaunchConfiguration, has_arm: bool, ld: LaunchDescription
 ) -> None:
     """Create image transport nodes to uncompress the compressed images from the driver."""
 
@@ -117,10 +115,12 @@ def create_uncompressed_image_publishers(
             launch_ros.actions.Node(
                 package="image_transport",
                 executable="republish",
-                arguments=['compressed', 'raw'],
+                arguments=["compressed", "raw"],
                 name=f"{camera}_uncompresser",
-                remappings=[('/in/compressed', f'/{spot_name}/camera/{camera}/compressed'),
-                            ('/out', f'/{spot_name}/camera/{camera}/uncompressed')],
+                remappings=[
+                    ("/in/compressed", f"/{spot_name}/camera/{camera}/compressed"),
+                    ("/out", f"/{spot_name}/camera/{camera}/uncompressed"),
+                ],
             ),
         )
 
@@ -261,7 +261,6 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     )
     spot_image_publisher_params = {
         "spot_name": spot_name,
-        "uncompress_images": uncompress_images,
         "publish_compressed_images": publish_compressed_images,
     }
 
@@ -374,7 +373,9 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     ld.add_action(container)
 
     # uncompress the images
-    create_uncompressed_image_publishers(context, spot_name, has_arm, ld)
+    if uncompress_images:
+        create_uncompressed_image_publishers(context, spot_name, has_arm, ld)
+
 
 def generate_launch_description() -> launch.LaunchDescription:
     launch_args = []

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -82,6 +82,15 @@ def create_point_cloud_nodelets(
     composable_node_descriptions = []
 
     for camera in get_camera_sources(has_arm):
+        name_prefix = f"/{spot_name}" if spot_name else ""
+        point_cloud_params = {}
+        point_cloud_params[f"qos_overrides.{name_prefix}/camera/{camera}/image.subscription.reliability"] = (
+            "best_effort"
+        )
+        point_cloud_params[f"qos_overrides.{name_prefix}/depth_registered/{camera}/image.subscription.reliability"] = (
+            "best_effort"
+        )
+
         composable_node_descriptions.append(
             launch_ros.descriptions.ComposableNode(
                 package="depth_image_proc",
@@ -100,6 +109,7 @@ def create_point_cloud_nodelets(
                     ),
                     ("points", PathJoinSubstitution(["depth_registered", camera, "points"]).perform(context)),
                 ],
+                parameters=[point_cloud_params],
             ),
         )
     return composable_node_descriptions

--- a/spot_driver/src/api/default_image_client.cpp
+++ b/spot_driver/src/api/default_image_client.cpp
@@ -153,7 +153,6 @@ DefaultImageClient::DefaultImageClient(::bosdyn::client::ImageClient* image_clie
     : image_client_{image_client}, time_sync_api_{time_sync_api}, robot_name_{robot_name} {}
 
 tl::expected<GetImagesResult, std::string> DefaultImageClient::getImages(::bosdyn::api::GetImageRequest request,
-                                                                         bool uncompress_images,
                                                                          bool publish_compressed_images) {
   std::shared_future<::bosdyn::client::GetImageResultType> get_image_result_future =
       image_client_->GetImageAsync(request);
@@ -196,7 +195,7 @@ tl::expected<GetImagesResult, std::string> DefaultImageClient::getImages(::bosdy
                                          CompressedImageWithCameraInfo{compressed_image_msg.value(), info_msg.value()});
     }
 
-    if (image.format() != bosdyn::api::Image_Format_FORMAT_JPEG || uncompress_images) {
+    if (image.format() != bosdyn::api::Image_Format_FORMAT_JPEG) {
       const auto image_msg = getDecompressImageMsg(image_response.shot(), robot_name_, clock_skew_result.value());
       if (!image_msg) {
         return tl::make_unexpected("Failed to convert SDK image response to ROS Image message: " + image_msg.error());

--- a/spot_driver/src/images/images_middleware_handle.cpp
+++ b/spot_driver/src/images/images_middleware_handle.cpp
@@ -20,7 +20,7 @@ ImagesMiddlewareHandle::ImagesMiddlewareHandle(const std::shared_ptr<rclcpp::Nod
 ImagesMiddlewareHandle::ImagesMiddlewareHandle(const rclcpp::NodeOptions& node_options)
     : ImagesMiddlewareHandle(std::make_shared<rclcpp::Node>("image_publisher", node_options)) {}
 
-void ImagesMiddlewareHandle::createPublishers(const std::set<ImageSource>& image_sources, bool uncompress_images,
+void ImagesMiddlewareHandle::createPublishers(const std::set<ImageSource>& image_sources,
                                               bool publish_compressed_images) {
   image_publishers_.clear();
   info_publishers_.clear();
@@ -36,7 +36,7 @@ void ImagesMiddlewareHandle::createPublishers(const std::set<ImageSource>& image
           image_topic_name, node_->create_publisher<sensor_msgs::msg::CompressedImage>(
                                 image_topic_name + "/compressed", makePublisherQoS(kPublisherHistoryDepth)));
     }
-    if (uncompress_images || (image_source.type != SpotImageType::RGB)) {
+    if (image_source.type != SpotImageType::RGB) {
       image_publishers_.try_emplace(
           image_topic_name, node_->create_publisher<sensor_msgs::msg::Image>(image_topic_name + "/image",
                                                                              makePublisherQoS(kPublisherHistoryDepth)));

--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -87,7 +87,6 @@ bool SpotImagePublisher::initialize() {
   const auto has_rgb_cameras = parameters_->getHasRGBCameras();
   // always use compressed transport from SPOT, we decompress it in paralell if desired
   const auto publish_raw_rgb_cameras = false;
-  const auto uncompress_images = parameters_->getUncompressImages();
   const auto publish_compressed_images = parameters_->getPublishCompressedImages();
 
   // Generate the set of image sources based on which cameras the user has requested that we publish
@@ -98,24 +97,23 @@ bool SpotImagePublisher::initialize() {
   image_request_message_ = createImageRequest(sources, has_rgb_cameras, rgb_image_quality, publish_raw_rgb_cameras);
 
   // Create a publisher for each image source
-  middleware_handle_->createPublishers(sources, uncompress_images, publish_compressed_images);
+  middleware_handle_->createPublishers(sources, publish_compressed_images);
 
   // Create a timer to request and publish images at a fixed rate
-  timer_->setTimer(kImageCallbackPeriod, [this, uncompress_images, publish_compressed_images]() {
-    timerCallback(uncompress_images, publish_compressed_images);
+  timer_->setTimer(kImageCallbackPeriod, [this, publish_compressed_images]() {
+    timerCallback(publish_compressed_images);
   });
 
   return true;
 }
 
-void SpotImagePublisher::timerCallback(bool uncompress_images, bool publish_compressed_images) {
+void SpotImagePublisher::timerCallback(bool publish_compressed_images) {
   if (!image_request_message_) {
     logger_->logError("No image request message generated. Returning.");
     return;
   }
 
-  const auto image_result =
-      image_client_interface_->getImages(*image_request_message_, uncompress_images, publish_compressed_images);
+  const auto image_result = image_client_interface_->getImages(*image_request_message_, publish_compressed_images);
   if (!image_result.has_value()) {
     logger_->logError(std::string{"Failed to get images: "}.append(image_result.error()));
     return;

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -19,7 +19,6 @@ constexpr auto kParameterNamePassword = "password";
 constexpr auto kParameterNameRGBImageQuality = "image_quality";
 constexpr auto kParameterNameHasRGBCameras = "rgb_cameras";
 constexpr auto kParameterNamePublishRGBImages = "publish_rgb";
-constexpr auto kParameterNameUncompressImages = "uncompress_images";
 constexpr auto kParameterNamePublishCompressedImages = "publish_compressed_images";
 constexpr auto kParameterNamePublishDepthImages = "publish_depth";
 constexpr auto kParameterNamePublishDepthRegisteredImages = "publish_depth_registered";
@@ -161,10 +160,6 @@ bool RclcppParameterInterface::getHasRGBCameras() const {
 
 bool RclcppParameterInterface::getPublishRGBImages() const {
   return declareAndGetParameter<bool>(node_, kParameterNamePublishRGBImages, kDefaultPublishRGBImages);
-}
-
-bool RclcppParameterInterface::getUncompressImages() const {
-  return declareAndGetParameter<bool>(node_, kParameterNameUncompressImages, kDefaultUncompressImages);
 }
 
 bool RclcppParameterInterface::getPublishCompressedImages() const {

--- a/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
+++ b/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
@@ -24,8 +24,6 @@ class FakeParameterInterface : public ParameterInterfaceBase {
 
   bool getHasRGBCameras() const override { return has_rgb_cameras; }
 
-  bool getUncompressImages() const override { return uncompress_images; }
-
   bool getPublishCompressedImages() const override { return publish_compressed_images; }
 
   bool getPublishRGBImages() const override { return publish_rgb_images; }
@@ -44,7 +42,6 @@ class FakeParameterInterface : public ParameterInterfaceBase {
 
   double rgb_image_quality = ParameterInterfaceBase::kDefaultRGBImageQuality;
   bool has_rgb_cameras = ParameterInterfaceBase::kDefaultHasRGBCameras;
-  bool uncompress_images = ParameterInterfaceBase::kDefaultUncompressImages;
   bool publish_compressed_images = ParameterInterfaceBase::kDefaultPublishCompressedImages;
   bool publish_rgb_images = ParameterInterfaceBase::kDefaultPublishRGBImages;
   bool publish_depth_images = ParameterInterfaceBase::kDefaultPublishDepthImages;

--- a/spot_driver/test/include/spot_driver/mock/mock_image_client.hpp
+++ b/spot_driver/test/include/spot_driver/mock/mock_image_client.hpp
@@ -11,7 +11,7 @@
 namespace spot_ros2::test {
 class MockImageClient : public ImageClientInterface {
  public:
-  MOCK_METHOD((tl::expected<GetImagesResult, std::string>), getImages, (::bosdyn::api::GetImageRequest, bool, bool),
+  MOCK_METHOD((tl::expected<GetImagesResult, std::string>), getImages, (::bosdyn::api::GetImageRequest, bool),
               (override));
 };
 }  // namespace spot_ros2::test

--- a/spot_driver/test/src/images/test_spot_image_publisher.cpp
+++ b/spot_driver/test/src/images/test_spot_image_publisher.cpp
@@ -28,7 +28,7 @@ using ::testing::Unused;
 namespace spot_ros2::test {
 class MockMiddlewareHandle : public images::SpotImagePublisher::MiddlewareHandle {
  public:
-  MOCK_METHOD(void, createPublishers, (const std::set<ImageSource>& image_sources, bool, bool), (override));
+  MOCK_METHOD(void, createPublishers, (const std::set<ImageSource>& image_sources, bool), (override));
   MOCK_METHOD((tl::expected<void, std::string>), publishImages,
               ((const std::map<ImageSource, ImageWithCameraInfo>&),
                (const std::map<ImageSource, CompressedImageWithCameraInfo>&)),
@@ -114,7 +114,7 @@ TEST_F(TestRunSpotImagePublisher, PublishCallbackTriggersWithArm) {
     // THEN the static transforms to the image frames are updated
     InSequence seq;
     EXPECT_CALL(*image_client_interface,
-                getImages(Property(&::bosdyn::api::GetImageRequest::image_requests_size, 18), true, false));
+                getImages(Property(&::bosdyn::api::GetImageRequest::image_requests_size, 18), true));
     EXPECT_CALL(*middleware_handle, publishImages);
     EXPECT_CALL(*mock_tf_broadcaster_interface_ptr, updateStaticTransforms);
   }
@@ -151,7 +151,7 @@ TEST_F(TestRunSpotImagePublisher, PublishCallbackTriggersWithNoArm) {
     // THEN the static transforms to the image frames are updated
     InSequence seq;
     EXPECT_CALL(*image_client_interface,
-                getImages(Property(&::bosdyn::api::GetImageRequest::image_requests_size, 15), true, false));
+                getImages(Property(&::bosdyn::api::GetImageRequest::image_requests_size, 15), true));
     EXPECT_CALL(*middleware_handle, publishImages);
     EXPECT_CALL(*mock_tf_broadcaster_interface_ptr, updateStaticTransforms);
   }

--- a/spot_driver/test/src/images/test_spot_image_publisher_node.cpp
+++ b/spot_driver/test/src/images/test_spot_image_publisher_node.cpp
@@ -28,7 +28,7 @@ using ::testing::Return;
 namespace spot_ros2::test {
 class MockMiddlewareHandle : public images::SpotImagePublisher::MiddlewareHandle {
  public:
-  MOCK_METHOD(void, createPublishers, (const std::set<ImageSource>& image_sources, bool, bool), (override));
+  MOCK_METHOD(void, createPublishers, (const std::set<ImageSource>& image_sources, bool), (override));
   MOCK_METHOD((tl::expected<void, std::string>), publishImages,
               ((const std::map<ImageSource, ImageWithCameraInfo>&),
                (const std::map<ImageSource, CompressedImageWithCameraInfo>&)),

--- a/spot_driver/test/src/test_parameter_interface.cpp
+++ b/spot_driver/test/src/test_parameter_interface.cpp
@@ -262,7 +262,7 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetConfigDefaults) {
   EXPECT_THAT(parameter_interface.getPassword(), StrEq("password"));
   EXPECT_THAT(parameter_interface.getRGBImageQuality(), Eq(70.0));
   EXPECT_THAT(parameter_interface.getHasRGBCameras(), IsTrue());
-  EXPECT_THAT(parameter_interface.getPublishCompressedImages(), false);
+  EXPECT_THAT(parameter_interface.getPublishCompressedImages(), IsTrue());
   EXPECT_THAT(parameter_interface.getPublishRGBImages(), IsTrue());
   EXPECT_THAT(parameter_interface.getPublishDepthImages(), IsTrue());
   EXPECT_THAT(parameter_interface.getPublishDepthRegisteredImages(), IsTrue());

--- a/spot_driver/test/src/test_parameter_interface.cpp
+++ b/spot_driver/test/src/test_parameter_interface.cpp
@@ -183,8 +183,6 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromParameters) {
   node_->declare_parameter("image_quality", rgb_image_quality_parameter);
   constexpr auto has_rgb_cameras_parameter = false;
   node_->declare_parameter("rgb_cameras", has_rgb_cameras_parameter);
-  constexpr auto uncompress_images = false;
-  node_->declare_parameter("uncompress_images", uncompress_images);
   constexpr auto publish_compressed_images = true;
   node_->declare_parameter("publish_compressed_images", publish_compressed_images);
   constexpr auto publish_rgb_images_parameter = false;
@@ -206,7 +204,6 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromParameters) {
   EXPECT_THAT(parameter_interface.getPassword(), StrEq(password_parameter));
   EXPECT_THAT(parameter_interface.getRGBImageQuality(), Eq(rgb_image_quality_parameter));
   EXPECT_THAT(parameter_interface.getHasRGBCameras(), Eq(has_rgb_cameras_parameter));
-  EXPECT_THAT(parameter_interface.getUncompressImages(), Eq(uncompress_images));
   EXPECT_THAT(parameter_interface.getPublishCompressedImages(), Eq(publish_compressed_images));
   EXPECT_THAT(parameter_interface.getPublishRGBImages(), Eq(publish_rgb_images_parameter));
   EXPECT_THAT(parameter_interface.getPublishDepthImages(), Eq(publish_depth_images_parameter));
@@ -265,7 +262,6 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetConfigDefaults) {
   EXPECT_THAT(parameter_interface.getPassword(), StrEq("password"));
   EXPECT_THAT(parameter_interface.getRGBImageQuality(), Eq(70.0));
   EXPECT_THAT(parameter_interface.getHasRGBCameras(), IsTrue());
-  EXPECT_THAT(parameter_interface.getUncompressImages(), true);
   EXPECT_THAT(parameter_interface.getPublishCompressedImages(), false);
   EXPECT_THAT(parameter_interface.getPublishRGBImages(), IsTrue());
   EXPECT_THAT(parameter_interface.getPublishDepthImages(), IsTrue());


### PR DESCRIPTION
## Change Overview

Always publish compressed images, with the option to uncompress. 

This speeds up uncompressed image publishing from ~5Hz to ~13Hz on my laptop over ethernet. Over wifi on my laptop, the speedup goes from <1Hz to ~3Hz. 

this is only when the point cloud publishing is turned off. If I enable point cloud publishing with `publish_point_clouds:=true` the compressed images still come in at 15 Hz but the regular images only at 3 (and the point clouds come in at 6 somehow). the chain goes compressed (spot_ros2) -> image (compressed_image_transport) -> point cloud (depth_image_proc)

## Testing Done

- [x] massive speed up if not publishing point clouds
- [x] successfully tested with or without `spot_name` set
- [ ] figure out how to maintain the speed while still publishing point clouds
- [ ] check speedup on a desktop machine
- [ ] check that greyscale publishing still functional

 ## questions
* There is a small slowdown when using the image republisher from image transport of about ~2Hz (I get the compressed images at 15, and the uncompressed at like 13). How much of an issue is this?
* the republisher nodes are somewhat slow to shut down after `CTRL+C`, how much of an issue is this?
