### PR TITLE
[SW-1112] update install_spot_ros2.sh for SDK 4.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 # Overview
 This is a ROS 2 package for Boston Dynamics' Spot. The package contains all necessary topics, services and actions to teleoperate or navigate Spot.
-This package is derived from this [ROS 1 package](https://github.com/heuristicus/spot_ros). This package currently corresponds to version 4.0.0 of the [spot-sdk](https://github.com/boston-dynamics/spot-sdk/releases/tag/v4.0.0).
+This package is derived from this [ROS 1 package](https://github.com/heuristicus/spot_ros). This package currently corresponds to version 4.0.2 of the [spot-sdk](https://github.com/boston-dynamics/spot-sdk/releases/tag/v4.0.2).
 
 ## Prerequisites
 This package is tested for Ubuntu 22.04 and ROS 2 Humble, which can be installed following [this guide](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html). 
@@ -144,29 +144,42 @@ The `bosdyn_msgs` package is installed as a debian package as part of the `insta
 
 If you encounter problems when using this repository, feel free to open an issue or PR.
 
-## Verify Boston Dynamics API Installation
-If you encounter `ModuleNotFoundErrors` with `bosdyn` packages upon running the driver, it is likely that the necessary Boston Dynamics API packages did not get installed with `install_spot_ros2.sh`. To check this, you can run the following command. Note that all versions should be `4.0.0`. 
+## Verify Package Versions
+If you encounter `ModuleNotFoundErrors` with `bosdyn` packages upon running the driver, it is likely that the necessary Boston Dynamics API packages did not get installed with `install_spot_ros2.sh`. To check this, you can run the following command. Note that all versions should be `4.0.2`. 
 ```bash
 $ pip list | grep bosdyn
-bosdyn-api                           4.0.0
-bosdyn-api-msgs                      4.0.0
-bosdyn-auto-return-api-msgs          4.0.0
-bosdyn-autowalk-api-msgs             4.0.0
-bosdyn-choreography-client           4.0.0
-bosdyn-choreography-protos           4.0.0
-bosdyn-client                        4.0.0
-bosdyn-core                          4.0.0
-bosdyn-graph-nav-api-msgs            4.0.0
-bosdyn-keepalive-api-msgs            4.0.0
-bosdyn-log-status-api-msgs           4.0.0
-bosdyn-metrics-logging-api-msgs      4.0.0
-bosdyn-mission                       4.0.0
-bosdyn-mission-api-msgs              4.0.0
-bosdyn-msgs                          4.0.0
-bosdyn-spot-api-msgs                 4.0.0
-bosdyn-spot-cam-api-msgs             4.0.0
+bosdyn-api                               4.0.2
+bosdyn-api-msgs                          4.0.2
+bosdyn-auto-return-api-msgs              4.0.2
+bosdyn-autowalk-api-msgs                 4.0.2
+bosdyn-choreography-client               4.0.2
+bosdyn-client                            4.0.2
+bosdyn-core                              4.0.2
+bosdyn-graph-nav-api-msgs                4.0.2
+bosdyn-keepalive-api-msgs                4.0.2
+bosdyn-log-status-api-msgs               4.0.2
+bosdyn-metrics-logging-api-msgs          4.0.2
+bosdyn-mission                           4.0.2
+bosdyn-mission-api-msgs                  4.0.2
+bosdyn-msgs                              4.0.2
+bosdyn-spot-api-msgs                     4.0.2
+bosdyn-spot-cam-api-msgs                 4.0.2
 ```
 If these packages were not installed correctly on your system, you can try manually installing them following [Boston Dynamics' guide](https://dev.bostondynamics.com/docs/python/quickstart#install-spot-python-packages).
+
+The above command verifies the installation of the `bosdyn` packages from Boston Dynamics and the generated protobuf to ROS messages in the `bosdyn_msgs` package (these have `msgs` in the name). You can also verify the `bosdyn_msgs` installation was correct with the following command:
+```bash
+$ ros2 pkg xml bosdyn_msgs -t version
+4.0.2
+```
+
+Finally, you can verify the installation of the `spot-cpp-sdk` with the following command:
+```
+$ dpkg -l spot-cpp-sdk
+||/ Name           Version      Architecture Description
++++-==============-============-============-=================================
+ii  spot-cpp-sdk   4.0.2        amd64        Boston Dynamics Spot C++ SDK
+```
 
 # License
 

--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -1,6 +1,6 @@
 ARCH="amd64"
-SDK_VERSION="4.0.0"
-MSG_VERSION="${SDK_VERSION}-2"
+SDK_VERSION="4.0.2"
+MSG_VERSION="${SDK_VERSION}"
 ROS_DISTRO=humble
 HELP=$'--arm64: Installs ARM64 version'
 REQUIREMENTS_FILE=spot_wrapper/requirements.txt

--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -38,6 +38,6 @@ yes | sudo /tmp/ros-humble-bosdyn_msgs_${MSG_VERSION}-jammy_${ARCH}.run  --nox11
 rm /tmp/ros-humble-bosdyn_msgs_${MSG_VERSION}-jammy_${ARCH}.run
 
 # Install spot-cpp-sdk
-wget -q -O /tmp/spot-cpp-sdk_${SDK_VERSION}_${ARCH}.deb https://github.com/bdaiinstitute/spot-cpp-sdk/releases/download/${SDK_VERSION}/spot-cpp-sdk_${SDK_VERSION}_${ARCH}.deb
+wget -q -O /tmp/spot-cpp-sdk_${SDK_VERSION}_${ARCH}.deb https://github.com/bdaiinstitute/spot-cpp-sdk/releases/download/v${SDK_VERSION}/spot-cpp-sdk_${SDK_VERSION}_${ARCH}.deb
 sudo dpkg -i /tmp/spot-cpp-sdk_${SDK_VERSION}_${ARCH}.deb
 rm /tmp/spot-cpp-sdk_${SDK_VERSION}_${ARCH}.deb


### PR DESCRIPTION
## Change Overview

Updates this repo for spot-sdk 4.0.2!

- [x] The update to spot_wrapper needs to go in first: https://github.com/bdaiinstitute/spot_ros2/pull/401


## Testing Done

- [x] locally ran the install script in my ros2 environment (outside of docker). Verified that installations of bosdyn_msgs, the python bosdyn sdk, and spot-cpp-sdk were all updated to 4.0.2. 
- [x] Tested all `spot_examples` on robot as well as a few standard service calls
- [x] CI
