### PR TITLE
Added dockerfile for running the driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
     python3-colcon-common-extensions \
     python3-colcon-mixin \
     python3-rosdep \
-    libpython3-dev \
-    ros-humble-tl-expected && \
+    libpython3-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Create ROS workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ WORKDIR /ros_ws/src
 
 # Clone driver code
 RUN git clone https://github.com/bdaiinstitute/spot_ros2.git .
+RUN git submodule update --init --recursive
 
 # Run install script
 RUN /ros_ws/src/install_spot_ros2.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ RUN /ros_ws/src/install_spot_ros2.sh
 # Build packages with Colcon
 WORKDIR /ros_ws/
 RUN . /opt/ros/humble/setup.sh && \
-    colcon build --symlink-install --packages-ignore proto2ros_tests
+    colcon build --symlink-install --packages-ignore proto2ros proto2ros_tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
     python3-colcon-mixin \
     python3-rosdep \
     libpython3-dev \
-    python3-vcstool \
     ros-humble-tl-expected && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,6 @@ WORKDIR /ros_ws/src
 # Clone driver code
 RUN git clone https://github.com/bdaiinstitute/spot_ros2.git .
 
-# Change gitmodule links to HTTPS to anonymously clone them
-RUN sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
-RUN git submodule update --init --recursive
-
 # Run install script
 RUN /ros_ws/src/install_spot_ros2.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM osrf/ros:humble-desktop-full
+
+# Install dependencies (taken from devcontainer dockerfile)
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
+    apt-get update -q && \
+    apt-get install -yq --no-install-recommends \
+    lcov \
+    curl \
+    python3-pip \
+    python-is-python3 \
+    python3-argcomplete \
+    python3-colcon-common-extensions \
+    python3-colcon-mixin \
+    python3-rosdep \
+    libpython3-dev \
+    python3-vcstool \
+    ros-humble-tl-expected && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /repo
+
+COPY . .
+
+RUN sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+RUN git submodule update --init --recursive

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM osrf/ros:humble-desktop-full
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
     apt-get update -q && \
     apt-get install -yq --no-install-recommends \
-    lcov \
     curl \
     wget \
     python3-pip \

--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ source install/local_setup.bash
 
 We suggest ignoring the `proto2ros_tests` package in the build as it is not necessary for running the driver. If you choose to build it, you will see a number of error messages from testing the failure paths. 
 
+### Alternative - Docker Image
+
+Alternatively, a Dockerfile is available that prepares a ready-to-run ROS2 Humble install with the Spot driver installed.
+
+No special precautions or actions need to be taken to build the image. Just clone the repository and run `docker build` in the root of the repo to build the image.
+
+No special actions need to be taken to run the image either. However, depending on what you intend to _do_ with the driver in your project, the following flags may be useful:
+
+| Flag     | Use             |
+| -------- | --------------- |
+| `--runtime nvidia` + `--gpus all`  | Use the [NVIDIA Container Runtime](https://developer.nvidia.com/container-runtime) to run the container with GPU acceleration |
+| `-e DISPLAY`  | Bind your display to the container in order to run GUI apps. Note that you will need to allow the Docker container to connect to your X11 server, which can be done in a number of ways ranging from disabling X11 authentication entirely, or by allowing the Docker daemon specifically to access your display server.  |
+| `--network host` | Use the host network directly. May help resolve issues connecting to Spot Wifi |
+
+The image does not have the `proto2ros_tests` package built. You'll need to build it yourself inside the container if you need to use it.
+
 # Spot ROS 2 Driver
 
 The Spot driver contains all of the necessary topics, services, and actions for controlling Spot over ROS 2. To launch the driver, run:


### PR DESCRIPTION
## Change Overview

I had spoken with @khughes-bdai on a previous Issue's discussion about creating a dockerfile that can be used to run the driver in production (whether that be on a computer or pushing it to Spot CORE I/O). This is separate from the Dockerfile found in the .devcontainer directory, as that is for creating a containerized development environment for something like GitHub Codespaces.

This PR adds a dockerfile to the root of the repository that can be used to run driver within a docker container. It uses the `osrf/ros-noetic-desktop-full` image as a base, and automatically downloads and installs the driver code from this repository.

I've pushed the built image to my docker hub account for convenience. It can be found at `ryroche/spot_ros2`

## Testing Done

This PR is a bit abnormal, as it does not modify any of the code. Thus I was unable to use traditional unit testing to ensure that the additions of this PR work.

- The docker image builds successfully
- Running the container, I was able to connect the driver to my robotics lab's spot robot and call the trigger services provided by the driver (`power_on`, `stand`, `sit`, etc.)
- Graphical tools such as `rviz2` work, you just need to enable your container to connect to your X11 server, whether that be by generating/exporting XAuth data to your container or by disabling authentication by running `xauth +x`