### PR TITLE
[SW-893] odometry velocities reported in the wrong frame

### DIFF
--- a/spot_driver/include/spot_driver/conversions/robot_state.hpp
+++ b/spot_driver/include/spot_driver/conversions/robot_state.hpp
@@ -151,6 +151,8 @@ std::optional<tf2_msgs::msg::TFMessage> getTf(const ::bosdyn::api::FrameTreeSnap
  *
  * @param robot_state Robot state message from Spot.
  * @param clock_skew The clock skew reported by Spot at the timepoint when the robot state was created.
+ * @param is_using_vision Set to 'true' if Spot's preferred base frame is "vision". Otherwise, the preferred base frame
+ * will be "odom".
  * @return If the robot state message contains the velocity of the Spot's body relative to the odometry frame in its
  * kinematic state, return a TwistWithCovarianceStamped containing this data. Otherwise, return nullopt.
  */

--- a/spot_driver/test/src/conversions/test_robot_state.cpp
+++ b/spot_driver/test/src/conversions/test_robot_state.cpp
@@ -335,7 +335,7 @@ TEST(RobotStateConversions, TestGetTfInverted) {
   EXPECT_THAT(transform.transform, GeometryMsgsTransformEq(-1.0, -2.0, -3.0, 1.0, 0.0, 0.0, 0.0));
 }
 
-TEST(RobotStateConversions, TestGetOdomTwist) {
+TEST(RobotStateConversions, TestGetOdomTwistNoTransformsSnapshot) {
   // GIVEN a RobotState that contains info about the velocity of the body in the odom frame
   ::bosdyn::api::RobotState robot_state;
   google::protobuf::Timestamp timestamp;
@@ -353,11 +353,116 @@ TEST(RobotStateConversions, TestGetOdomTwist) {
   const auto is_using_vision = false;
   const auto out = getOdomTwist(robot_state, clock_skew, is_using_vision);
 
+  // THEN this fails as there is no TransformsSnapshot
+  ASSERT_THAT(out.has_value(), IsFalse());
+}
+
+TEST(RobotStateConversions, TestGetOdomTwistBodyAtOdom) {
+  // GIVEN a RobotState that contains info about the velocity of the body in the odom frame
+  ::bosdyn::api::RobotState robot_state;
+  google::protobuf::Timestamp timestamp;
+  timestamp.set_seconds(99);
+  timestamp.set_nanos(0);
+  addAcquisitionTimestamp(robot_state.mutable_kinematic_state(), timestamp);
+
+  // GIVEN the odom frame is the root of the frame tree
+  addRootFrame(robot_state.mutable_kinematic_state()->mutable_transforms_snapshot(), "odom");
+  // GIVEN the body frame is at the odom frame
+  addTransform(robot_state.mutable_kinematic_state()->mutable_transforms_snapshot(), "body", "odom", 0.0, 0.0, 0.0, 1.0,
+               0.0, 0.0, 0.0);
+
+  auto* velocity_linear = robot_state.mutable_kinematic_state()->mutable_velocity_of_body_in_odom()->mutable_linear();
+  velocity_linear->set_x(1.0);
+  velocity_linear->set_y(2.0);
+  velocity_linear->set_z(3.0);
+  auto* velocity_angular = robot_state.mutable_kinematic_state()->mutable_velocity_of_body_in_odom()->mutable_angular();
+  velocity_angular->set_x(1.0);
+  velocity_angular->set_y(2.0);
+  velocity_angular->set_z(3.0);
+
+  // GIVEN some nominal clock skew
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(1);
+
+  // WHEN we create a TwistWithCovarianceStamped ROS message
+  const bool using_vision = false;
+  const auto out = getOdomTwist(robot_state, clock_skew, using_vision);
+
   // THEN this succeeds
   ASSERT_THAT(out.has_value(), IsTrue());
 
-  // THEN the output twist matches the velocity in the robot state
+  // THEN the output twist matches the velocity in the robot state.
   EXPECT_THAT(out->twist.twist, GeometryMsgsTwistEq(1.0, 2.0, 3.0, 1.0, 2.0, 3.0));
+  EXPECT_THAT(out->header, ClockSkewIsAppliedToHeader(timestamp, clock_skew));
+}
+
+TEST(RobotStateConversions, TestGetOdomTwistLinearTransformationLinearVelocity) {
+  // GIVEN a RobotState that contains info about the velocity of the body in the odom frame
+  ::bosdyn::api::RobotState robot_state;
+  google::protobuf::Timestamp timestamp;
+  timestamp.set_seconds(99);
+  timestamp.set_nanos(0);
+  addAcquisitionTimestamp(robot_state.mutable_kinematic_state(), timestamp);
+
+  // GIVEN the odom frame is the root of the frame tree
+  addRootFrame(robot_state.mutable_kinematic_state()->mutable_transforms_snapshot(), "odom");
+  // GIVEN the body frame is linearly translated 2m forward in the x direction
+  addTransform(robot_state.mutable_kinematic_state()->mutable_transforms_snapshot(), "body", "odom", 2.0, 0.0, 0.0, 1.0,
+               0.0, 0.0, 0.0);
+
+  auto* velocity_linear = robot_state.mutable_kinematic_state()->mutable_velocity_of_body_in_odom()->mutable_linear();
+  velocity_linear->set_x(1.0);
+  velocity_linear->set_y(0.0);
+  velocity_linear->set_z(0.0);
+
+  // GIVEN some nominal clock skew
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(1);
+
+  // WHEN we create a TwistWithCovarianceStamped ROS message
+  const bool using_vision = false;
+  const auto out = getOdomTwist(robot_state, clock_skew, using_vision);
+
+  // THEN this succeeds
+  ASSERT_THAT(out.has_value(), IsTrue());
+
+  // THEN the output twist matches the velocity in the robot state.
+  EXPECT_THAT(out->twist.twist, GeometryMsgsTwistEq(1.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+  EXPECT_THAT(out->header, ClockSkewIsAppliedToHeader(timestamp, clock_skew));
+}
+
+TEST(RobotStateConversions, TestGetOdomTwistAngularTransformationLinearVelocity) {
+  // GIVEN a RobotState that contains info about the velocity of the body in the odom frame
+  ::bosdyn::api::RobotState robot_state;
+  google::protobuf::Timestamp timestamp;
+  timestamp.set_seconds(99);
+  timestamp.set_nanos(0);
+  addAcquisitionTimestamp(robot_state.mutable_kinematic_state(), timestamp);
+
+  // GIVEN the odom frame is the root of the frame tree
+  addRootFrame(robot_state.mutable_kinematic_state()->mutable_transforms_snapshot(), "odom");
+  // GIVEN the body frame is rotated by 180 degrees from the odom frame (quaternion 0 0 0 1)
+  addTransform(robot_state.mutable_kinematic_state()->mutable_transforms_snapshot(), "body", "odom", 0.0, 0.0, 0.0, 0.0,
+               0.0, 0.0, 1.0);
+
+  auto* velocity_linear = robot_state.mutable_kinematic_state()->mutable_velocity_of_body_in_odom()->mutable_linear();
+  velocity_linear->set_x(1.0);
+  velocity_linear->set_y(0.0);
+  velocity_linear->set_z(0.0);
+
+  // GIVEN some nominal clock skew
+  google::protobuf::Duration clock_skew;
+  clock_skew.set_seconds(1);
+
+  // WHEN we create a TwistWithCovarianceStamped ROS message
+  const bool using_vision = false;
+  const auto out = getOdomTwist(robot_state, clock_skew, using_vision);
+
+  // THEN this succeeds
+  ASSERT_THAT(out.has_value(), IsTrue());
+
+  // THEN the output twist matches the velocity in the robot state.
+  EXPECT_THAT(out->twist.twist, GeometryMsgsTwistEq(-1.0, 0.0, 0.0, 0.0, 0.0, 0.0));
   EXPECT_THAT(out->header, ClockSkewIsAppliedToHeader(timestamp, clock_skew));
 }
 
@@ -378,6 +483,7 @@ TEST(RobotStateConversions, TestGetOdomTwistNoBodyVelocityInRobotState) {
   ASSERT_THAT(out.has_value(), IsFalse());
 }
 
+// TODO(khughes): Fix this test
 TEST(RobotStateConversions, TestGetOdomInOdomFrame) {
   // GIVEN some nominal clock skew
   google::protobuf::Duration clock_skew;
@@ -393,10 +499,10 @@ TEST(RobotStateConversions, TestGetOdomInOdomFrame) {
   // GIVEN the odom frame is the root of the frame tree
   addRootFrame(robot_state.mutable_kinematic_state()->mutable_transforms_snapshot(), "odom");
   // GIVEN the body frame is at a nonzero pose relative to the odom frame
-  addTransform(robot_state.mutable_kinematic_state()->mutable_transforms_snapshot(), "body", "odom", 1.0, 2.0, 3.0, 1.0,
+  addTransform(robot_state.mutable_kinematic_state()->mutable_transforms_snapshot(), "body", "odom", 1.0, 2.0, 0.0, 1.0,
                0.0, 0.0, 0.0);
   // GIVEN the body is moving at a nonzero velocity relative to the odom frame
-  addBodyVelocityOdom(robot_state.mutable_kinematic_state(), 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+  addBodyVelocityOdom(robot_state.mutable_kinematic_state(), 0.0, 0.0, 0.0, 0.0, 0.0, 3.0);
   // GIVEN the frame tree snapshot is valid
   ASSERT_THAT(bosdyn::api::ValidateFrameTreeSnapshot(robot_state.kinematic_state().transforms_snapshot()),
               Eq(::bosdyn::api::ValidateFrameTreeSnapshotStatus::VALID));
@@ -413,9 +519,10 @@ TEST(RobotStateConversions, TestGetOdomInOdomFrame) {
   EXPECT_THAT(out->child_frame_id, StrEq("prefix/body"));
   EXPECT_THAT(out->header, ClockSkewIsAppliedToHeader(timestamp, clock_skew));
 
-  // THEN the Odometry ROS message contains the same pose and twist data as the RobotState
-  EXPECT_THAT(out->pose.pose, GeometryMsgsPoseEq(1.0, 2.0, 3.0, 1.0, 0.0, 0.0, 0.0));
-  EXPECT_THAT(out->twist.twist, GeometryMsgsTwistEq(1.0, 2.0, 3.0, 4.0, 5.0, 6.0));
+  // THEN the Odometry ROS message contains the same pose data as the robot state
+  EXPECT_THAT(out->pose.pose, GeometryMsgsPoseEq(1.0, 2.0, 0.0, 1.0, 0.0, 0.0, 0.0));
+  // THEN the Odometry ROS message contains the appropriate transformed twist data
+  EXPECT_THAT(out->twist.twist, GeometryMsgsTwistEq(-6.0, 3.0, 0.0, 0.0, 0.0, 3.0));
 }
 
 TEST(RobotStateConversions, TestGetOdomInVisionFrame) {
@@ -430,9 +537,9 @@ TEST(RobotStateConversions, TestGetOdomInVisionFrame) {
   timestamp.set_seconds(99);
   timestamp.set_nanos(0);
   addAcquisitionTimestamp(robot_state.mutable_kinematic_state(), timestamp);
-  addBodyVelocityVision(robot_state.mutable_kinematic_state(), 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+  addBodyVelocityVision(robot_state.mutable_kinematic_state(), 0.0, 0.0, 0.0, 0.0, 0.0, 3.0);
   addRootFrame(robot_state.mutable_kinematic_state()->mutable_transforms_snapshot(), "vision");
-  addTransform(robot_state.mutable_kinematic_state()->mutable_transforms_snapshot(), "body", "vision", 1.0, 2.0, 3.0,
+  addTransform(robot_state.mutable_kinematic_state()->mutable_transforms_snapshot(), "body", "vision", 1.0, 2.0, 0.0,
                1.0, 0.0, 0.0, 0.0);
   ASSERT_THAT(bosdyn::api::ValidateFrameTreeSnapshot(robot_state.kinematic_state().transforms_snapshot()),
               Eq(::bosdyn::api::ValidateFrameTreeSnapshotStatus::VALID));
@@ -449,9 +556,10 @@ TEST(RobotStateConversions, TestGetOdomInVisionFrame) {
   EXPECT_THAT(out->child_frame_id, StrEq("prefix/body"));
   EXPECT_THAT(out->header, ClockSkewIsAppliedToHeader(timestamp, clock_skew));
 
-  // THEN the Odometry ROS message contains the same pose and twist data as the RobotState
-  EXPECT_THAT(out->pose.pose, GeometryMsgsPoseEq(1.0, 2.0, 3.0, 1.0, 0.0, 0.0, 0.0));
-  EXPECT_THAT(out->twist.twist, GeometryMsgsTwistEq(1.0, 2.0, 3.0, 4.0, 5.0, 6.0));
+  // THEN the Odometry ROS message contains the same pose data as the robot state
+  EXPECT_THAT(out->pose.pose, GeometryMsgsPoseEq(1.0, 2.0, 0.0, 1.0, 0.0, 0.0, 0.0));
+  // THEN the Odometry ROS message contains the appropriate transformed twist data
+  EXPECT_THAT(out->twist.twist, GeometryMsgsTwistEq(-6.0, 3.0, 0.0, 0.0, 0.0, 3.0));
 }
 
 TEST(RobotStateConversions, TestGetOdomMissingAcquisitionTimestamp) {
@@ -492,7 +600,7 @@ TEST(RobotStateConversions, TestGetOdomMissingBodyVelocityOdom) {
               Eq(::bosdyn::api::ValidateFrameTreeSnapshotStatus::VALID));
 
   // WHEN we try to create an Odometry message from the RobotState
-  const auto out = getOdom(robot_state, clock_skew, "prefix/", true);
+  const auto out = getOdom(robot_state, clock_skew, "prefix/", false);
 
   // THEN this does not succeed
   ASSERT_THAT(out.has_value(), IsFalse());
@@ -528,7 +636,7 @@ TEST(RobotStateConversions, TestGetOdomInvalidTransformSnapshot) {
   timestamp.set_seconds(99);
   timestamp.set_nanos(0);
   addAcquisitionTimestamp(robot_state.mutable_kinematic_state(), timestamp);
-  addBodyVelocityOdom(robot_state.mutable_kinematic_state(), 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+  addBodyVelocityVision(robot_state.mutable_kinematic_state(), 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
   addTransform(robot_state.mutable_kinematic_state()->mutable_transforms_snapshot(), "body", "vision", 1.0, 2.0, 3.0,
                1.0, 0.0, 0.0, 0.0);
   ASSERT_THAT(bosdyn::api::ValidateFrameTreeSnapshot(robot_state.kinematic_state().transforms_snapshot()),


### PR DESCRIPTION
## Change Overview

As brought up in https://github.com/bdaiinstitute/spot_ros2/issues/29, the odometry twist should be reported in the body frame, not the odom frame. This will make the spot driver easier to use with other ROS tools that expect this data to be in this format. 

## Testing Done

- [x] walk the robot in a straight line from a variety of different heading angles. ensure that the twist component has linear velocity only in the x dimension.
- [x] update tests to account for new change
- [ ] I want confirmation from users in https://github.com/bdaiinstitute/spot_ros2/issues/29 that this correctly resolves the issue before merging (leaving the do not merge label on until this is verified) 