### PR TITLE
[SW-736] Only sit on shutdown if driver holds the estop

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2913,7 +2913,8 @@ class SpotROS(Node):
     def destroy_node(self) -> None:
         self.get_logger().info("Shutting down ROS driver for Spot")
         if self.spot_wrapper is not None:
-            if self.spot_wrapper.check_is_powered_on():
+            # If the driver owns the estop, we want to sit before powering off.
+            if self.spot_wrapper.check_is_powered_on() and self.start_estop.value:
                 self.spot_wrapper.sit()
             self.spot_wrapper.disconnect()
         super().destroy_node()

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2913,11 +2913,9 @@ class SpotROS(Node):
     def destroy_node(self) -> None:
         self.get_logger().info("Shutting down ROS driver for Spot")
         if self.spot_wrapper is not None:
-            # If the driver owns the estop, we want to sit before powering off.
             if self.spot_wrapper.check_is_powered_on() and self.start_estop.value:
-                self.spot_wrapper.sit()
-                # This sleep is necessary for the robot to not collapse
-                time.sleep(3.0)
+                self.get_logger().info("Sitting down...")
+                self.spot_wrapper.sit_blocking()
             self.spot_wrapper.disconnect()
         super().destroy_node()
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2916,6 +2916,8 @@ class SpotROS(Node):
             # If the driver owns the estop, we want to sit before powering off.
             if self.spot_wrapper.check_is_powered_on() and self.start_estop.value:
                 self.spot_wrapper.sit()
+                # This sleep is necessary for the robot to not collapse on the ground as sit() is non-blocking
+                time.sleep(3.0)
             self.spot_wrapper.disconnect()
         super().destroy_node()
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2916,7 +2916,7 @@ class SpotROS(Node):
             # If the driver owns the estop, we want to sit before powering off.
             if self.spot_wrapper.check_is_powered_on() and self.start_estop.value:
                 self.spot_wrapper.sit()
-                # This sleep is necessary for the robot to not collapse on the ground as sit() is non-blocking
+                # This sleep is necessary for the robot to not collapse
                 time.sleep(3.0)
             self.spot_wrapper.disconnect()
         super().destroy_node()


### PR DESCRIPTION
## Change Overview

Currently, when you CTRL+C the driver, Spot will sit. If the estop is held by the tablet, this is annoying to deal with if you are starting and stopping the driver often, so this PR removes this feature.

If the estop is held by the driver, we still need to force sitting on shutdown, otherwise the robot will collapse to the ground if you CTRL+C.

EDIT: https://github.com/bdaiinstitute/spot_wrapper/pull/122 and https://github.com/bdaiinstitute/spot_ros2/pull/420 need to go in first so I can use the blocking version of the sit command. 

## Testing Done

- [x] started driver without an estop (i.e., estop is controlled by the tablet). Upon CTRL+C'ing the driver, the robot doesn't sit.
- [x] started driver with an estop (i.e., added `start_estop: True` to my config yaml). Robot cleanly sits down upon driver CTRL+C
