### PR TITLE
Add `python3-tk` as `spot_driver` dep

### DIFF
--- a/spot_driver/package.xml
+++ b/spot_driver/package.xml
@@ -33,6 +33,7 @@
 
   <exec_depend>bdai_ros2_wrappers</exec_depend>
   <exec_depend>python3-protobuf</exec_depend>
+  <exec_depend>python3-tk</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>spot_description</exec_depend>


### PR DESCRIPTION
## Change Overview

Precisely what the title says. This omission is causing CI failures.

## Testing Done

I'll leave this to CI.