### PR TITLE
[SW-1142] Add cameras_used parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ See [`spot_examples`](spot_examples/) for some more complex examples of using th
 ## Images
 Perception data from Spot is handled through the `spot_image_publishers.launch.py` launchfile, which is launched by default from the driver. If you want to only view images from Spot, without bringing up any of the nodes to control the robot, you can also choose to run this launchfile independently.
 
-By default, the driver will publish RGB images as well as depth maps from the `frontleft`, `frontright`, `left`, `right`, and `back` cameras on Spot (plus `hand` if your Spot has an arm). You can customize the cameras that are streamed from by adding the `cameras_used` parameter to your config yaml. (For example, to stream from only the front left and front right cameras, you can add `cameras_used: ["frontleft", "frontright"]`). Additionally, if your Spot has greyscale cameras, you will need to set `rgb_cameras: False` in your configuration YAML file, or you will not recieve any image data.
+By default, the driver will publish RGB images as well as depth maps from the `frontleft`, `frontright`, `left`, `right`, and `back` cameras on Spot (plus `hand` if your Spot has an arm). You can customize the cameras that are streamed from by adding the `cameras_used` parameter to your config yaml. (For example, to stream from only the front left and front right cameras, you can add `cameras_used: ["frontleft", "frontright"]`). Additionally, if your Spot has greyscale cameras, you will need to set `rgb_cameras: False` in your configuration YAML file, or you will not receive any image data.
 
 By default, the driver does not publish point clouds. To enable this, launch the driver with `publish_point_clouds:=True`.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ See [`spot_examples`](spot_examples/) for some more complex examples of using th
 ## Images
 Perception data from Spot is handled through the `spot_image_publishers.launch.py` launchfile, which is launched by default from the driver. If you want to only view images from Spot, without bringing up any of the nodes to control the robot, you can also choose to run this launchfile independently.
 
-By default, the driver will publish RGB images as well as depth maps from the `frontleft`, `frontright`, `left`, `right`, and `back` cameras on Spot (plus `hand` if your Spot has an arm). You can customize the cameras that are streamed from by adding `cameras_used` parameter to your config yaml. For example, to stream from only the frontleft and frontright cameras, you can add `cameras_used: ["frontleft", "frontright"]`. Additionally, if your Spot has greyscale cameras, you will need to set `rgb_cameras: False` in your configuration YAML file, or you will not recieve any image data.
+By default, the driver will publish RGB images as well as depth maps from the `frontleft`, `frontright`, `left`, `right`, and `back` cameras on Spot (plus `hand` if your Spot has an arm). You can customize the cameras that are streamed from by adding the `cameras_used` parameter to your config yaml. (For example, to stream from only the front left and front right cameras, you can add `cameras_used: ["frontleft", "frontright"]`). Additionally, if your Spot has greyscale cameras, you will need to set `rgb_cameras: False` in your configuration YAML file, or you will not recieve any image data.
 
 By default, the driver does not publish point clouds. To enable this, launch the driver with `publish_point_clouds:=True`.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ See [`spot_examples`](spot_examples/) for some more complex examples of using th
 ## Images
 Perception data from Spot is handled through the `spot_image_publishers.launch.py` launchfile, which is launched by default from the driver. If you want to only view images from Spot, without bringing up any of the nodes to control the robot, you can also choose to run this launchfile independently.
 
-By default, the driver will publish RGB images as well as depth maps from the `frontleft`, `frontright`, `left`, `right`, and `back` cameras on Spot (plus `hand` if your Spot has an arm). If your Spot has greyscale cameras, you will need to set `rgb_cameras: False` in your configuration YAML file, or you will not recieve any image data. 
+By default, the driver will publish RGB images as well as depth maps from the `frontleft`, `frontright`, `left`, `right`, and `back` cameras on Spot (plus `hand` if your Spot has an arm). You can customize the cameras that are streamed from by adding `cameras_used` parameter to your config yaml. For example, to stream from only the frontleft and frontright cameras, you can add `cameras_used: ["frontleft", "frontright"]`. Additionally, if your Spot has greyscale cameras, you will need to set `rgb_cameras: False` in your configuration YAML file, or you will not recieve any image data.
 
 By default, the driver does not publish point clouds. To enable this, launch the driver with `publish_point_clouds:=True`.
 

--- a/spot_driver/config/spot_ros_example.yaml
+++ b/spot_driver/config/spot_ros_example.yaml
@@ -27,6 +27,8 @@
     rgb_cameras: True  # Set to False if your robot has greyscale cameras -- otherwise you won't receive data.
     initialize_spot_cam: False # Set to True if you are connecting to a SpotCam payload module.
 
+    # cameras_enabled: ["frontleft", "frontright", "left", "right", "back", "hand"]
+
     # The following parameters are used in the image stitcher node and were determined through a lot of manual tuning.
     # They can be adjusted if the stitched image looks incorrect on your robot.
 

--- a/spot_driver/config/spot_ros_example.yaml
+++ b/spot_driver/config/spot_ros_example.yaml
@@ -27,7 +27,8 @@
     rgb_cameras: True  # Set to False if your robot has greyscale cameras -- otherwise you won't receive data.
     initialize_spot_cam: False # Set to True if you are connecting to a SpotCam payload module.
 
-    # cameras_enabled: ["frontleft", "frontright", "left", "right", "back", "hand"]
+    # You can uncomment and edit the list below if you only want to publish data from a certain set of cameras.
+    # cameras_used: ["frontleft", "frontright", "left", "right", "back", "hand"]
 
     # The following parameters are used in the image stitcher node and were determined through a lot of manual tuning.
     # They can be adjusted if the stitched image looks incorrect on your robot.

--- a/spot_driver/include/spot_driver/api/spot_image_sources.hpp
+++ b/spot_driver/include/spot_driver/api/spot_image_sources.hpp
@@ -8,6 +8,7 @@
 
 #include <set>
 #include <string>
+#include <vector>
 
 namespace spot_ros2 {
 /**
@@ -46,7 +47,7 @@ namespace spot_ros2 {
  * @param has_hand_camera Sets whether to request images from the hand camera.
  * @return A set of ImageSources which represents all requested image and camera types.
  */
-[[nodiscard]] std::set<ImageSource> createImageSources(const bool get_rgb_images, const bool get_depth_images,
-                                                       const bool get_depth_registered_images,
-                                                       const bool has_hand_camera);
+[[nodiscard]] std::set<ImageSource> createImageSources(const std::vector<std::string> cameras_used,
+                                                       const bool get_rgb_images, const bool get_depth_images,
+                                                       const bool get_depth_registered_images);
 }  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/api/spot_image_sources.hpp
+++ b/spot_driver/include/spot_driver/api/spot_image_sources.hpp
@@ -37,6 +37,16 @@ namespace spot_ros2 {
 [[nodiscard]] tl::expected<ImageSource, std::string> fromSpotImageSourceName(const std::string& source_name);
 
 /**
+ * @brief Create a list of the Spot cameras to use from the list of cameras_used.
+
+ * @param has_hand_camera Sets whether to request images from the hand camera.
+ * @param cameras_used List of cameras to stream from.
+ * @return A list of SpotCameras representing which cameras are enabled.
+ */
+[[nodiscard]] std::vector<spot_ros2::SpotCamera> getSpotCamerasUsed(const bool has_hand_camera,
+                                                                    const std::vector<std::string>& cameras_used);
+
+/**
  * @brief Create a set of image sources corresponding to the specified image types.
  * @details We represent the collection of ImageSources as a std::set to clearly communicate the requirement that we
  * must only send one request to Spot for a given combination of camera type and image type.

--- a/spot_driver/include/spot_driver/api/spot_image_sources.hpp
+++ b/spot_driver/include/spot_driver/api/spot_image_sources.hpp
@@ -37,14 +37,14 @@ namespace spot_ros2 {
 [[nodiscard]] tl::expected<ImageSource, std::string> fromSpotImageSourceName(const std::string& source_name);
 
 /**
- * @brief Create a list of the Spot cameras to use from the list of cameras_used.
+ * @brief Create a set of the Spot cameras to use from the list of cameras_used.
 
  * @param has_hand_camera Sets whether to request images from the hand camera.
  * @param cameras_used List of cameras to stream from.
- * @return A list of SpotCameras representing which cameras are enabled.
+ * @return A set of SpotCameras representing which cameras are enabled.
  */
-[[nodiscard]] std::vector<spot_ros2::SpotCamera> getSpotCamerasUsed(const bool has_hand_camera,
-                                                                    const std::vector<std::string>& cameras_used);
+[[nodiscard]] std::set<SpotCamera> getSpotCamerasUsed(const bool has_hand_camera,
+                                                      const std::vector<std::string>& cameras_used);
 
 /**
  * @brief Create a set of image sources corresponding to the specified image types.

--- a/spot_driver/include/spot_driver/api/spot_image_sources.hpp
+++ b/spot_driver/include/spot_driver/api/spot_image_sources.hpp
@@ -45,9 +45,11 @@ namespace spot_ros2 {
  * @param get_depth_images Sets whether to request depth images.
  * @param get_depth_registered_images Sets whether to request registered depth images.
  * @param has_hand_camera Sets whether to request images from the hand camera.
+ * @param cameras_used List of cameras to stream from.
  * @return A set of ImageSources which represents all requested image and camera types.
  */
-[[nodiscard]] std::set<ImageSource> createImageSources(const std::vector<std::string> cameras_used,
-                                                       const bool get_rgb_images, const bool get_depth_images,
-                                                       const bool get_depth_registered_images);
+[[nodiscard]] std::set<ImageSource> createImageSources(const bool get_rgb_images, const bool get_depth_images,
+                                                       const bool get_depth_registered_images,
+                                                       const bool has_hand_camera,
+                                                       const std::vector<std::string> cameras_used);
 }  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/api/spot_image_sources.hpp
+++ b/spot_driver/include/spot_driver/api/spot_image_sources.hpp
@@ -36,16 +36,6 @@ namespace spot_ros2 {
  */
 [[nodiscard]] tl::expected<ImageSource, std::string> fromSpotImageSourceName(const std::string& source_name);
 
-// /**
-//  * @brief Create a set of the Spot cameras to use from the list of cameras_used.
-
-//  * @param has_hand_camera Sets whether to request images from the hand camera.
-//  * @param cameras_used List of cameras to stream from.
-//  * @return A set of SpotCameras representing which cameras are enabled.
-//  */
-// [[nodiscard]] std::set<SpotCamera> getSpotCamerasUsed(const bool has_hand_camera,
-//                                                       const std::vector<std::string>& cameras_used);
-
 /**
  * @brief Create a set of image sources corresponding to the specified image types.
  * @details We represent the collection of ImageSources as a std::set to clearly communicate the requirement that we

--- a/spot_driver/include/spot_driver/api/spot_image_sources.hpp
+++ b/spot_driver/include/spot_driver/api/spot_image_sources.hpp
@@ -36,15 +36,15 @@ namespace spot_ros2 {
  */
 [[nodiscard]] tl::expected<ImageSource, std::string> fromSpotImageSourceName(const std::string& source_name);
 
-/**
- * @brief Create a set of the Spot cameras to use from the list of cameras_used.
+// /**
+//  * @brief Create a set of the Spot cameras to use from the list of cameras_used.
 
- * @param has_hand_camera Sets whether to request images from the hand camera.
- * @param cameras_used List of cameras to stream from.
- * @return A set of SpotCameras representing which cameras are enabled.
- */
-[[nodiscard]] std::set<SpotCamera> getSpotCamerasUsed(const bool has_hand_camera,
-                                                      const std::vector<std::string>& cameras_used);
+//  * @param has_hand_camera Sets whether to request images from the hand camera.
+//  * @param cameras_used List of cameras to stream from.
+//  * @return A set of SpotCameras representing which cameras are enabled.
+//  */
+// [[nodiscard]] std::set<SpotCamera> getSpotCamerasUsed(const bool has_hand_camera,
+//                                                       const std::vector<std::string>& cameras_used);
 
 /**
  * @brief Create a set of image sources corresponding to the specified image types.
@@ -55,11 +55,11 @@ namespace spot_ros2 {
  * @param get_depth_images Sets whether to request depth images.
  * @param get_depth_registered_images Sets whether to request registered depth images.
  * @param has_hand_camera Sets whether to request images from the hand camera.
- * @param cameras_used List of cameras to stream from.
+ * @param spot_cameras_used Set of SpotCameras to stream from.
  * @return A set of ImageSources which represents all requested image and camera types.
  */
 [[nodiscard]] std::set<ImageSource> createImageSources(const bool get_rgb_images, const bool get_depth_images,
                                                        const bool get_depth_registered_images,
                                                        const bool has_hand_camera,
-                                                       const std::vector<std::string>& cameras_used);
+                                                       const std::set<SpotCamera>& spot_cameras_used);
 }  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/api/spot_image_sources.hpp
+++ b/spot_driver/include/spot_driver/api/spot_image_sources.hpp
@@ -8,7 +8,6 @@
 
 #include <set>
 #include <string>
-#include <vector>
 
 namespace spot_ros2 {
 /**

--- a/spot_driver/include/spot_driver/api/spot_image_sources.hpp
+++ b/spot_driver/include/spot_driver/api/spot_image_sources.hpp
@@ -44,12 +44,10 @@ namespace spot_ros2 {
  * @param get_rgb_images Sets whether to request RGB images.
  * @param get_depth_images Sets whether to request depth images.
  * @param get_depth_registered_images Sets whether to request registered depth images.
- * @param has_hand_camera Sets whether to request images from the hand camera.
  * @param spot_cameras_used Set of SpotCameras to stream from.
  * @return A set of ImageSources which represents all requested image and camera types.
  */
 [[nodiscard]] std::set<ImageSource> createImageSources(const bool get_rgb_images, const bool get_depth_images,
                                                        const bool get_depth_registered_images,
-                                                       const bool has_hand_camera,
                                                        const std::set<SpotCamera>& spot_cameras_used);
 }  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/api/spot_image_sources.hpp
+++ b/spot_driver/include/spot_driver/api/spot_image_sources.hpp
@@ -51,5 +51,5 @@ namespace spot_ros2 {
 [[nodiscard]] std::set<ImageSource> createImageSources(const bool get_rgb_images, const bool get_depth_images,
                                                        const bool get_depth_registered_images,
                                                        const bool has_hand_camera,
-                                                       const std::vector<std::string> cameras_used);
+                                                       const std::vector<std::string>& cameras_used);
 }  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -38,7 +38,7 @@ class ParameterInterfaceBase {
   virtual bool getPublishDepthRegisteredImages() const = 0;
   virtual std::string getPreferredOdomFrame() const = 0;
   virtual std::string getSpotName() const = 0;
-  virtual std::vector<std::string> getCamerasUsed() const = 0;
+  virtual std::vector<std::string> getCamerasUsed(bool has_arm) const = 0;
 
  protected:
   // These are the definitions of the default values for optional parameters.
@@ -53,6 +53,7 @@ class ParameterInterfaceBase {
   static constexpr bool kDefaultPublishDepthImages{true};
   static constexpr bool kDefaultPublishDepthRegisteredImages{true};
   static constexpr auto kDefaultPreferredOdomFrame = "odom";
-  static constexpr auto kDefaultCamerasUsed = {"frontleft", "frontright", "left", "right", "back"};
+  static constexpr auto kDefaultCamerasUsedWithoutArm = {"frontleft", "frontright", "left", "right", "back"};
+  static constexpr auto kDefaultCamerasUsedWithArm = {"frontleft", "frontright", "left", "right", "back", "hand"};
 };
 }  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -6,7 +6,6 @@
 #include <set>
 #include <string>
 #include <tl_expected/expected.hpp>
-#include <vector>
 
 #include <spot_driver/types.hpp>
 

--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <tl_expected/expected.hpp>
 #include <vector>
 
 #include <spot_driver/types.hpp>
@@ -42,7 +43,7 @@ class ParameterInterfaceBase {
   virtual std::string getPreferredOdomFrame() const = 0;
   virtual std::string getSpotName() const = 0;
   virtual std::set<spot_ros2::SpotCamera> getDefaultCamerasUsed(bool has_arm) const = 0;
-  virtual std::set<spot_ros2::SpotCamera> getCamerasUsed(bool has_arm) const = 0;
+  virtual tl::expected<std::set<spot_ros2::SpotCamera>, std::string> getCamerasUsed(bool has_arm) const = 0;
 
  protected:
   // These are the definitions of the default values for optional parameters.

--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -41,6 +41,7 @@ class ParameterInterfaceBase {
   virtual bool getPublishDepthRegisteredImages() const = 0;
   virtual std::string getPreferredOdomFrame() const = 0;
   virtual std::string getSpotName() const = 0;
+  virtual std::set<spot_ros2::SpotCamera> getDefaultCamerasUsed(bool has_arm) const = 0;
   virtual std::set<spot_ros2::SpotCamera> getCamerasUsed(bool has_arm) const = 0;
 
  protected:

--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -3,8 +3,11 @@
 #pragma once
 
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
+
+#include <spot_driver/types.hpp>
 
 namespace spot_ros2 {
 /**
@@ -38,7 +41,7 @@ class ParameterInterfaceBase {
   virtual bool getPublishDepthRegisteredImages() const = 0;
   virtual std::string getPreferredOdomFrame() const = 0;
   virtual std::string getSpotName() const = 0;
-  virtual std::vector<std::string> getCamerasUsed(bool has_arm) const = 0;
+  virtual std::set<spot_ros2::SpotCamera> getCamerasUsed(bool has_arm) const = 0;
 
  protected:
   // These are the definitions of the default values for optional parameters.

--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -4,6 +4,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace spot_ros2 {
 /**
@@ -37,6 +38,7 @@ class ParameterInterfaceBase {
   virtual bool getPublishDepthRegisteredImages() const = 0;
   virtual std::string getPreferredOdomFrame() const = 0;
   virtual std::string getSpotName() const = 0;
+  virtual std::vector<std::string> getCamerasUsed() const = 0;
 
  protected:
   // These are the definitions of the default values for optional parameters.
@@ -51,5 +53,6 @@ class ParameterInterfaceBase {
   static constexpr bool kDefaultPublishDepthImages{true};
   static constexpr bool kDefaultPublishDepthRegisteredImages{true};
   static constexpr auto kDefaultPreferredOdomFrame = "odom";
+  static constexpr auto kDefaultCamerasUsed = {"frontleft", "frontright", "left", "right", "back"};
 };
 }  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
@@ -35,7 +35,7 @@ class RclcppParameterInterface : public ParameterInterfaceBase {
   [[nodiscard]] bool getPublishDepthRegisteredImages() const override;
   [[nodiscard]] std::string getPreferredOdomFrame() const override;
   [[nodiscard]] std::string getSpotName() const override;
-  [[nodiscard]] std::vector<std::string> getCamerasUsed() const override;
+  [[nodiscard]] std::vector<std::string> getCamerasUsed(bool has_arm) const override;
 
  private:
   std::shared_ptr<rclcpp::Node> node_;

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
@@ -36,6 +36,7 @@ class RclcppParameterInterface : public ParameterInterfaceBase {
   [[nodiscard]] bool getPublishDepthRegisteredImages() const override;
   [[nodiscard]] std::string getPreferredOdomFrame() const override;
   [[nodiscard]] std::string getSpotName() const override;
+  [[nodiscard]] std::set<spot_ros2::SpotCamera> getDefaultCamerasUsed(const bool has_arm) const override;
   [[nodiscard]] std::set<spot_ros2::SpotCamera> getCamerasUsed(const bool has_arm) const override;
 
  private:

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace spot_ros2 {
 /**
@@ -34,6 +35,7 @@ class RclcppParameterInterface : public ParameterInterfaceBase {
   [[nodiscard]] bool getPublishDepthRegisteredImages() const override;
   [[nodiscard]] std::string getPreferredOdomFrame() const override;
   [[nodiscard]] std::string getSpotName() const override;
+  [[nodiscard]] std::vector<std::string> getCamerasUsed() const override;
 
  private:
   std::shared_ptr<rclcpp::Node> node_;

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
@@ -37,7 +37,8 @@ class RclcppParameterInterface : public ParameterInterfaceBase {
   [[nodiscard]] std::string getPreferredOdomFrame() const override;
   [[nodiscard]] std::string getSpotName() const override;
   [[nodiscard]] std::set<spot_ros2::SpotCamera> getDefaultCamerasUsed(const bool has_arm) const override;
-  [[nodiscard]] std::set<spot_ros2::SpotCamera> getCamerasUsed(const bool has_arm) const override;
+  [[nodiscard]] tl::expected<std::set<spot_ros2::SpotCamera>, std::string> getCamerasUsed(
+      const bool has_arm) const override;
 
  private:
   std::shared_ptr<rclcpp::Node> node_;

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -35,7 +36,7 @@ class RclcppParameterInterface : public ParameterInterfaceBase {
   [[nodiscard]] bool getPublishDepthRegisteredImages() const override;
   [[nodiscard]] std::string getPreferredOdomFrame() const override;
   [[nodiscard]] std::string getSpotName() const override;
-  [[nodiscard]] std::vector<std::string> getCamerasUsed(const bool has_arm) const override;
+  [[nodiscard]] std::set<spot_ros2::SpotCamera> getCamerasUsed(const bool has_arm) const override;
 
  private:
   std::shared_ptr<rclcpp::Node> node_;

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
@@ -35,7 +35,7 @@ class RclcppParameterInterface : public ParameterInterfaceBase {
   [[nodiscard]] bool getPublishDepthRegisteredImages() const override;
   [[nodiscard]] std::string getPreferredOdomFrame() const override;
   [[nodiscard]] std::string getSpotName() const override;
-  [[nodiscard]] std::vector<std::string> getCamerasUsed(bool has_arm) const override;
+  [[nodiscard]] std::vector<std::string> getCamerasUsed(const bool has_arm) const override;
 
  private:
   std::shared_ptr<rclcpp::Node> node_;

--- a/spot_driver/include/spot_driver/types.hpp
+++ b/spot_driver/include/spot_driver/types.hpp
@@ -21,6 +21,8 @@
 
 #include <functional>
 #include <optional>
+#include <string>
+#include <unordered_map>
 
 namespace spot_ros2 {
 /** @brief Represents the six different cameras on Spot. */
@@ -31,6 +33,18 @@ enum class SpotCamera {
   LEFT,
   RIGHT,
   HAND,
+};
+
+/**
+ * @brief Map from each ROS camera topic name to SpotCamera value.
+ */
+static const std::unordered_map<std::string, spot_ros2::SpotCamera> kRosStringToSpotCamera{
+    {"back", spot_ros2::SpotCamera::BACK},
+    {"frontleft", spot_ros2::SpotCamera::FRONTLEFT},
+    {"frontright", spot_ros2::SpotCamera::FRONTRIGHT},
+    {"hand", spot_ros2::SpotCamera::HAND},
+    {"left", spot_ros2::SpotCamera::LEFT},
+    {"right", spot_ros2::SpotCamera::RIGHT},
 };
 
 /** @brief Represents the three types of images Spot can capture. */

--- a/spot_driver/launch/spot_image_publishers.launch.py
+++ b/spot_driver/launch/spot_image_publishers.launch.py
@@ -161,28 +161,29 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     )
     ld.add_action(container)
 
-    # add the image stitcher node
-    stitcher_params = {
-        "body_frame": f"{spot_name}/body" if spot_name else "body",
-        "virtual_camera_frame": f"{spot_name}/virtual_camera" if spot_name else "virtual_camera",
-    }
-    stitcher_prefix = f"/{spot_name}" if spot_name else ""
-    image_stitcher_node = launch_ros.actions.Node(
-        package="spot_driver",
-        executable="image_stitcher_node",
-        namespace=spot_name,
-        output="screen",
-        remappings=[
-            (f"{stitcher_prefix}/left/image", f"{stitcher_prefix}/camera/frontleft/image"),
-            (f"{stitcher_prefix}/left/camera_info", f"{stitcher_prefix}/camera/frontleft/camera_info"),
-            (f"{stitcher_prefix}/right/image", f"{stitcher_prefix}/camera/frontright/image"),
-            (f"{stitcher_prefix}/right/camera_info", f"{stitcher_prefix}/camera/frontright/camera_info"),
-            (f"{stitcher_prefix}/virtual_camera/image", f"{stitcher_prefix}/camera/frontmiddle_virtual/image"),
-        ],
-        parameters=[config_file, stitcher_params],
-        condition=IfCondition(LaunchConfiguration("stitch_front_images")),
-    )
-    ld.add_action(image_stitcher_node)
+    # add the image stitcher node, but only if frontleft and frontright cameras are enabled.
+    if "frontleft" in camera_sources and "frontright" in camera_sources:
+        stitcher_params = {
+            "body_frame": f"{spot_name}/body" if spot_name else "body",
+            "virtual_camera_frame": f"{spot_name}/virtual_camera" if spot_name else "virtual_camera",
+        }
+        stitcher_prefix = f"/{spot_name}" if spot_name else ""
+        image_stitcher_node = launch_ros.actions.Node(
+            package="spot_driver",
+            executable="image_stitcher_node",
+            namespace=spot_name,
+            output="screen",
+            remappings=[
+                (f"{stitcher_prefix}/left/image", f"{stitcher_prefix}/camera/frontleft/image"),
+                (f"{stitcher_prefix}/left/camera_info", f"{stitcher_prefix}/camera/frontleft/camera_info"),
+                (f"{stitcher_prefix}/right/image", f"{stitcher_prefix}/camera/frontright/image"),
+                (f"{stitcher_prefix}/right/camera_info", f"{stitcher_prefix}/camera/frontright/camera_info"),
+                (f"{stitcher_prefix}/virtual_camera/image", f"{stitcher_prefix}/camera/frontmiddle_virtual/image"),
+            ],
+            parameters=[config_file, stitcher_params],
+            condition=IfCondition(LaunchConfiguration("stitch_front_images")),
+        )
+        ld.add_action(image_stitcher_node)
 
 
 def generate_launch_description() -> launch.LaunchDescription:

--- a/spot_driver/spot_driver/launch/spot_launch_helpers.py
+++ b/spot_driver/spot_driver/launch/spot_launch_helpers.py
@@ -99,11 +99,14 @@ def default_camera_sources(has_arm: bool) -> List[str]:
 
 def get_camera_sources_from_ros_params(ros_params: Dict[str, Any], has_arm: bool) -> List[str]:
     """Get the list of cameras to stream from. This will be taken from the parameters in the config yaml if it exists
-    and is correctly formatted, and if not, it will default to all available cameras.
+    and contains valid cameras. If this list contains invalid cameras, fall back to the default of all cameras.
 
     Args:
         ros_params (str): Dictionary of ros parameters from the config file.
         has_arm (bool): Whether or not your Spot has an arm.
+
+    Raises:
+        ValueError: If the parameter cameras_used is not formattted as a list.
 
     Returns:
         List[str]: List of cameras the driver will stream from.
@@ -115,10 +118,12 @@ def get_camera_sources_from_ros_params(ros_params: Dict[str, Any], has_arm: bool
             # check if the user inputted any camera that's not in the default sources.
             invalid_cameras = [cam for cam in camera_sources if cam not in default_sources]
             if invalid_cameras:
-                raise ValueError(
-                    f"Your camera sources {camera_sources} contain invalid cameras. Make sure the values are a subset"
-                    f" of {default_sources}!"
+                print(
+                    f"{COLOR_YELLOW}WARNING: Your camera sources {camera_sources} contain invalid cameras. Make sure"
+                    f" that the values are a subset of the default {default_sources}. Falling back to these default"
+                    f" sources instead.{COLOR_END}"
                 )
+                return default_sources
             return camera_sources
         else:
             raise ValueError(f"Your camera sources {camera_sources} are not formatted correctly as a list!")

--- a/spot_driver/spot_driver/launch/spot_launch_helpers.py
+++ b/spot_driver/spot_driver/launch/spot_launch_helpers.py
@@ -19,8 +19,7 @@ def get_ros_param_dict(config_file_path: str) -> Dict[str, Any]:
         config_file_path (str): Path to the config yaml.
 
     Raises:
-        FileNotFoundError: If the config file doesn't exist
-        YamlError: If the yaml cannot be parsed
+        YamlError: If the yaml can't be parsed
         ValueError: If the yaml file doesn't follow ROS conventions
 
     Returns:
@@ -30,22 +29,19 @@ def get_ros_param_dict(config_file_path: str) -> Dict[str, Any]:
     # an empty config file path is a valid way to start the driver, so here we just return the empty dictionary.
     if not config_file_path:
         return {}
-    if os.path.isfile(config_file_path):
-        with open(config_file_path, "r") as config_yaml:
-            try:
-                config_dict = yaml.safe_load(config_yaml)
-                if ("/**" in config_dict) and ("ros__parameters" in config_dict["/**"]):
-                    ros_params = config_dict["/**"]["ros__parameters"]
-                    return ros_params
-                else:
-                    raise ValueError(
-                        "Your yaml file does not follow ROS conventions! Make sure it starts with '/**' and"
-                        " 'ros__parameters'."
-                    )
-            except yaml.YAMLError as exc:
-                raise yaml.YAMLError(f"Config file {config_file_path} couldn't be parsed: failed with '{exc}'")
-    else:
-        raise FileNotFoundError(f"Your config file {config_file_path} doesn't exist!")
+    with open(config_file_path, "r") as config_yaml:
+        try:
+            config_dict = yaml.safe_load(config_yaml)
+            if ("/**" in config_dict) and ("ros__parameters" in config_dict["/**"]):
+                ros_params = config_dict["/**"]["ros__parameters"]
+                return ros_params
+            else:
+                raise ValueError(
+                    "Your yaml file does not follow ROS conventions! Make sure it starts with '/**' and"
+                    " 'ros__parameters'."
+                )
+        except yaml.YAMLError as exc:
+            raise yaml.YAMLError(f"Config file {config_file_path} couldn't be parsed: failed with '{exc}'")
 
 
 def get_login_parameters(config_file_path: str) -> Tuple[str, str, str, Optional[int], Optional[str]]:

--- a/spot_driver/src/api/spot_image_sources.cpp
+++ b/spot_driver/src/api/spot_image_sources.cpp
@@ -105,16 +105,21 @@ tl::expected<ImageSource, std::string> fromSpotImageSourceName(const std::string
   }
 }
 
-std::set<ImageSource> createImageSources(const std::vector<std::string> cameras_used, const bool get_rgb_images,
-                                         const bool get_depth_images, const bool get_depth_registered_images) {
+std::set<ImageSource> createImageSources(const bool get_rgb_images, const bool get_depth_images,
+                                         const bool get_depth_registered_images, const bool has_hand_camera,
+                                         const std::vector<std::string> cameras_used) {
   std::set<ImageSource> sources;
   std::vector<spot_ros2::SpotCamera> spot_cameras_used;
   for (const auto& camera : cameras_used) {
     try {
-      spot_cameras_used.push_back(kRosStringToSpotCamera.at(camera));
+      const auto spot_camera = kRosStringToSpotCamera.at(camera);
+      if ((spot_camera == SpotCamera::HAND) && (!has_hand_camera)) {
+        std::cout << "Can't add the hand camera, your robot doesn't have an arm" << std::endl;
+      } else {
+        spot_cameras_used.push_back(kRosStringToSpotCamera.at(camera));
+      }
     } catch (const std::out_of_range& e) {
-      // TODO handle this better
-      std::cout << "Invalid name " << camera << std::endl;
+      std::cout << "Invalid name: " << camera << ", skipping" << std::endl;
     }
   }
   if (get_rgb_images) {

--- a/spot_driver/src/api/spot_image_sources.cpp
+++ b/spot_driver/src/api/spot_image_sources.cpp
@@ -98,10 +98,9 @@ tl::expected<ImageSource, std::string> fromSpotImageSourceName(const std::string
 }
 
 std::set<ImageSource> createImageSources(const bool get_rgb_images, const bool get_depth_images,
-                                         const bool get_depth_registered_images, const bool has_hand_camera,
+                                         const bool get_depth_registered_images,
                                          const std::set<SpotCamera>& spot_cameras_used) {
   std::set<ImageSource> sources;
-  // const auto spot_cameras_used = getSpotCamerasUsed(has_hand_camera, cameras_used);
   if (get_rgb_images) {
     for (const auto& camera : spot_cameras_used) {
       sources.insert(ImageSource{camera, SpotImageType::RGB});
@@ -117,7 +116,6 @@ std::set<ImageSource> createImageSources(const bool get_rgb_images, const bool g
       sources.insert(ImageSource{camera, SpotImageType::DEPTH_REGISTERED});
     }
   }
-
   return sources;
 }
 }  // namespace spot_ros2

--- a/spot_driver/src/api/spot_image_sources.cpp
+++ b/spot_driver/src/api/spot_image_sources.cpp
@@ -114,12 +114,13 @@ std::set<ImageSource> createImageSources(const bool get_rgb_images, const bool g
     try {
       const auto spot_camera = kRosStringToSpotCamera.at(camera);
       if ((spot_camera == SpotCamera::HAND) && (!has_hand_camera)) {
-        std::cout << "Can't add the hand camera, your robot doesn't have an arm" << std::endl;
+        // Do nothing in this case, because the hand camera shouldn't be added if the robot doesn't have an arm.
       } else {
         spot_cameras_used.push_back(kRosStringToSpotCamera.at(camera));
       }
     } catch (const std::out_of_range& e) {
-      std::cout << "Invalid name: " << camera << ", skipping" << std::endl;
+      // If this input cannot be converted to a SpotCamera (e.g., because of a typo) we should just skip adding this
+      // camera.
     }
   }
   if (get_rgb_images) {

--- a/spot_driver/src/api/spot_image_sources.cpp
+++ b/spot_driver/src/api/spot_image_sources.cpp
@@ -107,7 +107,7 @@ tl::expected<ImageSource, std::string> fromSpotImageSourceName(const std::string
 
 std::set<ImageSource> createImageSources(const bool get_rgb_images, const bool get_depth_images,
                                          const bool get_depth_registered_images, const bool has_hand_camera,
-                                         const std::vector<std::string> cameras_used) {
+                                         const std::vector<std::string>& cameras_used) {
   std::set<ImageSource> sources;
   std::vector<spot_ros2::SpotCamera> spot_cameras_used;
   for (const auto& camera : cameras_used) {

--- a/spot_driver/src/api/spot_image_sources.cpp
+++ b/spot_driver/src/api/spot_image_sources.cpp
@@ -105,16 +105,15 @@ tl::expected<ImageSource, std::string> fromSpotImageSourceName(const std::string
   }
 }
 
-std::vector<spot_ros2::SpotCamera> getSpotCamerasUsed(const bool has_hand_camera,
-                                                      const std::vector<std::string>& cameras_used) {
-  std::vector<spot_ros2::SpotCamera> spot_cameras_used;
+std::set<SpotCamera> getSpotCamerasUsed(const bool has_hand_camera, const std::vector<std::string>& cameras_used) {
+  std::set<SpotCamera> spot_cameras_used;
   for (const auto& camera : cameras_used) {
     try {
       const auto spot_camera = kRosStringToSpotCamera.at(camera);
       if ((spot_camera == SpotCamera::HAND) && (!has_hand_camera)) {
         // Do nothing in this case, because the hand camera shouldn't be added if the robot doesn't have an arm.
       } else {
-        spot_cameras_used.push_back(kRosStringToSpotCamera.at(camera));
+        spot_cameras_used.insert(kRosStringToSpotCamera.at(camera));
       }
     } catch (const std::out_of_range& e) {
       // If this input cannot be converted to a SpotCamera (e.g., because of a typo) we should just skip adding this

--- a/spot_driver/src/api/spot_image_sources.cpp
+++ b/spot_driver/src/api/spot_image_sources.cpp
@@ -6,6 +6,7 @@
 #include <stdexcept>
 #include <tl_expected/expected.hpp>
 #include <unordered_map>
+#include <vector>
 
 namespace {
 using ImageSource = spot_ros2::ImageSource;

--- a/spot_driver/src/api/spot_image_sources.cpp
+++ b/spot_driver/src/api/spot_image_sources.cpp
@@ -105,10 +105,8 @@ tl::expected<ImageSource, std::string> fromSpotImageSourceName(const std::string
   }
 }
 
-std::set<ImageSource> createImageSources(const bool get_rgb_images, const bool get_depth_images,
-                                         const bool get_depth_registered_images, const bool has_hand_camera,
-                                         const std::vector<std::string>& cameras_used) {
-  std::set<ImageSource> sources;
+std::vector<spot_ros2::SpotCamera> getSpotCamerasUsed(const bool has_hand_camera,
+                                                      const std::vector<std::string>& cameras_used) {
   std::vector<spot_ros2::SpotCamera> spot_cameras_used;
   for (const auto& camera : cameras_used) {
     try {
@@ -123,6 +121,14 @@ std::set<ImageSource> createImageSources(const bool get_rgb_images, const bool g
       // camera.
     }
   }
+  return spot_cameras_used;
+}
+
+std::set<ImageSource> createImageSources(const bool get_rgb_images, const bool get_depth_images,
+                                         const bool get_depth_registered_images, const bool has_hand_camera,
+                                         const std::vector<std::string>& cameras_used) {
+  std::set<ImageSource> sources;
+  const auto spot_cameras_used = getSpotCamerasUsed(has_hand_camera, cameras_used);
   if (get_rgb_images) {
     for (const auto& camera : spot_cameras_used) {
       sources.insert(ImageSource{camera, SpotImageType::RGB});

--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -89,6 +89,10 @@ bool SpotImagePublisher::initialize() {
   const auto publish_raw_rgb_cameras = false;
   const auto uncompress_images = parameters_->getUncompressImages();
   const auto publish_compressed_images = parameters_->getPublishCompressedImages();
+  const auto cameras_used = parameters_->getCamerasUsed(has_arm_);
+  for (const auto& camera : cameras_used) {
+    std::cout << camera << std::endl;
+  }
 
   // Generate the set of image sources based on which cameras the user has requested that we publish
   const auto sources =

--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -95,8 +95,8 @@ bool SpotImagePublisher::initialize() {
   }
 
   // Generate the set of image sources based on which cameras the user has requested that we publish
-  const auto sources =
-      createImageSources(cameras_used, publish_rgb_images, publish_depth_images, publish_depth_registered_images);
+  const auto sources = createImageSources(publish_rgb_images, publish_depth_images, publish_depth_registered_images,
+                                          has_arm_, cameras_used);
 
   // Generate the image request message to capture the data from the specified image sources
   image_request_message_ = createImageRequest(sources, has_rgb_cameras, rgb_image_quality, publish_raw_rgb_cameras);

--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -96,7 +96,7 @@ bool SpotImagePublisher::initialize() {
 
   // Generate the set of image sources based on which cameras the user has requested that we publish
   const auto sources =
-      createImageSources(publish_rgb_images, publish_depth_images, publish_depth_registered_images, has_arm_);
+      createImageSources(cameras_used, publish_rgb_images, publish_depth_images, publish_depth_registered_images);
 
   // Generate the image request message to capture the data from the specified image sources
   image_request_message_ = createImageRequest(sources, has_rgb_cameras, rgb_image_quality, publish_raw_rgb_cameras);

--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -90,9 +90,6 @@ bool SpotImagePublisher::initialize() {
   const auto uncompress_images = parameters_->getUncompressImages();
   const auto publish_compressed_images = parameters_->getPublishCompressedImages();
   const auto cameras_used = parameters_->getCamerasUsed(has_arm_);
-  for (const auto& camera : cameras_used) {
-    std::cout << camera << std::endl;
-  }
 
   // Generate the set of image sources based on which cameras the user has requested that we publish
   const auto sources = createImageSources(publish_rgb_images, publish_depth_images, publish_depth_registered_images,

--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -100,8 +100,8 @@ bool SpotImagePublisher::initialize() {
   }
 
   // Generate the set of image sources based on which cameras the user has requested that we publish
-  const auto sources = createImageSources(publish_rgb_images, publish_depth_images, publish_depth_registered_images,
-                                          has_arm_, cameras_used);
+  const auto sources =
+      createImageSources(publish_rgb_images, publish_depth_images, publish_depth_registered_images, cameras_used);
 
   // Generate the image request message to capture the data from the specified image sources
   image_request_message_ = createImageRequest(sources, has_rgb_cameras, rgb_image_quality, publish_raw_rgb_cameras);

--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -89,7 +89,15 @@ bool SpotImagePublisher::initialize() {
   const auto publish_raw_rgb_cameras = false;
   const auto uncompress_images = parameters_->getUncompressImages();
   const auto publish_compressed_images = parameters_->getPublishCompressedImages();
-  const auto cameras_used = parameters_->getCamerasUsed(has_arm_);
+
+  std::set<spot_ros2::SpotCamera> cameras_used;
+  const auto cameras_used_parameter = parameters_->getCamerasUsed(has_arm_);
+  if (cameras_used_parameter.has_value()) {
+    cameras_used = cameras_used_parameter.value();
+  } else {
+    logger_->logWarn("Invalid cameras_used parameter! Defaulting to publishing from all cameras.");
+    cameras_used = parameters_->getDefaultCamerasUsed(has_arm_);
+  }
 
   // Generate the set of image sources based on which cameras the user has requested that we publish
   const auto sources = createImageSources(publish_rgb_images, publish_depth_images, publish_depth_registered_images,

--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -95,7 +95,8 @@ bool SpotImagePublisher::initialize() {
   if (cameras_used_parameter.has_value()) {
     cameras_used = cameras_used_parameter.value();
   } else {
-    logger_->logWarn("Invalid cameras_used parameter! Defaulting to publishing from all cameras.");
+    logger_->logWarn("Invalid cameras_used parameter! Got error: " + cameras_used_parameter.error() +
+                     " Defaulting to publishing from all cameras.");
     cameras_used = parameters_->getDefaultCamerasUsed(has_arm_);
   }
 

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -3,6 +3,7 @@
 #include <spot_driver/interfaces/rclcpp_parameter_interface.hpp>
 
 #include <cstdlib>
+#include <vector>
 
 namespace {
 constexpr auto kEnvVarNameHostname = "SPOT_IP";

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -187,10 +187,8 @@ std::string RclcppParameterInterface::getPreferredOdomFrame() const {
 
 std::vector<std::string> RclcppParameterInterface::getCamerasUsed(const bool has_arm) const {
   const auto kDefaultCamerasUsed = has_arm ? kDefaultCamerasUsedWithArm : kDefaultCamerasUsedWithoutArm;
-  std::vector<std::string> kDefaultCamerasUsedVector;
-  for (const auto& camera : kDefaultCamerasUsed) {
-    kDefaultCamerasUsedVector.push_back(std::string(camera));
-  }
+  const std::vector<std::string> kDefaultCamerasUsedVector(std::begin(kDefaultCamerasUsed),
+                                                           std::end(kDefaultCamerasUsed));
   return declareAndGetParameter<std::vector<std::string>>(node_, kParameterNameCamerasUsed, kDefaultCamerasUsedVector);
 }
 

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -13,6 +13,7 @@ constexpr auto kEnvVarNamePassword = "BOSDYN_CLIENT_PASSWORD";
 
 constexpr auto kParameterNameHostname = "hostname";
 constexpr auto kParameterNamePort = "port";
+constexpr auto kParameterNameCamerasUsed = "cameras_used";
 constexpr auto kParameterNameCertificate = "certificate";
 constexpr auto kParameterNameUsername = "username";
 constexpr auto kParameterNamePassword = "password";
@@ -182,6 +183,15 @@ bool RclcppParameterInterface::getPublishDepthRegisteredImages() const {
 
 std::string RclcppParameterInterface::getPreferredOdomFrame() const {
   return declareAndGetParameter<std::string>(node_, kParameterPreferredOdomFrame, kDefaultPreferredOdomFrame);
+}
+
+std::vector<std::string> RclcppParameterInterface::getCamerasUsed() const {
+  std::vector<std::string> kDefaultCamerasUsedVector;
+  for (const auto& camera : kDefaultCamerasUsed) {
+    std::string cameraString(camera);
+    kDefaultCamerasUsedVector.push_back(cameraString);
+  }
+  return declareAndGetParameter<std::vector<std::string>>(node_, kParameterNameCamerasUsed, kDefaultCamerasUsedVector);
 }
 
 std::string RclcppParameterInterface::getSpotName() const {

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -189,8 +189,7 @@ std::vector<std::string> RclcppParameterInterface::getCamerasUsed(bool has_arm) 
   const auto kDefaultCamerasUsed = has_arm ? kDefaultCamerasUsedWithArm : kDefaultCamerasUsedWithoutArm;
   std::vector<std::string> kDefaultCamerasUsedVector;
   for (const auto& camera : kDefaultCamerasUsed) {
-    std::string cameraString(camera);
-    kDefaultCamerasUsedVector.push_back(cameraString);
+    kDefaultCamerasUsedVector.push_back(std::string(camera));
   }
   return declareAndGetParameter<std::vector<std::string>>(node_, kParameterNameCamerasUsed, kDefaultCamerasUsedVector);
 }

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -211,7 +211,7 @@ tl::expected<std::set<spot_ros2::SpotCamera>, std::string> RclcppParameterInterf
         spot_cameras_used.insert(spot_camera);
       }
     } catch (const std::out_of_range& e) {
-      return tl::make_unexpected("Cannot convert camera " + camera + " to a SpotCamera.");
+      return tl::make_unexpected("Cannot convert camera '" + camera + "' to a SpotCamera.");
     }
   }
   return spot_cameras_used;

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -185,7 +185,8 @@ std::string RclcppParameterInterface::getPreferredOdomFrame() const {
   return declareAndGetParameter<std::string>(node_, kParameterPreferredOdomFrame, kDefaultPreferredOdomFrame);
 }
 
-std::vector<std::string> RclcppParameterInterface::getCamerasUsed() const {
+std::vector<std::string> RclcppParameterInterface::getCamerasUsed(bool has_arm) const {
+  const auto kDefaultCamerasUsed = has_arm ? kDefaultCamerasUsedWithArm : kDefaultCamerasUsedWithoutArm;
   std::vector<std::string> kDefaultCamerasUsedVector;
   for (const auto& camera : kDefaultCamerasUsed) {
     std::string cameraString(camera);

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -185,7 +185,7 @@ std::string RclcppParameterInterface::getPreferredOdomFrame() const {
   return declareAndGetParameter<std::string>(node_, kParameterPreferredOdomFrame, kDefaultPreferredOdomFrame);
 }
 
-std::vector<std::string> RclcppParameterInterface::getCamerasUsed(bool has_arm) const {
+std::vector<std::string> RclcppParameterInterface::getCamerasUsed(const bool has_arm) const {
   const auto kDefaultCamerasUsed = has_arm ? kDefaultCamerasUsedWithArm : kDefaultCamerasUsedWithoutArm;
   std::vector<std::string> kDefaultCamerasUsedVector;
   for (const auto& camera : kDefaultCamerasUsed) {

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -208,9 +208,8 @@ tl::expected<std::set<spot_ros2::SpotCamera>, std::string> RclcppParameterInterf
       const auto spot_camera = kRosStringToSpotCamera.at(camera);
       if ((spot_camera == SpotCamera::HAND) && (!has_arm)) {
         return tl::make_unexpected("Cannot add SpotCamera 'hand', the robot does not have an arm!");
-      } else {
-        spot_cameras_used.insert(spot_camera);
       }
+      spot_cameras_used.insert(spot_camera);
     } catch (const std::out_of_range& e) {
       return tl::make_unexpected("Cannot convert camera '" + camera + "' to a SpotCamera.");
     }

--- a/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
+++ b/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
@@ -39,7 +39,8 @@ class FakeParameterInterface : public ParameterInterfaceBase {
 
   std::string getSpotName() const override { return spot_name; }
 
-  std::vector<std::string> getCamerasUsed() const override {
+  std::vector<std::string> getCamerasUsed(bool has_arm) const override {
+    const auto kDefaultCamerasUsed = has_arm ? kDefaultCamerasUsedWithArm : kDefaultCamerasUsedWithoutArm;
     std::vector<std::string> kDefaultCamerasUsedVector;
     for (const auto& camera : kDefaultCamerasUsed) {
       std::string cameraString(camera);

--- a/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
+++ b/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
@@ -43,8 +43,7 @@ class FakeParameterInterface : public ParameterInterfaceBase {
     const auto kDefaultCamerasUsed = has_arm ? kDefaultCamerasUsedWithArm : kDefaultCamerasUsedWithoutArm;
     std::vector<std::string> kDefaultCamerasUsedVector;
     for (const auto& camera : kDefaultCamerasUsed) {
-      std::string cameraString(camera);
-      kDefaultCamerasUsedVector.push_back(cameraString);
+      kDefaultCamerasUsedVector.push_back(std::string(camera));
     }
     return kDefaultCamerasUsedVector;
   }

--- a/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
+++ b/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
@@ -49,7 +49,7 @@ class FakeParameterInterface : public ParameterInterfaceBase {
     return spot_cameras_used;
   }
 
-  std::set<spot_ros2::SpotCamera> getCamerasUsed(const bool has_arm) const override {
+  tl::expected<std::set<spot_ros2::SpotCamera>, std::string> getCamerasUsed(const bool has_arm) const override {
     return getDefaultCamerasUsed(has_arm);
   }
 

--- a/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
+++ b/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
@@ -6,6 +6,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace spot_ros2::test {
 class FakeParameterInterface : public ParameterInterfaceBase {
@@ -37,6 +38,15 @@ class FakeParameterInterface : public ParameterInterfaceBase {
   std::string getPreferredOdomFrame() const override { return "odom"; }
 
   std::string getSpotName() const override { return spot_name; }
+
+  std::vector<std::string> getCamerasUsed() const override {
+    std::vector<std::string> kDefaultCamerasUsedVector;
+    for (const auto& camera : kDefaultCamerasUsed) {
+      std::string cameraString(camera);
+      kDefaultCamerasUsedVector.push_back(cameraString);
+    }
+    return kDefaultCamerasUsedVector;
+  }
 
   static constexpr auto kExampleHostname{"192.168.0.10"};
   static constexpr auto kExampleUsername{"spot_user"};

--- a/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
+++ b/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
@@ -40,13 +40,17 @@ class FakeParameterInterface : public ParameterInterfaceBase {
 
   std::string getSpotName() const override { return spot_name; }
 
-  std::set<spot_ros2::SpotCamera> getCamerasUsed(const bool has_arm) const override {
+  std::set<spot_ros2::SpotCamera> getDefaultCamerasUsed(const bool has_arm) const override {
     const auto kDefaultCamerasUsed = has_arm ? kDefaultCamerasUsedWithArm : kDefaultCamerasUsedWithoutArm;
     std::set<spot_ros2::SpotCamera> spot_cameras_used;
     for (const auto& camera : kDefaultCamerasUsed) {
       spot_cameras_used.insert(kRosStringToSpotCamera.at(std::string(camera)));
     }
     return spot_cameras_used;
+  }
+
+  std::set<spot_ros2::SpotCamera> getCamerasUsed(const bool has_arm) const override {
+    return getDefaultCamerasUsed(has_arm);
   }
 
   static constexpr auto kExampleHostname{"192.168.0.10"};

--- a/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
+++ b/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
@@ -5,6 +5,7 @@
 #include <spot_driver/interfaces/parameter_interface_base.hpp>
 
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -39,11 +40,13 @@ class FakeParameterInterface : public ParameterInterfaceBase {
 
   std::string getSpotName() const override { return spot_name; }
 
-  std::vector<std::string> getCamerasUsed(const bool has_arm) const override {
+  std::set<spot_ros2::SpotCamera> getCamerasUsed(const bool has_arm) const override {
     const auto kDefaultCamerasUsed = has_arm ? kDefaultCamerasUsedWithArm : kDefaultCamerasUsedWithoutArm;
-    const std::vector<std::string> kDefaultCamerasUsedVector(std::begin(kDefaultCamerasUsed),
-                                                             std::end(kDefaultCamerasUsed));
-    return kDefaultCamerasUsedVector;
+    std::set<spot_ros2::SpotCamera> spot_cameras_used;
+    for (const auto& camera : kDefaultCamerasUsed) {
+      spot_cameras_used.insert(kRosStringToSpotCamera.at(std::string(camera)));
+    }
+    return spot_cameras_used;
   }
 
   static constexpr auto kExampleHostname{"192.168.0.10"};

--- a/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
+++ b/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
@@ -41,10 +41,8 @@ class FakeParameterInterface : public ParameterInterfaceBase {
 
   std::vector<std::string> getCamerasUsed(const bool has_arm) const override {
     const auto kDefaultCamerasUsed = has_arm ? kDefaultCamerasUsedWithArm : kDefaultCamerasUsedWithoutArm;
-    std::vector<std::string> kDefaultCamerasUsedVector;
-    for (const auto& camera : kDefaultCamerasUsed) {
-      kDefaultCamerasUsedVector.push_back(std::string(camera));
-    }
+    const std::vector<std::string> kDefaultCamerasUsedVector(std::begin(kDefaultCamerasUsed),
+                                                             std::end(kDefaultCamerasUsed));
     return kDefaultCamerasUsedVector;
   }
 

--- a/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
+++ b/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
@@ -39,7 +39,7 @@ class FakeParameterInterface : public ParameterInterfaceBase {
 
   std::string getSpotName() const override { return spot_name; }
 
-  std::vector<std::string> getCamerasUsed(bool has_arm) const override {
+  std::vector<std::string> getCamerasUsed(const bool has_arm) const override {
     const auto kDefaultCamerasUsed = has_arm ? kDefaultCamerasUsedWithArm : kDefaultCamerasUsedWithoutArm;
     std::vector<std::string> kDefaultCamerasUsedVector;
     for (const auto& camera : kDefaultCamerasUsed) {

--- a/spot_driver/test/src/images/test_spot_image_sources.cpp
+++ b/spot_driver/test/src/images/test_spot_image_sources.cpp
@@ -134,156 +134,156 @@ TEST(SpotImageSources, fromSpotImageSourceName) {
               Eq(ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
 }
 
-TEST(SpotImageSources, getSpotCamerasUsed) {
-  std::vector<std::string> body_cameras = {"frontleft", "frontright", "left", "right", "back"};
-  std::vector<std::string> body_cameras_plus_hand = {"frontleft", "frontright", "left", "right", "back", "hand"};
-  std::vector<std::string> front_cameras = {"frontleft", "frontright"};
-  std::vector<std::string> front_cameras_plus_invalid_camera = {"frontleft", "frontright", "not_a_camera"};
-  // WHEN no cameras are requested, regardless of whether or not the robot has an arm
-  // THEN no SpotCameras are returned
-  EXPECT_THAT(getSpotCamerasUsed(true, std::vector<std::string>{}), IsEmpty());
-  EXPECT_THAT(getSpotCamerasUsed(false, std::vector<std::string>{}), IsEmpty());
+// TEST(SpotImageSources, getSpotCamerasUsed) {
+//   std::vector<std::string> body_cameras = {"frontleft", "frontright", "left", "right", "back"};
+//   std::vector<std::string> body_cameras_plus_hand = {"frontleft", "frontright", "left", "right", "back", "hand"};
+//   std::vector<std::string> front_cameras = {"frontleft", "frontright"};
+//   std::vector<std::string> front_cameras_plus_invalid_camera = {"frontleft", "frontright", "not_a_camera"};
+//   // WHEN no cameras are requested, regardless of whether or not the robot has an arm
+//   // THEN no SpotCameras are returned
+//   EXPECT_THAT(getSpotCamerasUsed(true, std::vector<std::string>{}), IsEmpty());
+//   EXPECT_THAT(getSpotCamerasUsed(false, std::vector<std::string>{}), IsEmpty());
 
-  // WHEN Spot has a hand camera, and all body cameras plus the hand camera are requested
-  // THEN SpotCameras for all body cameras plus the hand camera are returned.
-  EXPECT_THAT(getSpotCamerasUsed(true, body_cameras_plus_hand),
-              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
-                                   SpotCamera::RIGHT, SpotCamera::HAND));
+//   // WHEN Spot has a hand camera, and all body cameras plus the hand camera are requested
+//   // THEN SpotCameras for all body cameras plus the hand camera are returned.
+//   EXPECT_THAT(getSpotCamerasUsed(true, body_cameras_plus_hand),
+//               UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
+//                                    SpotCamera::RIGHT, SpotCamera::HAND));
 
-  // WHEN Spot does not have a hand camera, and all body cameras plus the hand camera are requested
-  // THEN SpotCameras for all body cameras are returned.
-  EXPECT_THAT(getSpotCamerasUsed(false, body_cameras_plus_hand),
-              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
-                                   SpotCamera::RIGHT));
+//   // WHEN Spot does not have a hand camera, and all body cameras plus the hand camera are requested
+//   // THEN SpotCameras for all body cameras are returned.
+//   EXPECT_THAT(getSpotCamerasUsed(false, body_cameras_plus_hand),
+//               UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
+//                                    SpotCamera::RIGHT));
 
-  // WHEN Spot has a hand camera, and all body cameras are requested
-  // THEN SpotCameras for all body cameras are returned.
-  EXPECT_THAT(getSpotCamerasUsed(true, body_cameras),
-              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
-                                   SpotCamera::RIGHT));
+//   // WHEN Spot has a hand camera, and all body cameras are requested
+//   // THEN SpotCameras for all body cameras are returned.
+//   EXPECT_THAT(getSpotCamerasUsed(true, body_cameras),
+//               UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
+//                                    SpotCamera::RIGHT));
 
-  // WHEN Spot does not have a hand camera, and all body cameras are requested
-  // THEN SpotCameras for all body cameras are returned.
-  EXPECT_THAT(getSpotCamerasUsed(false, body_cameras),
-              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
-                                   SpotCamera::RIGHT));
+//   // WHEN Spot does not have a hand camera, and all body cameras are requested
+//   // THEN SpotCameras for all body cameras are returned.
+//   EXPECT_THAT(getSpotCamerasUsed(false, body_cameras),
+//               UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
+//                                    SpotCamera::RIGHT));
 
-  // WHEN only the front cameras are requested, and the robot has a hand camera
-  // THEN SpotCameras for only the front cameras are returned
-  EXPECT_THAT(getSpotCamerasUsed(true, front_cameras),
-              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT));
+//   // WHEN only the front cameras are requested, and the robot has a hand camera
+//   // THEN SpotCameras for only the front cameras are returned
+//   EXPECT_THAT(getSpotCamerasUsed(true, front_cameras),
+//               UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT));
 
-  // WHEN only the front cameras are requested, and the robot does not have a hand camera
-  // THEN SpotCameras for only the front cameras are returned
-  EXPECT_THAT(getSpotCamerasUsed(false, front_cameras),
-              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT));
+//   // WHEN only the front cameras are requested, and the robot does not have a hand camera
+//   // THEN SpotCameras for only the front cameras are returned
+//   EXPECT_THAT(getSpotCamerasUsed(false, front_cameras),
+//               UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT));
 
-  // WHEN the front cameras and an invalid camera are requested
-  // THEN SpotCameras for only the front cameras are returned
-  EXPECT_THAT(getSpotCamerasUsed(false, front_cameras_plus_invalid_camera),
-              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT));
-}
+//   // WHEN the front cameras and an invalid camera are requested
+//   // THEN SpotCameras for only the front cameras are returned
+//   EXPECT_THAT(getSpotCamerasUsed(false, front_cameras_plus_invalid_camera),
+//               UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT));
+// }
 
-// TODO(khughes-bdai): fix these tests for new function definition
-TEST(SpotImageSources, createImageSources) {
-  std::vector<std::string> default_cameras_used = {"frontleft", "frontright", "left", "right", "back", "hand"};
-  // WHEN no image types are requested, regardless of whether or not the hand camera is requested
-  // THEN no ImageSources are returned
-  EXPECT_THAT(createImageSources(false, false, false, false, default_cameras_used), IsEmpty());
-  EXPECT_THAT(createImageSources(false, false, false, true, default_cameras_used), IsEmpty());
+// // TODO(khughes-bdai): fix these tests for new function definition
+// TEST(SpotImageSources, createImageSources) {
+//   std::vector<std::string> default_cameras_used = {"frontleft", "frontright", "left", "right", "back", "hand"};
+//   // WHEN no image types are requested, regardless of whether or not the hand camera is requested
+//   // THEN no ImageSources are returned
+//   EXPECT_THAT(createImageSources(false, false, false, false, default_cameras_used), IsEmpty());
+//   EXPECT_THAT(createImageSources(false, false, false, true, default_cameras_used), IsEmpty());
 
-  // WHEN RGB images are requested from the body cameras, excluding the hand camera
-  // THEN image sources for all RGB body cameras are returned
-  EXPECT_THAT(createImageSources(true, false, false, false, default_cameras_used),
-              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::RIGHT, SpotImageType::RGB}));
+//   // WHEN RGB images are requested from the body cameras, excluding the hand camera
+//   // THEN image sources for all RGB body cameras are returned
+//   EXPECT_THAT(createImageSources(true, false, false, false, default_cameras_used),
+//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::RGB}));
 
-  // WHEN RGB images are requested from the body cameras and the hand camera
-  // THEN image sources for all RGB body cameras and the hand camera are returned
-  EXPECT_THAT(createImageSources(true, false, false, true, default_cameras_used),
-              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::HAND, SpotImageType::RGB}));
+//   // WHEN RGB images are requested from the body cameras and the hand camera
+//   // THEN image sources for all RGB body cameras and the hand camera are returned
+//   EXPECT_THAT(createImageSources(true, false, false, true, default_cameras_used),
+//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::HAND, SpotImageType::RGB}));
 
-  // WHEN depth images are requested from the body cameras, excluding the hand camera
-  // THEN image sources for all depth body cameras are returned
-  EXPECT_THAT(createImageSources(false, true, false, false, default_cameras_used),
-              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}));
+//   // WHEN depth images are requested from the body cameras, excluding the hand camera
+//   // THEN image sources for all depth body cameras are returned
+//   EXPECT_THAT(createImageSources(false, true, false, false, default_cameras_used),
+//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}));
 
-  // WHEN depth images are requested from the body cameras and the hand camera
-  // THEN image sources for all depth body cameras and the hand camera are returned
-  EXPECT_THAT(createImageSources(false, true, false, true, default_cameras_used),
-              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::HAND, SpotImageType::DEPTH}));
+//   // WHEN depth images are requested from the body cameras and the hand camera
+//   // THEN image sources for all depth body cameras and the hand camera are returned
+//   EXPECT_THAT(createImageSources(false, true, false, true, default_cameras_used),
+//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::HAND, SpotImageType::DEPTH}));
 
-  // WHEN registered depth images are requested from the body cameras, excluding the hand camera
-  // THEN image sources for all registered depth body cameras are returned
-  EXPECT_THAT(createImageSources(false, false, true, false, default_cameras_used),
-              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
+//   // WHEN registered depth images are requested from the body cameras, excluding the hand camera
+//   // THEN image sources for all registered depth body cameras are returned
+//   EXPECT_THAT(createImageSources(false, false, true, false, default_cameras_used),
+//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
 
-  // WHEN registered depth images are requested from the body cameras and the hand camera
-  // THEN image sources for all registered depth body cameras and the hand camera are returned
-  EXPECT_THAT(createImageSources(false, false, true, true, default_cameras_used),
-              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
+//   // WHEN registered depth images are requested from the body cameras and the hand camera
+//   // THEN image sources for all registered depth body cameras and the hand camera are returned
+//   EXPECT_THAT(createImageSources(false, false, true, true, default_cameras_used),
+//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
 
-  // WHEN RGB, depth, and registered images are requested from the body cameras, excluding the hand camera
-  // THEN image sources for all camera types and all body cameras are returned
-  EXPECT_THAT(
-      createImageSources(true, true, true, false, default_cameras_used),
-      UnorderedElementsAre(
-          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-          ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
-          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
+//   // WHEN RGB, depth, and registered images are requested from the body cameras, excluding the hand camera
+//   // THEN image sources for all camera types and all body cameras are returned
+//   EXPECT_THAT(
+//       createImageSources(true, true, true, false, default_cameras_used),
+//       UnorderedElementsAre(
+//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+//           ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
+//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
+//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
+//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
 
-  // WHEN RGB, depth, and registered images are requested from the body cameras and the hand camera
-  // THEN image sources for all camera types and all body cameras (plus the hand camera) are returned
-  EXPECT_THAT(
-      createImageSources(true, true, true, true, default_cameras_used),
-      UnorderedElementsAre(
-          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-          ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
-          ImageSource{SpotCamera::HAND, SpotImageType::RGB}, ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}, ImageSource{SpotCamera::HAND, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
-}
+//   // WHEN RGB, depth, and registered images are requested from the body cameras and the hand camera
+//   // THEN image sources for all camera types and all body cameras (plus the hand camera) are returned
+//   EXPECT_THAT(
+//       createImageSources(true, true, true, true, default_cameras_used),
+//       UnorderedElementsAre(
+//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+//           ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
+//           ImageSource{SpotCamera::HAND, SpotImageType::RGB}, ImageSource{SpotCamera::FRONTLEFT,
+//           SpotImageType::DEPTH}, ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}, ImageSource{SpotCamera::HAND, SpotImageType::DEPTH},
+//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
+// }
 }  // namespace spot_ros2::images::test

--- a/spot_driver/test/src/images/test_spot_image_sources.cpp
+++ b/spot_driver/test/src/images/test_spot_image_sources.cpp
@@ -135,104 +135,105 @@ TEST(SpotImageSources, fromSpotImageSourceName) {
 }
 
 // TODO(khughes-bdai): fix these tests for new function definition
-// TEST(SpotImageSources, createImageSources) {
-//   // WHEN no image types are requested, regardless of whether or not the hand camera is requested
-//   // THEN no ImageSources are returned
-//   EXPECT_THAT(createImageSources(false, false, false, false), IsEmpty());
-//   EXPECT_THAT(createImageSources(false, false, false, true), IsEmpty());
+TEST(SpotImageSources, createImageSources) {
+  std::vector<std::string> default_cameras_used = {"frontleft", "frontright", "left", "right", "back", "hand"};
+  // WHEN no image types are requested, regardless of whether or not the hand camera is requested
+  // THEN no ImageSources are returned
+  EXPECT_THAT(createImageSources(false, false, false, false, default_cameras_used), IsEmpty());
+  EXPECT_THAT(createImageSources(false, false, false, true, default_cameras_used), IsEmpty());
 
-//   // WHEN RGB images are requested from the body cameras, excluding the hand camera
-//   // THEN image sources for all RGB body cameras are returned
-//   EXPECT_THAT(createImageSources(true, false, false, false),
-//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::RGB}));
+  // WHEN RGB images are requested from the body cameras, excluding the hand camera
+  // THEN image sources for all RGB body cameras are returned
+  EXPECT_THAT(createImageSources(true, false, false, false, default_cameras_used),
+              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::RIGHT, SpotImageType::RGB}));
 
-//   // WHEN RGB images are requested from the body cameras and the hand camera
-//   // THEN image sources for all RGB body cameras and the hand camera are returned
-//   EXPECT_THAT(createImageSources(true, false, false, true),
-//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::HAND, SpotImageType::RGB}));
+  // WHEN RGB images are requested from the body cameras and the hand camera
+  // THEN image sources for all RGB body cameras and the hand camera are returned
+  EXPECT_THAT(createImageSources(true, false, false, true, default_cameras_used),
+              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::HAND, SpotImageType::RGB}));
 
-//   // WHEN depth images are requested from the body cameras, excluding the hand camera
-//   // THEN image sources for all depth body cameras are returned
-//   EXPECT_THAT(createImageSources(false, true, false, false),
-//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}));
+  // WHEN depth images are requested from the body cameras, excluding the hand camera
+  // THEN image sources for all depth body cameras are returned
+  EXPECT_THAT(createImageSources(false, true, false, false, default_cameras_used),
+              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}));
 
-//   // WHEN depth images are requested from the body cameras and the hand camera
-//   // THEN image sources for all depth body cameras and the hand camera are returned
-//   EXPECT_THAT(createImageSources(false, true, false, true),
-//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::HAND, SpotImageType::DEPTH}));
+  // WHEN depth images are requested from the body cameras and the hand camera
+  // THEN image sources for all depth body cameras and the hand camera are returned
+  EXPECT_THAT(createImageSources(false, true, false, true, default_cameras_used),
+              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::HAND, SpotImageType::DEPTH}));
 
-//   // WHEN registered depth images are requested from the body cameras, excluding the hand camera
-//   // THEN image sources for all registered depth body cameras are returned
-//   EXPECT_THAT(createImageSources(false, false, true, false),
-//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
+  // WHEN registered depth images are requested from the body cameras, excluding the hand camera
+  // THEN image sources for all registered depth body cameras are returned
+  EXPECT_THAT(createImageSources(false, false, true, false, default_cameras_used),
+              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
 
-//   // WHEN registered depth images are requested from the body cameras and the hand camera
-//   // THEN image sources for all registered depth body cameras and the hand camera are returned
-//   EXPECT_THAT(createImageSources(false, false, true, true),
-//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
+  // WHEN registered depth images are requested from the body cameras and the hand camera
+  // THEN image sources for all registered depth body cameras and the hand camera are returned
+  EXPECT_THAT(createImageSources(false, false, true, true, default_cameras_used),
+              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
 
-//   // WHEN RGB, depth, and registered images are requested from the body cameras, excluding the hand camera
-//   // THEN image sources for all camera types and all body cameras are returned
-//   EXPECT_THAT(
-//       createImageSources(true, true, true, false),
-//       UnorderedElementsAre(
-//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-//           ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
-//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
-//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
-//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
+  // WHEN RGB, depth, and registered images are requested from the body cameras, excluding the hand camera
+  // THEN image sources for all camera types and all body cameras are returned
+  EXPECT_THAT(
+      createImageSources(true, true, true, false, default_cameras_used),
+      UnorderedElementsAre(
+          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+          ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
+          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
 
-//   // WHEN RGB, depth, and registered images are requested from the body cameras and the hand camera
-//   // THEN image sources for all camera types and all body cameras (plus the hand camera) are returned
-//   EXPECT_THAT(
-//       createImageSources(true, true, true, true),
-//       UnorderedElementsAre(
-//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-//           ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
-//           ImageSource{SpotCamera::HAND, SpotImageType::RGB}, ImageSource{SpotCamera::FRONTLEFT,
-//           SpotImageType::DEPTH}, ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}, ImageSource{SpotCamera::HAND, SpotImageType::DEPTH},
-//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
-// }
+  // WHEN RGB, depth, and registered images are requested from the body cameras and the hand camera
+  // THEN image sources for all camera types and all body cameras (plus the hand camera) are returned
+  EXPECT_THAT(
+      createImageSources(true, true, true, true, default_cameras_used),
+      UnorderedElementsAre(
+          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+          ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
+          ImageSource{SpotCamera::HAND, SpotImageType::RGB}, ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}, ImageSource{SpotCamera::HAND, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
+}
 }  // namespace spot_ros2::images::test

--- a/spot_driver/test/src/images/test_spot_image_sources.cpp
+++ b/spot_driver/test/src/images/test_spot_image_sources.cpp
@@ -134,104 +134,105 @@ TEST(SpotImageSources, fromSpotImageSourceName) {
               Eq(ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
 }
 
-TEST(SpotImageSources, createImageSources) {
-  // WHEN no image types are requested, regardless of whether or not the hand camera is requested
-  // THEN no ImageSources are returned
-  EXPECT_THAT(createImageSources(false, false, false, false), IsEmpty());
-  EXPECT_THAT(createImageSources(false, false, false, true), IsEmpty());
+// TODO(khughes-bdai): fix these tests for new function definition
+// TEST(SpotImageSources, createImageSources) {
+//   // WHEN no image types are requested, regardless of whether or not the hand camera is requested
+//   // THEN no ImageSources are returned
+//   EXPECT_THAT(createImageSources(false, false, false, false), IsEmpty());
+//   EXPECT_THAT(createImageSources(false, false, false, true), IsEmpty());
 
-  // WHEN RGB images are requested from the body cameras, excluding the hand camera
-  // THEN image sources for all RGB body cameras are returned
-  EXPECT_THAT(createImageSources(true, false, false, false),
-              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::RIGHT, SpotImageType::RGB}));
+//   // WHEN RGB images are requested from the body cameras, excluding the hand camera
+//   // THEN image sources for all RGB body cameras are returned
+//   EXPECT_THAT(createImageSources(true, false, false, false),
+//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::RGB}));
 
-  // WHEN RGB images are requested from the body cameras and the hand camera
-  // THEN image sources for all RGB body cameras and the hand camera are returned
-  EXPECT_THAT(createImageSources(true, false, false, true),
-              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
-                                   ImageSource{SpotCamera::HAND, SpotImageType::RGB}));
+//   // WHEN RGB images are requested from the body cameras and the hand camera
+//   // THEN image sources for all RGB body cameras and the hand camera are returned
+//   EXPECT_THAT(createImageSources(true, false, false, true),
+//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
+//                                    ImageSource{SpotCamera::HAND, SpotImageType::RGB}));
 
-  // WHEN depth images are requested from the body cameras, excluding the hand camera
-  // THEN image sources for all depth body cameras are returned
-  EXPECT_THAT(createImageSources(false, true, false, false),
-              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}));
+//   // WHEN depth images are requested from the body cameras, excluding the hand camera
+//   // THEN image sources for all depth body cameras are returned
+//   EXPECT_THAT(createImageSources(false, true, false, false),
+//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}));
 
-  // WHEN depth images are requested from the body cameras and the hand camera
-  // THEN image sources for all depth body cameras and the hand camera are returned
-  EXPECT_THAT(createImageSources(false, true, false, true),
-              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
-                                   ImageSource{SpotCamera::HAND, SpotImageType::DEPTH}));
+//   // WHEN depth images are requested from the body cameras and the hand camera
+//   // THEN image sources for all depth body cameras and the hand camera are returned
+//   EXPECT_THAT(createImageSources(false, true, false, true),
+//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
+//                                    ImageSource{SpotCamera::HAND, SpotImageType::DEPTH}));
 
-  // WHEN registered depth images are requested from the body cameras, excluding the hand camera
-  // THEN image sources for all registered depth body cameras are returned
-  EXPECT_THAT(createImageSources(false, false, true, false),
-              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
+//   // WHEN registered depth images are requested from the body cameras, excluding the hand camera
+//   // THEN image sources for all registered depth body cameras are returned
+//   EXPECT_THAT(createImageSources(false, false, true, false),
+//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
 
-  // WHEN registered depth images are requested from the body cameras and the hand camera
-  // THEN image sources for all registered depth body cameras and the hand camera are returned
-  EXPECT_THAT(createImageSources(false, false, true, true),
-              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
-                                   ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
+//   // WHEN registered depth images are requested from the body cameras and the hand camera
+//   // THEN image sources for all registered depth body cameras and the hand camera are returned
+//   EXPECT_THAT(createImageSources(false, false, true, true),
+//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
+//                                    ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
 
-  // WHEN RGB, depth, and registered images are requested from the body cameras, excluding the hand camera
-  // THEN image sources for all camera types and all body cameras are returned
-  EXPECT_THAT(
-      createImageSources(true, true, true, false),
-      UnorderedElementsAre(
-          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-          ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
-          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
+//   // WHEN RGB, depth, and registered images are requested from the body cameras, excluding the hand camera
+//   // THEN image sources for all camera types and all body cameras are returned
+//   EXPECT_THAT(
+//       createImageSources(true, true, true, false),
+//       UnorderedElementsAre(
+//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+//           ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
+//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
+//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
+//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
 
-  // WHEN RGB, depth, and registered images are requested from the body cameras and the hand camera
-  // THEN image sources for all camera types and all body cameras (plus the hand camera) are returned
-  EXPECT_THAT(
-      createImageSources(true, true, true, true),
-      UnorderedElementsAre(
-          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-          ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
-          ImageSource{SpotCamera::HAND, SpotImageType::RGB}, ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}, ImageSource{SpotCamera::HAND, SpotImageType::DEPTH},
-          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
-          ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
-}
+//   // WHEN RGB, depth, and registered images are requested from the body cameras and the hand camera
+//   // THEN image sources for all camera types and all body cameras (plus the hand camera) are returned
+//   EXPECT_THAT(
+//       createImageSources(true, true, true, true),
+//       UnorderedElementsAre(
+//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+//           ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
+//           ImageSource{SpotCamera::HAND, SpotImageType::RGB}, ImageSource{SpotCamera::FRONTLEFT,
+//           SpotImageType::DEPTH}, ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}, ImageSource{SpotCamera::HAND, SpotImageType::DEPTH},
+//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
+//           ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
+// }
 }  // namespace spot_ros2::images::test

--- a/spot_driver/test/src/images/test_spot_image_sources.cpp
+++ b/spot_driver/test/src/images/test_spot_image_sources.cpp
@@ -141,6 +141,8 @@ TEST(SpotImageSources, createImageSources) {
   std::set<spot_ros2::SpotCamera> default_cameras_without_arm = {
       spot_ros2::SpotCamera::FRONTLEFT, spot_ros2::SpotCamera::FRONTRIGHT, spot_ros2::SpotCamera::LEFT,
       spot_ros2::SpotCamera::RIGHT, spot_ros2::SpotCamera::BACK};
+  std::set<spot_ros2::SpotCamera> only_front_cameras = {spot_ros2::SpotCamera::FRONTLEFT,
+                                                        spot_ros2::SpotCamera::FRONTRIGHT};
   // WHEN no image types are requested, regardless of whether or not the hand camera is requested
   // THEN no ImageSources are returned
   EXPECT_THAT(createImageSources(false, false, false, default_cameras_without_arm), IsEmpty());
@@ -239,5 +241,15 @@ TEST(SpotImageSources, createImageSources) {
           ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
           ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
+
+  // WHEN RGB, depth, and registered images are requested from only the frontleft and frontright cameras
+  // THEN image sources for only these camera types are returned
+  EXPECT_THAT(createImageSources(true, true, true, only_front_cameras),
+              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED}));
 }
 }  // namespace spot_ros2::images::test

--- a/spot_driver/test/src/images/test_spot_image_sources.cpp
+++ b/spot_driver/test/src/images/test_spot_image_sources.cpp
@@ -134,6 +134,56 @@ TEST(SpotImageSources, fromSpotImageSourceName) {
               Eq(ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
 }
 
+TEST(SpotImageSources, getSpotCamerasUsed) {
+  std::vector<std::string> body_cameras = {"frontleft", "frontright", "left", "right", "back"};
+  std::vector<std::string> body_cameras_plus_hand = {"frontleft", "frontright", "left", "right", "back", "hand"};
+  std::vector<std::string> front_cameras = {"frontleft", "frontright"};
+  std::vector<std::string> front_cameras_plus_invalid_camera = {"frontleft", "frontright", "not_a_camera"};
+  // WHEN no cameras are requested, regardless of whether or not the robot has an arm
+  // THEN no SpotCameras are returned
+  EXPECT_THAT(getSpotCamerasUsed(true, std::vector<std::string>{}), IsEmpty());
+  EXPECT_THAT(getSpotCamerasUsed(false, std::vector<std::string>{}), IsEmpty());
+
+  // WHEN Spot has a hand camera, and all body cameras plus the hand camera are requested
+  // THEN SpotCameras for all body cameras plus the hand camera are returned.
+  EXPECT_THAT(getSpotCamerasUsed(true, body_cameras_plus_hand),
+              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
+                                   SpotCamera::RIGHT, SpotCamera::HAND));
+
+  // WHEN Spot does not have a hand camera, and all body cameras plus the hand camera are requested
+  // THEN SpotCameras for all body cameras are returned.
+  EXPECT_THAT(getSpotCamerasUsed(false, body_cameras_plus_hand),
+              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
+                                   SpotCamera::RIGHT));
+
+  // WHEN Spot has a hand camera, and all body cameras are requested
+  // THEN SpotCameras for all body cameras are returned.
+  EXPECT_THAT(getSpotCamerasUsed(true, body_cameras),
+              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
+                                   SpotCamera::RIGHT));
+
+  // WHEN Spot does not have a hand camera, and all body cameras are requested
+  // THEN SpotCameras for all body cameras are returned.
+  EXPECT_THAT(getSpotCamerasUsed(false, body_cameras),
+              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
+                                   SpotCamera::RIGHT));
+
+  // WHEN only the front cameras are requested, and the robot has a hand camera
+  // THEN SpotCameras for only the front cameras are returned
+  EXPECT_THAT(getSpotCamerasUsed(true, front_cameras),
+              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT));
+
+  // WHEN only the front cameras are requested, and the robot does not have a hand camera
+  // THEN SpotCameras for only the front cameras are returned
+  EXPECT_THAT(getSpotCamerasUsed(false, front_cameras),
+              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT));
+
+  // WHEN the front cameras and an invalid camera are requested
+  // THEN SpotCameras for only the front cameras are returned
+  EXPECT_THAT(getSpotCamerasUsed(false, front_cameras_plus_invalid_camera),
+              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT));
+}
+
 // TODO(khughes-bdai): fix these tests for new function definition
 TEST(SpotImageSources, createImageSources) {
   std::vector<std::string> default_cameras_used = {"frontleft", "frontright", "left", "right", "back", "hand"};

--- a/spot_driver/test/src/images/test_spot_image_sources.cpp
+++ b/spot_driver/test/src/images/test_spot_image_sources.cpp
@@ -134,156 +134,110 @@ TEST(SpotImageSources, fromSpotImageSourceName) {
               Eq(ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
 }
 
-// TEST(SpotImageSources, getSpotCamerasUsed) {
-//   std::vector<std::string> body_cameras = {"frontleft", "frontright", "left", "right", "back"};
-//   std::vector<std::string> body_cameras_plus_hand = {"frontleft", "frontright", "left", "right", "back", "hand"};
-//   std::vector<std::string> front_cameras = {"frontleft", "frontright"};
-//   std::vector<std::string> front_cameras_plus_invalid_camera = {"frontleft", "frontright", "not_a_camera"};
-//   // WHEN no cameras are requested, regardless of whether or not the robot has an arm
-//   // THEN no SpotCameras are returned
-//   EXPECT_THAT(getSpotCamerasUsed(true, std::vector<std::string>{}), IsEmpty());
-//   EXPECT_THAT(getSpotCamerasUsed(false, std::vector<std::string>{}), IsEmpty());
+TEST(SpotImageSources, createImageSources) {
+  std::set<spot_ros2::SpotCamera> default_cameras_with_arm = {
+      spot_ros2::SpotCamera::FRONTLEFT, spot_ros2::SpotCamera::FRONTRIGHT, spot_ros2::SpotCamera::LEFT,
+      spot_ros2::SpotCamera::RIGHT,     spot_ros2::SpotCamera::BACK,       spot_ros2::SpotCamera::HAND};
+  std::set<spot_ros2::SpotCamera> default_cameras_without_arm = {
+      spot_ros2::SpotCamera::FRONTLEFT, spot_ros2::SpotCamera::FRONTRIGHT, spot_ros2::SpotCamera::LEFT,
+      spot_ros2::SpotCamera::RIGHT, spot_ros2::SpotCamera::BACK};
+  // WHEN no image types are requested, regardless of whether or not the hand camera is requested
+  // THEN no ImageSources are returned
+  EXPECT_THAT(createImageSources(false, false, false, default_cameras_without_arm), IsEmpty());
+  EXPECT_THAT(createImageSources(false, false, false, default_cameras_with_arm), IsEmpty());
 
-//   // WHEN Spot has a hand camera, and all body cameras plus the hand camera are requested
-//   // THEN SpotCameras for all body cameras plus the hand camera are returned.
-//   EXPECT_THAT(getSpotCamerasUsed(true, body_cameras_plus_hand),
-//               UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
-//                                    SpotCamera::RIGHT, SpotCamera::HAND));
+  // WHEN RGB images are requested from the body cameras, excluding the hand camera
+  // THEN image sources for all RGB body cameras are returned
+  EXPECT_THAT(createImageSources(true, false, false, default_cameras_without_arm),
+              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::RIGHT, SpotImageType::RGB}));
 
-//   // WHEN Spot does not have a hand camera, and all body cameras plus the hand camera are requested
-//   // THEN SpotCameras for all body cameras are returned.
-//   EXPECT_THAT(getSpotCamerasUsed(false, body_cameras_plus_hand),
-//               UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
-//                                    SpotCamera::RIGHT));
+  // WHEN RGB images are requested from the body cameras and the hand camera
+  // THEN image sources for all RGB body cameras and the hand camera are returned
+  EXPECT_THAT(createImageSources(true, false, false, default_cameras_with_arm),
+              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
+                                   ImageSource{SpotCamera::HAND, SpotImageType::RGB}));
 
-//   // WHEN Spot has a hand camera, and all body cameras are requested
-//   // THEN SpotCameras for all body cameras are returned.
-//   EXPECT_THAT(getSpotCamerasUsed(true, body_cameras),
-//               UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
-//                                    SpotCamera::RIGHT));
+  // WHEN depth images are requested from the body cameras, excluding the hand camera
+  // THEN image sources for all depth body cameras are returned
+  EXPECT_THAT(createImageSources(false, true, false, default_cameras_without_arm),
+              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}));
 
-//   // WHEN Spot does not have a hand camera, and all body cameras are requested
-//   // THEN SpotCameras for all body cameras are returned.
-//   EXPECT_THAT(getSpotCamerasUsed(false, body_cameras),
-//               UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::BACK, SpotCamera::LEFT,
-//                                    SpotCamera::RIGHT));
+  // WHEN depth images are requested from the body cameras and the hand camera
+  // THEN image sources for all depth body cameras and the hand camera are returned
+  EXPECT_THAT(createImageSources(false, true, false, default_cameras_with_arm),
+              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
+                                   ImageSource{SpotCamera::HAND, SpotImageType::DEPTH}));
 
-//   // WHEN only the front cameras are requested, and the robot has a hand camera
-//   // THEN SpotCameras for only the front cameras are returned
-//   EXPECT_THAT(getSpotCamerasUsed(true, front_cameras),
-//               UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT));
+  // WHEN registered depth images are requested from the body cameras, excluding the hand camera
+  // THEN image sources for all registered depth body cameras are returned
+  EXPECT_THAT(createImageSources(false, false, true, default_cameras_without_arm),
+              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
 
-//   // WHEN only the front cameras are requested, and the robot does not have a hand camera
-//   // THEN SpotCameras for only the front cameras are returned
-//   EXPECT_THAT(getSpotCamerasUsed(false, front_cameras),
-//               UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT));
+  // WHEN registered depth images are requested from the body cameras and the hand camera
+  // THEN image sources for all registered depth body cameras and the hand camera are returned
+  EXPECT_THAT(createImageSources(false, false, true, default_cameras_with_arm),
+              UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
+                                   ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
 
-//   // WHEN the front cameras and an invalid camera are requested
-//   // THEN SpotCameras for only the front cameras are returned
-//   EXPECT_THAT(getSpotCamerasUsed(false, front_cameras_plus_invalid_camera),
-//               UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT));
-// }
+  // WHEN RGB, depth, and registered images are requested from the body cameras, excluding the hand camera
+  // THEN image sources for all camera types and all body cameras are returned
+  EXPECT_THAT(
+      createImageSources(true, true, true, default_cameras_without_arm),
+      UnorderedElementsAre(
+          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+          ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
+          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
 
-// // TODO(khughes-bdai): fix these tests for new function definition
-// TEST(SpotImageSources, createImageSources) {
-//   std::vector<std::string> default_cameras_used = {"frontleft", "frontright", "left", "right", "back", "hand"};
-//   // WHEN no image types are requested, regardless of whether or not the hand camera is requested
-//   // THEN no ImageSources are returned
-//   EXPECT_THAT(createImageSources(false, false, false, false, default_cameras_used), IsEmpty());
-//   EXPECT_THAT(createImageSources(false, false, false, true, default_cameras_used), IsEmpty());
-
-//   // WHEN RGB images are requested from the body cameras, excluding the hand camera
-//   // THEN image sources for all RGB body cameras are returned
-//   EXPECT_THAT(createImageSources(true, false, false, false, default_cameras_used),
-//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::RGB}));
-
-//   // WHEN RGB images are requested from the body cameras and the hand camera
-//   // THEN image sources for all RGB body cameras and the hand camera are returned
-//   EXPECT_THAT(createImageSources(true, false, false, true, default_cameras_used),
-//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::LEFT, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
-//                                    ImageSource{SpotCamera::HAND, SpotImageType::RGB}));
-
-//   // WHEN depth images are requested from the body cameras, excluding the hand camera
-//   // THEN image sources for all depth body cameras are returned
-//   EXPECT_THAT(createImageSources(false, true, false, false, default_cameras_used),
-//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}));
-
-//   // WHEN depth images are requested from the body cameras and the hand camera
-//   // THEN image sources for all depth body cameras and the hand camera are returned
-//   EXPECT_THAT(createImageSources(false, true, false, true, default_cameras_used),
-//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
-//                                    ImageSource{SpotCamera::HAND, SpotImageType::DEPTH}));
-
-//   // WHEN registered depth images are requested from the body cameras, excluding the hand camera
-//   // THEN image sources for all registered depth body cameras are returned
-//   EXPECT_THAT(createImageSources(false, false, true, false, default_cameras_used),
-//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
-
-//   // WHEN registered depth images are requested from the body cameras and the hand camera
-//   // THEN image sources for all registered depth body cameras and the hand camera are returned
-//   EXPECT_THAT(createImageSources(false, false, true, true, default_cameras_used),
-//               UnorderedElementsAre(ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
-//                                    ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
-
-//   // WHEN RGB, depth, and registered images are requested from the body cameras, excluding the hand camera
-//   // THEN image sources for all camera types and all body cameras are returned
-//   EXPECT_THAT(
-//       createImageSources(true, true, true, false, default_cameras_used),
-//       UnorderedElementsAre(
-//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-//           ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
-//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
-//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH},
-//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED}));
-
-//   // WHEN RGB, depth, and registered images are requested from the body cameras and the hand camera
-//   // THEN image sources for all camera types and all body cameras (plus the hand camera) are returned
-//   EXPECT_THAT(
-//       createImageSources(true, true, true, true, default_cameras_used),
-//       UnorderedElementsAre(
-//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
-//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
-//           ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
-//           ImageSource{SpotCamera::HAND, SpotImageType::RGB}, ImageSource{SpotCamera::FRONTLEFT,
-//           SpotImageType::DEPTH}, ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
-//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
-//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}, ImageSource{SpotCamera::HAND, SpotImageType::DEPTH},
-//           ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
-//           ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
-// }
+  // WHEN RGB, depth, and registered images are requested from the body cameras and the hand camera
+  // THEN image sources for all camera types and all body cameras (plus the hand camera) are returned
+  EXPECT_THAT(
+      createImageSources(true, true, true, default_cameras_with_arm),
+      UnorderedElementsAre(
+          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::RGB},
+          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::RGB}, ImageSource{SpotCamera::BACK, SpotImageType::RGB},
+          ImageSource{SpotCamera::LEFT, SpotImageType::RGB}, ImageSource{SpotCamera::RIGHT, SpotImageType::RGB},
+          ImageSource{SpotCamera::HAND, SpotImageType::RGB}, ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH}, ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH}, ImageSource{SpotCamera::HAND, SpotImageType::DEPTH},
+          ImageSource{SpotCamera::FRONTLEFT, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::FRONTRIGHT, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::BACK, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::LEFT, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::RIGHT, SpotImageType::DEPTH_REGISTERED},
+          ImageSource{SpotCamera::HAND, SpotImageType::DEPTH_REGISTERED}));
+}
 }  // namespace spot_ros2::images::test

--- a/spot_driver/test/src/test_parameter_interface.cpp
+++ b/spot_driver/test/src/test_parameter_interface.cpp
@@ -13,9 +13,11 @@
 namespace {
 using ::testing::Eq;
 using ::testing::IsEmpty;
+using ::testing::IsFalse;
 using ::testing::IsTrue;
 using ::testing::Optional;
 using ::testing::StrEq;
+using ::testing::UnorderedElementsAre;
 
 constexpr auto kNodeName = "my_node_name";
 constexpr auto kNamespace = "my_namespace";
@@ -270,5 +272,91 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetConfigDefaults) {
   EXPECT_THAT(parameter_interface.getPublishRGBImages(), IsTrue());
   EXPECT_THAT(parameter_interface.getPublishDepthImages(), IsTrue());
   EXPECT_THAT(parameter_interface.getPublishDepthRegisteredImages(), IsTrue());
+}
+
+TEST_F(RclcppParameterInterfaceEnvVarTest, GetCamerasUsedDefaultWithArm) {
+  // GIVEN we don't set the cameras_used parameter
+  // GIVEN we create a RclcppParameterInterface using the node
+  RclcppParameterInterface parameter_interface{node_};
+
+  // WHEN we call the functions to get the config values from the parameter interface
+  // THEN we get the default of all available cameras.
+  const auto cameras_used_arm = parameter_interface.getCamerasUsed(true);
+  EXPECT_THAT(cameras_used_arm.has_value(), IsTrue());
+  EXPECT_THAT(cameras_used_arm.value(),
+              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::LEFT, SpotCamera::RIGHT,
+                                   SpotCamera::BACK, SpotCamera::HAND));
+}
+
+TEST_F(RclcppParameterInterfaceEnvVarTest, GetCamerasUsedDefaultWithoutArm) {
+  // Note: this cannot live in the same test as above, as the first call to getCamerasUsed will declare a parameter,
+  // and here we want to explicitly test what happens with no parameter declared.
+
+  // GIVEN we don't set the cameras_used parameter
+  // GIVEN we create a RclcppParameterInterface using the node
+  RclcppParameterInterface parameter_interface{node_};
+
+  // WHEN we call the functions to get the config values from the parameter interface
+  // THEN we get the default of all available cameras.
+  const auto cameras_used_no_arm = parameter_interface.getCamerasUsed(false);
+  EXPECT_THAT(cameras_used_no_arm.has_value(), IsTrue());
+  EXPECT_THAT(cameras_used_no_arm.value(), UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT,
+                                                                SpotCamera::LEFT, SpotCamera::RIGHT, SpotCamera::BACK));
+}
+
+TEST_F(RclcppParameterInterfaceEnvVarTest, GetCamerasUsedSubset) {
+  // GIVEN we set cameras used to a subset of the available cameras
+  const std::vector<std::string> cameras_used_parameter = {"frontleft", "frontright"};
+  node_->declare_parameter("cameras_used", cameras_used_parameter);
+
+  // GIVEN we create a RclcppParameterInterface using the node
+  RclcppParameterInterface parameter_interface{node_};
+
+  // WHEN we call the functions to get the config values from the parameter interface
+  // THEN the returned values match the values we used when declaring the parameters, regardless of if there is an arm
+  const auto cameras_used_arm = parameter_interface.getCamerasUsed(true);
+  EXPECT_THAT(cameras_used_arm.has_value(), IsTrue());
+  EXPECT_THAT(cameras_used_arm.value(), UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT));
+
+  const auto cameras_used_no_arm = parameter_interface.getCamerasUsed(false);
+  EXPECT_THAT(cameras_used_no_arm.has_value(), IsTrue());
+  EXPECT_THAT(cameras_used_no_arm.value(), UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT));
+}
+
+TEST_F(RclcppParameterInterfaceEnvVarTest, GetCamerasUsedSubsetWithHand) {
+  // GIVEN we set cameras used to a subset of the available cameras including the hand camera
+  const std::vector<std::string> cameras_used_parameter = {"frontleft", "frontright", "hand"};
+  node_->declare_parameter("cameras_used", cameras_used_parameter);
+
+  // GIVEN we create a RclcppParameterInterface using the node
+  RclcppParameterInterface parameter_interface{node_};
+
+  // WHEN we call the functions to get the config values from the parameter interface if the robot has an arm
+  // THEN the returned values match the values we used when declaring the parameters
+  const auto cameras_used_arm = parameter_interface.getCamerasUsed(true);
+  EXPECT_THAT(cameras_used_arm.has_value(), IsTrue());
+  EXPECT_THAT(cameras_used_arm.value(),
+              UnorderedElementsAre(SpotCamera::FRONTLEFT, SpotCamera::FRONTRIGHT, SpotCamera::HAND));
+
+  // WHEN we call the functions to get the config values from the parameter interface if the robot does not have an arm
+  // THEN this is an invalid choice of parameters.
+  const auto cameras_used_no_arm = parameter_interface.getCamerasUsed(false);
+  EXPECT_THAT(cameras_used_no_arm.has_value(), IsFalse());
+}
+
+TEST_F(RclcppParameterInterfaceEnvVarTest, GetCamerasUsedWithInvalidCamera) {
+  // GIVEN we set cameras used to a subset of the available cameras, with an invalid camera
+  const std::vector<std::string> cameras_used_parameter = {"frontleft", "frontright", "not_a_camera"};
+  node_->declare_parameter("cameras_used", cameras_used_parameter);
+
+  // GIVEN we create a RclcppParameterInterface using the node
+  RclcppParameterInterface parameter_interface{node_};
+
+  // WHEN we call the functions to get the config values from the parameter interface
+  // THEN the result is invalid for robots with and without arms, as the camera "not_a_camera" does not exist on Spot.
+  const auto cameras_used_arm = parameter_interface.getCamerasUsed(true);
+  EXPECT_THAT(cameras_used_arm.has_value(), IsFalse());
+  const auto cameras_used_no_arm = parameter_interface.getCamerasUsed(false);
+  EXPECT_THAT(cameras_used_no_arm.has_value(), IsFalse());
 }
 }  // namespace spot_ros2::test

--- a/spot_driver/test/src/test_parameter_interface.cpp
+++ b/spot_driver/test/src/test_parameter_interface.cpp
@@ -342,6 +342,7 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetCamerasUsedSubsetWithHand) {
   // THEN this is an invalid choice of parameters.
   const auto cameras_used_no_arm = parameter_interface.getCamerasUsed(false);
   EXPECT_THAT(cameras_used_no_arm.has_value(), IsFalse());
+  EXPECT_THAT(cameras_used_no_arm.error(), StrEq("Cannot add SpotCamera 'hand', the robot does not have an arm!"));
 }
 
 TEST_F(RclcppParameterInterfaceEnvVarTest, GetCamerasUsedWithInvalidCamera) {
@@ -356,7 +357,9 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetCamerasUsedWithInvalidCamera) {
   // THEN the result is invalid for robots with and without arms, as the camera "not_a_camera" does not exist on Spot.
   const auto cameras_used_arm = parameter_interface.getCamerasUsed(true);
   EXPECT_THAT(cameras_used_arm.has_value(), IsFalse());
+  EXPECT_THAT(cameras_used_arm.error(), StrEq("Cannot convert camera 'not_a_camera' to a SpotCamera."));
   const auto cameras_used_no_arm = parameter_interface.getCamerasUsed(false);
   EXPECT_THAT(cameras_used_no_arm.has_value(), IsFalse());
+  EXPECT_THAT(cameras_used_no_arm.error(), StrEq("Cannot convert camera 'not_a_camera' to a SpotCamera."));
 }
 }  // namespace spot_ros2::test


### PR DESCRIPTION
## Change Overview

Allows the user to specify the cameras they want to stream from in their config file. This can help alleviate some bandwidth problems from streaming from all cameras all the time. 

For example, to only stream from the frontleft, frontright, and hand cameras, you can add the following to the config yaml:
```
cameras_used: ["frontleft", "frontright", "hand"]
```

## Testing Done

- [x] when updating `cameras_used` in the config file, only those camera streams get published.
- [x] default launch with no specification of `cameras_used` still publishes all camera streams
- [x] stress testing with badly formed config yamls / no config file
    - [x] driver launches with all cameras if no config file is used
    - [x] if there are nonexistent cameras in the parameter `cameras_used` this logs a warning and defaults to all cameras used. This includes if the user specifies the hand camera when the robot doesn't have an arm
    - [x] image stitcher won't launch unless frontleft and frontright are also enabled (in addition to the launch argument `stitch_front_images` being set to true)
- [x] Test that things still work as expected on Spots without arms
- [x] update unit tests 