### PR TITLE
[N/A] Mark successful `ExecuteDance` goals as successful

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2731,6 +2731,7 @@ class SpotROS(Node):
         self.run_dance_feedback = False
         feedback_thread.join()
 
+        execute_dance_handle.succeed()
         result = ExecuteDance.Result()
         result.success = res
         result.message = msg


### PR DESCRIPTION
## Change Overview

Precisely what the title says. The `ExecuteDance` action server implementation has other problems when action leaves the happy path, but for the time being this patch completes the happy path.

## Testing Done

Manually at the Spot lab.
