### PR TITLE
[SW-822] Spot Driver without gripper

### DIFF
--- a/spot_driver/config/spot_ros_example.yaml
+++ b/spot_driver/config/spot_ros_example.yaml
@@ -43,5 +43,5 @@
     # The stitched image will be of size (<frontleft image width>, <frontleft image height> + row_padding)
     stitched_image_row_padding: 1182
 
-    # Change to false if missing gripper on arm
+    # Change to True if missing gripper on arm
     gripperless: False

--- a/spot_driver/config/spot_ros_example.yaml
+++ b/spot_driver/config/spot_ros_example.yaml
@@ -42,3 +42,6 @@
     virtual_camera_plane_distance: 0.5
     # The stitched image will be of size (<frontleft image width>, <frontleft image height> + row_padding)
     stitched_image_row_padding: 1182
+
+    # Change to false if missing gripper on arm
+    gripperless: False


### PR DESCRIPTION
## Change Overview

Added a parameter "gripperless" to indicate if the gripper is attached to the arm or not. If the arm is present but gripper is not, it will skip making the gripper and hand camera services.

Goes with https://github.com/bdaiinstitute/spot_wrapper/pull/125

## Testing Done
Tested on a Spot with a special gripperless firmware 

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
