### PR TITLE
[SW-1252] add missing header for stitched image, and correctly remap stitched image camera info topic from launchfile

### DIFF
--- a/spot_driver/include/spot_driver/image_stitcher/image_stitcher.hpp
+++ b/spot_driver/include/spot_driver/image_stitcher/image_stitcher.hpp
@@ -116,6 +116,9 @@ class RclcppCameraHandle : public CameraHandleBase {
   image_transport::ImageTransport image_transport_;
   image_transport::CameraPublisher camera_publisher_;
   RclcppTfBroadcasterInterface tf_broadcaster_;
+  std::string spot_name_;
+  std::string frame_prefix_;
+  std::string camera_prefix_;
   std::string body_frame_;
   std::string camera_frame_;
   cv::Matx33d intrinsics_;

--- a/spot_driver/include/spot_driver/image_stitcher/image_stitcher.hpp
+++ b/spot_driver/include/spot_driver/image_stitcher/image_stitcher.hpp
@@ -116,9 +116,6 @@ class RclcppCameraHandle : public CameraHandleBase {
   image_transport::ImageTransport image_transport_;
   image_transport::CameraPublisher camera_publisher_;
   RclcppTfBroadcasterInterface tf_broadcaster_;
-  std::string spot_name_;
-  std::string frame_prefix_;
-  std::string camera_prefix_;
   std::string body_frame_;
   std::string camera_frame_;
   cv::Matx33d intrinsics_;

--- a/spot_driver/launch/spot_image_publishers.launch.py
+++ b/spot_driver/launch/spot_image_publishers.launch.py
@@ -163,10 +163,11 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
 
     # add the image stitcher node, but only if frontleft and frontright cameras are enabled.
     if "frontleft" in camera_sources and "frontright" in camera_sources:
+        virtual_camera_frame = "frontmiddle_virtual"
         stitcher_params = {
             "spot_name": spot_name,
             "body_frame": "body",
-            "virtual_camera_frame": "frontmiddle_virtual",
+            "virtual_camera_frame": virtual_camera_frame,
         }
         stitcher_prefix = f"/{spot_name}" if spot_name else ""
         image_stitcher_node = launch_ros.actions.Node(
@@ -179,7 +180,11 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
                 (f"{stitcher_prefix}/left/camera_info", f"{stitcher_prefix}/camera/frontleft/camera_info"),
                 (f"{stitcher_prefix}/right/image", f"{stitcher_prefix}/camera/frontright/image"),
                 (f"{stitcher_prefix}/right/camera_info", f"{stitcher_prefix}/camera/frontright/camera_info"),
-                (f"{stitcher_prefix}/virtual_camera/image", f"{stitcher_prefix}/camera/frontmiddle_virtual/image"),
+                (f"{stitcher_prefix}/virtual_camera/image", f"{stitcher_prefix}/camera/{virtual_camera_frame}/image"),
+                (
+                    f"{stitcher_prefix}/virtual_camera/camera_info",
+                    f"{stitcher_prefix}/camera/{virtual_camera_frame}/camera_info",
+                ),
             ],
             parameters=[config_file, stitcher_params],
             condition=IfCondition(LaunchConfiguration("stitch_front_images")),

--- a/spot_driver/launch/spot_image_publishers.launch.py
+++ b/spot_driver/launch/spot_image_publishers.launch.py
@@ -169,22 +169,19 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
             "body_frame": "body",
             "virtual_camera_frame": virtual_camera_frame,
         }
-        stitcher_prefix = f"/{spot_name}" if spot_name else ""
+        cam_prefix = f"/{spot_name}" if spot_name else ""
         image_stitcher_node = launch_ros.actions.Node(
             package="spot_driver",
             executable="image_stitcher_node",
             namespace=spot_name,
             output="screen",
             remappings=[
-                (f"{stitcher_prefix}/left/image", f"{stitcher_prefix}/camera/frontleft/image"),
-                (f"{stitcher_prefix}/left/camera_info", f"{stitcher_prefix}/camera/frontleft/camera_info"),
-                (f"{stitcher_prefix}/right/image", f"{stitcher_prefix}/camera/frontright/image"),
-                (f"{stitcher_prefix}/right/camera_info", f"{stitcher_prefix}/camera/frontright/camera_info"),
-                (f"{stitcher_prefix}/virtual_camera/image", f"{stitcher_prefix}/camera/{virtual_camera_frame}/image"),
-                (
-                    f"{stitcher_prefix}/virtual_camera/camera_info",
-                    f"{stitcher_prefix}/camera/{virtual_camera_frame}/camera_info",
-                ),
+                (f"{cam_prefix}/left/image", f"{cam_prefix}/camera/frontleft/image"),
+                (f"{cam_prefix}/left/camera_info", f"{cam_prefix}/camera/frontleft/camera_info"),
+                (f"{cam_prefix}/right/image", f"{cam_prefix}/camera/frontright/image"),
+                (f"{cam_prefix}/right/camera_info", f"{cam_prefix}/camera/frontright/camera_info"),
+                (f"{cam_prefix}/virtual_camera/image", f"{cam_prefix}/camera/{virtual_camera_frame}/image"),
+                (f"{cam_prefix}/virtual_camera/camera_info", f"{cam_prefix}/camera/{virtual_camera_frame}/camera_info"),
             ],
             parameters=[config_file, stitcher_params],
             condition=IfCondition(LaunchConfiguration("stitch_front_images")),

--- a/spot_driver/launch/spot_image_publishers.launch.py
+++ b/spot_driver/launch/spot_image_publishers.launch.py
@@ -164,8 +164,9 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     # add the image stitcher node, but only if frontleft and frontright cameras are enabled.
     if "frontleft" in camera_sources and "frontright" in camera_sources:
         stitcher_params = {
-            "body_frame": f"{spot_name}/body" if spot_name else "body",
-            "virtual_camera_frame": f"{spot_name}/virtual_camera" if spot_name else "virtual_camera",
+            "spot_name": spot_name,
+            "body_frame": "body",
+            "virtual_camera_frame": "frontmiddle_virtual",
         }
         stitcher_prefix = f"/{spot_name}" if spot_name else ""
         image_stitcher_node = launch_ros.actions.Node(

--- a/spot_driver/src/image_stitcher/image_stitcher.cpp
+++ b/spot_driver/src/image_stitcher/image_stitcher.cpp
@@ -210,14 +210,14 @@ RclcppCameraHandle::RclcppCameraHandle(const std::shared_ptr<rclcpp::Node>& node
       camera_publisher_{
           image_transport_.advertiseCamera("virtual_camera/image", 1)},  // Remap to actual topic in launch file
       tf_broadcaster_{node} {
-  spot_name_ = node->declare_parameter("spot_name", "");
-  frame_prefix_ = spot_name_.empty() ? "" : spot_name_ + "/";
+  const auto spot_name = node->declare_parameter("spot_name", "");
+  const auto frame_prefix = spot_name.empty() ? "" : spot_name + "/";
   // Name of the frame to relate the virtual camera with respect to
   const auto body_frame_param = node->declare_parameter("body_frame", "body");
-  body_frame_ = frame_prefix_ + body_frame_param;
+  body_frame_ = frame_prefix + body_frame_param;
   // Name of the virtual camera frame to publish
   const auto camera_frame_param = node->declare_parameter("virtual_camera_frame", "virtual_camera");
-  camera_frame_ = frame_prefix_ + camera_frame_param;
+  camera_frame_ = frame_prefix + camera_frame_param;
   // Get the virtual camera intrinsics, which could fail if the wrong number of parameters are specified in the yaml
   try {
     intrinsics_ = toCvMatx33d(

--- a/spot_driver/src/image_stitcher/image_stitcher.cpp
+++ b/spot_driver/src/image_stitcher/image_stitcher.cpp
@@ -210,10 +210,14 @@ RclcppCameraHandle::RclcppCameraHandle(const std::shared_ptr<rclcpp::Node>& node
       camera_publisher_{
           image_transport_.advertiseCamera("virtual_camera/image", 1)},  // Remap to actual topic in launch file
       tf_broadcaster_{node} {
+  spot_name_ = node->declare_parameter("spot_name", "");
+  frame_prefix_ = spot_name_.empty() ? "" : spot_name_ + "/";
   // Name of the frame to relate the virtual camera with respect to
-  body_frame_ = node->declare_parameter("body_frame", "robot/body");
+  const auto body_frame_param = node->declare_parameter("body_frame", "body");
+  body_frame_ = frame_prefix_ + body_frame_param;
   // Name of the virtual camera frame to publish
-  camera_frame_ = node->declare_parameter("virtual_camera_frame", "robot/virtual_camera");
+  const auto camera_frame_param = node->declare_parameter("virtual_camera_frame", "virtual_camera");
+  camera_frame_ = frame_prefix_ + camera_frame_param;
   // Get the virtual camera intrinsics, which could fail if the wrong number of parameters are specified in the yaml
   try {
     intrinsics_ = toCvMatx33d(
@@ -420,12 +424,14 @@ void ImageStitcher::callback(const std::shared_ptr<const Image>& image_left,
     camera_handle_->broadcast(camera_->getTransform(), info_left->header.stamp);
   }
   const auto current_stamp = info_left->header.stamp;
+  const auto camera_frame = camera_handle_->getCameraFrame();
   // The rest of the time we should just be stitching and publishing
   const auto image_stitched = camera_->stitch(image_left, image_right);
   image_stitched->header.stamp = current_stamp;
+  image_stitched->header.frame_id = camera_frame;
   // The only reason we have to remake this every time is to update the time stamp
-  const auto info_stitched = toCameraInfo(current_stamp, camera_handle_->getCameraFrame(), image_stitched->width,
-                                          image_stitched->height, camera_handle_->getIntrinsics());
+  const auto info_stitched = toCameraInfo(current_stamp, camera_frame, image_stitched->width, image_stitched->height,
+                                          camera_handle_->getIntrinsics());
   camera_handle_->publish(*image_stitched, info_stitched);
 }
 

--- a/spot_driver/src/image_stitcher/image_stitcher.cpp
+++ b/spot_driver/src/image_stitcher/image_stitcher.cpp
@@ -419,12 +419,13 @@ void ImageStitcher::callback(const std::shared_ptr<const Image>& image_left,
     // Virtual camera transform only has to be broadcast once since it is static wrt the body
     camera_handle_->broadcast(camera_->getTransform(), info_left->header.stamp);
   }
+  const auto current_stamp = info_left->header.stamp;
   // The rest of the time we should just be stitching and publishing
   const auto image_stitched = camera_->stitch(image_left, image_right);
+  image_stitched->header.stamp = current_stamp;
   // The only reason we have to remake this every time is to update the time stamp
-  const auto info_stitched =
-      toCameraInfo(info_left->header.stamp, camera_handle_->getCameraFrame(), image_stitched->width,
-                   image_stitched->height, camera_handle_->getIntrinsics());
+  const auto info_stitched = toCameraInfo(current_stamp, camera_handle_->getCameraFrame(), image_stitched->width,
+                                          image_stitched->height, camera_handle_->getIntrinsics());
   camera_handle_->publish(*image_stitched, info_stitched);
 }
 

--- a/spot_driver/src/image_stitcher/image_stitcher.cpp
+++ b/spot_driver/src/image_stitcher/image_stitcher.cpp
@@ -423,8 +423,8 @@ void ImageStitcher::callback(const std::shared_ptr<const Image>& image_left,
     // Virtual camera transform only has to be broadcast once since it is static wrt the body
     camera_handle_->broadcast(camera_->getTransform(), info_left->header.stamp);
   }
-  const auto current_stamp = info_left->header.stamp;
-  const auto camera_frame = camera_handle_->getCameraFrame();
+  const auto& current_stamp = info_left->header.stamp;
+  const auto& camera_frame = camera_handle_->getCameraFrame();
   // The rest of the time we should just be stitching and publishing
   const auto image_stitched = camera_->stitch(image_left, image_right);
   image_stitched->header.stamp = current_stamp;


### PR DESCRIPTION
## Change Overview

The stitched image published currently is missing relevant info in its header (time stamp and frame ID). Additionally, the camera info topic for the stitched image was not remapped correctly, so the image and camera info topics had different names. This resolves both of these issues.

## Testing Done

- [x] Image topic on `/<Robot Name>/camera/frontmiddle_virtual/image` now has a header with frame ID `<Robot Name>/frontmiddle_virtual`
- [x] camera info topic for the stitched image is now on `/<Robot Name>/camera/frontmiddle_virtual/camera_info`
- [x] things work as expected with no robot name / namespace