### PR TITLE
[N/A] remove gripperless param from SpotCamWrapper

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -416,7 +416,6 @@ class SpotROS(Node):
                         port=self.port,
                         logger=self.cam_logger,
                         cert_resource_glob=self.certificate,
-                        gripperless=self.gripperless,
                     )
                 except SystemError:
                     self.spot_cam_wrapper = None


### PR DESCRIPTION
## Change Overview

Was causing CI issues on internal repo as it is not a valid input to SpotCamWrapper

## Testing Done

- [x] CI 