### PR TITLE
[N/A] Services correctly created if not gripperless 

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -428,14 +428,9 @@ class SpotROS(Node):
                 self.get_logger().error(error_msg)
                 raise ValueError(error_msg)
 
-        all_cameras = ["frontleft", "frontright", "left", "right", "back"]
         has_arm = self.mock_has_arm
         if self.spot_wrapper is not None:
             has_arm = self.spot_wrapper.has_arm()
-        if has_arm and not self.gripperless:
-            all_cameras.append("hand")
-        self.declare_parameter("cameras_used", all_cameras)
-        self.cameras_used = self.get_parameter("cameras_used")
 
         if self.publish_graph_nav_pose.value:
             # graph nav pose will be published both on a topic
@@ -866,7 +861,7 @@ class SpotROS(Node):
             self.handle_graph_nav_set_localization,
             callback_group=self.group,
         )
-        if has_arm and self.gripperless:
+        if has_arm and not self.gripperless:
             self.create_service(
                 GetGripperCameraParameters,
                 "get_gripper_camera_parameters",


### PR DESCRIPTION
## Change Overview

Get/set gripper camera parameters and override grasp or carry should get created as services if the robot is not gripperless

Also removes the cameras_used param in spot_ros2.py as it isn't used in the Python version of the driver 

## Testing Done

- [x] started the driver on a robot with an arm and a gripper. Verified that these services exist with `ros2 service list`
