### PR TITLE
[N/A] Workaround automatic power off on rollover

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1904,14 +1904,16 @@ class SpotROS(Node):
         # return None to continue processing the command feedback
         return None
 
-    def _process_full_body_command_feedback(self, command: FullBodyCommand, feedback: FullBodyCommandFeedback) -> GoalResponse:
+    def _process_full_body_command_feedback(
+        self, command: FullBodyCommand, feedback: FullBodyCommandFeedback
+    ) -> GoalResponse:
         # NOTE: Spot powers off on roll over to battery change pose. For Spot <=4.0.2 software,
         # this can result in the battery change pose command being overriden before reporting
         # any battery change pose feedback of success. The following clause is a best-effort
         # attempt to deal gracefully with this.
         if command.command.which == command.command.COMMAND_BATTERY_CHANGE_POSE_REQUEST_SET:
             powered_off = self.spot_wrapper and not self.spot_wrapper.check_is_powered_on()
-            command_overriden = (feedback.status.value == RobotCommandFeedbackStatusStatus.STATUS_COMMAND_OVERRIDDEN)
+            command_overriden = feedback.status.value == RobotCommandFeedbackStatusStatus.STATUS_COMMAND_OVERRIDDEN
             if command_overriden and powered_off:
                 return GoalResponse.SUCCESS
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -43,12 +43,14 @@ from bosdyn_msgs.conversions import convert
 from bosdyn_msgs.msg import (
     ArmCommandFeedback,
     Camera,
+    FullBodyCommand,
     FullBodyCommandFeedback,
     GripperCommandFeedback,
     Logpoint,
     ManipulationApiFeedbackResponse,
     MobilityCommandFeedback,
     PtzDescription,
+    RobotCommand,
     RobotCommandFeedback,
     RobotCommandFeedbackStatusStatus,
 )
@@ -1902,7 +1904,17 @@ class SpotROS(Node):
         # return None to continue processing the command feedback
         return None
 
-    def _process_full_body_command_feedback(self, feedback: FullBodyCommandFeedback) -> GoalResponse:
+    def _process_full_body_command_feedback(self, command: FullBodyCommand, feedback: FullBodyCommandFeedback) -> GoalResponse:
+        # NOTE: Spot powers off on roll over to battery change pose. For Spot <=4.0.2 software,
+        # this can result in the battery change pose command being overriden before reporting
+        # any battery change pose feedback of success. The following clause is a best-effort
+        # attempt to deal gracefully with this.
+        if command.command.which == command.command.COMMAND_BATTERY_CHANGE_POSE_REQUEST_SET:
+            powered_off = self.spot_wrapper and not self.spot_wrapper.check_is_powered_on()
+            command_overriden = (feedback.status.value == RobotCommandFeedbackStatusStatus.STATUS_COMMAND_OVERRIDDEN)
+            if command_overriden and powered_off:
+                return GoalResponse.SUCCESS
+
         maybe_goal_response = self._process_feedback_status(feedback.status.value)
         if maybe_goal_response is not None:
             return maybe_goal_response
@@ -2071,15 +2083,16 @@ class SpotROS(Node):
             return GoalResponse.IN_PROGRESS
         return GoalResponse.SUCCESS
 
-    def _robot_command_goal_complete(self, feedback: RobotCommandFeedback) -> GoalResponse:
+    def _robot_command_goal_complete(self, command: RobotCommand, feedback: RobotCommandFeedback) -> GoalResponse:
         if feedback is None:
             # NOTE: it takes an iteration for the feedback to get set.
             return GoalResponse.IN_PROGRESS
 
         choice = feedback.command.command_choice
         if choice == feedback.command.COMMAND_FULL_BODY_FEEDBACK_SET:
+            full_body_command = command.command.full_body_command
             full_body_feedback = feedback.command.full_body_feedback
-            return self._process_full_body_command_feedback(full_body_feedback)
+            return self._process_full_body_command_feedback(full_body_command, full_body_feedback)
 
         elif choice == feedback.command.COMMAND_SYNCHRONIZED_FEEDBACK_SET:
             # The idea here is that a synchronized command can have arm, mobility, and/or gripper
@@ -2190,7 +2203,7 @@ class SpotROS(Node):
             rclpy.ok()
             and goal_handle.is_active
             and not goal_handle.is_cancel_requested
-            and self._robot_command_goal_complete(feedback) == GoalResponse.IN_PROGRESS
+            and self._robot_command_goal_complete(ros_command, feedback) == GoalResponse.IN_PROGRESS
         ):
             # We keep looping and send batches at the expected times until the
             # last batch succeeds. We always send the next batch before the
@@ -2219,7 +2232,7 @@ class SpotROS(Node):
             goal_handle.publish_feedback(feedback_msg)
             result.result = feedback
 
-        result.success = self._robot_command_goal_complete(feedback) == GoalResponse.SUCCESS
+        result.success = self._robot_command_goal_complete(ros_command, feedback) == GoalResponse.SUCCESS
 
         if goal_handle.is_cancel_requested:
             result.success = False

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1912,7 +1912,7 @@ class SpotROS(Node):
         # any battery change pose feedback of success. The following clause is a best-effort
         # attempt to deal gracefully with this.
         if command.command.which == command.command.COMMAND_BATTERY_CHANGE_POSE_REQUEST_SET:
-            powered_off = self.spot_wrapper and not self.spot_wrapper.check_is_powered_on()
+            powered_off = not self.spot_wrapper or not self.spot_wrapper.check_is_powered_on()
             command_overriden = feedback.status.value == RobotCommandFeedbackStatusStatus.STATUS_COMMAND_OVERRIDDEN
             if command_overriden and powered_off:
                 return GoalResponse.SUCCESS

--- a/spot_driver/test/pytests/test_ros_interfaces.py
+++ b/spot_driver/test/pytests/test_ros_interfaces.py
@@ -81,7 +81,9 @@ class SpotDriverTest(unittest.TestCase):
         FEEDBACK_INVALID = -128
 
         dummy_command = RobotCommand()
-        self.assertEqual(self.spot_ros2._robot_command_goal_complete(dummy_command, None), GoalResponse.IN_PROGRESS, "Empty Command")
+        self.assertEqual(
+            self.spot_ros2._robot_command_goal_complete(dummy_command, None), GoalResponse.IN_PROGRESS, "Empty Command"
+        )
 
         feedback = RobotCommandFeedback()
 
@@ -103,7 +105,9 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.FEEDBACK_STOP_FEEDBACK_SET
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback), GoalResponse.SUCCESS, "FEEDBACK_STOP_FEEDBACK_SET"
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
+            GoalResponse.SUCCESS,
+            "FEEDBACK_STOP_FEEDBACK_SET",
         )
 
         """ Testing FREEZE_FEEDBACK_SET """
@@ -111,7 +115,9 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.FEEDBACK_FREEZE_FEEDBACK_SET
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback), GoalResponse.SUCCESS, "FEEDBACK_FREEZE_FEEDBACK_SET"
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
+            GoalResponse.SUCCESS,
+            "FEEDBACK_FREEZE_FEEDBACK_SET",
         )
 
         """ Testing SELFRIGHT_FEEDBACK_SET """
@@ -389,7 +395,7 @@ class SpotDriverTest(unittest.TestCase):
         feedback.command.synchronized_feedback.arm_command_feedback.feedback.arm_cartesian_feedback.status.value = (
             arm_command_feedback.feedback.arm_cartesian_feedback.status.STATUS_TRAJECTORY_CANCELLED
         )
-        
+
         self.assertEqual(
             self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
@@ -858,7 +864,9 @@ class SpotDriverTest(unittest.TestCase):
         )
         # Stop commands provide no feedback, therefore expect SUCCESS
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback), GoalResponse.SUCCESS, "FEEDBACK_STOP_FEEDBACK_SET"
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
+            GoalResponse.SUCCESS,
+            "FEEDBACK_STOP_FEEDBACK_SET",
         )
 
         """ Testing stop feedback """
@@ -879,7 +887,9 @@ class SpotDriverTest(unittest.TestCase):
         # mobility command feedback is not set, this could be caused by a command that finishes and resets the feedback status.
         # because of this case, it will return success as long as no other synchronous commands are run afterwards.
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback), GoalResponse.SUCCESS, "MOBILITY | FEEDBACK_NOT_SET"
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
+            GoalResponse.SUCCESS,
+            "MOBILITY | FEEDBACK_NOT_SET",
         )
 
         """ Testing unknown command """

--- a/spot_driver/test/pytests/test_ros_interfaces.py
+++ b/spot_driver/test/pytests/test_ros_interfaces.py
@@ -5,7 +5,7 @@ import unittest
 
 import bdai_ros2_wrappers.scope as ros_scope
 import rclpy
-from bosdyn_msgs.msg import RobotCommandFeedback
+from bosdyn_msgs.msg import RobotCommand, RobotCommandFeedback
 from std_srvs.srv import Trigger
 
 import spot_driver.spot_ros2
@@ -80,18 +80,18 @@ class SpotDriverTest(unittest.TestCase):
     def test_robot_command_goal_complete(self) -> None:
         FEEDBACK_INVALID = -128
 
-        self.assertEqual(self.spot_ros2._robot_command_goal_complete(None), GoalResponse.IN_PROGRESS, "Empty Command")
+        dummy_command = RobotCommand()
+        self.assertEqual(self.spot_ros2._robot_command_goal_complete(dummy_command, None), GoalResponse.IN_PROGRESS, "Empty Command")
 
         feedback = RobotCommandFeedback()
 
         """ Testing FullBodyFeedback """
-
         fullbody_feedback = feedback.command.full_body_feedback
         feedback.command.command_choice = feedback.command.COMMAND_FULL_BODY_FEEDBACK_SET
 
         feedback.command.full_body_feedback.status.value = fullbody_feedback.status.STATUS_UNKNOWN
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "COMMAND_FULL_BODY_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -103,7 +103,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.FEEDBACK_STOP_FEEDBACK_SET
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback), GoalResponse.SUCCESS, "FEEDBACK_STOP_FEEDBACK_SET"
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback), GoalResponse.SUCCESS, "FEEDBACK_STOP_FEEDBACK_SET"
         )
 
         """ Testing FREEZE_FEEDBACK_SET """
@@ -111,7 +111,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.FEEDBACK_FREEZE_FEEDBACK_SET
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback), GoalResponse.SUCCESS, "FEEDBACK_FREEZE_FEEDBACK_SET"
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback), GoalResponse.SUCCESS, "FEEDBACK_FREEZE_FEEDBACK_SET"
         )
 
         """ Testing SELFRIGHT_FEEDBACK_SET """
@@ -122,7 +122,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.selfright_feedback.status.STATUS_COMPLETED
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_SELFRIGHT_FEEDBACK_SET | STATUS_COMPLETED",
         )
@@ -131,7 +131,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.selfright_feedback.status.STATUS_UNKNOWN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_SELFRIGHT_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -140,7 +140,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.selfright_feedback.status.STATUS_IN_PROGRESS
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_SELFRIGHT_FEEDBACK_SET | STATUS_IN_PROGRESS",
         )
@@ -153,7 +153,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.safe_power_off_feedback.status.STATUS_POWERED_OFF
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_SAFE_POWER_OFF_FEEDBACK_SET | STATUS_POWERED_OFF",
         )
@@ -162,7 +162,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.safe_power_off_feedback.status.STATUS_UNKNOWN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_SAFE_POWER_OFF_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -171,7 +171,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.safe_power_off_feedback.status.STATUS_IN_PROGRESS
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_SAFE_POWER_OFF_FEEDBACK_SET | STATUS_IN_PROGRESS",
         )
@@ -184,7 +184,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.battery_change_pose_feedback.status.STATUS_COMPLETED
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_BATTERY_CHANGE_POSE_FEEDBACK_SET | STATUS_COMPLETED",
         )
@@ -193,7 +193,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.battery_change_pose_feedback.status.STATUS_UNKNOWN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_BATTERY_CHANGE_POSE_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -202,7 +202,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.battery_change_pose_feedback.status.STATUS_IN_PROGRESS
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_BATTERY_CHANGE_POSE_FEEDBACK_SET | STATUS_IN_PROGRESS",
         )
@@ -211,7 +211,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.battery_change_pose_feedback.status.STATUS_FAILED
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_BATTERY_CHANGE_POSE_FEEDBACK_SET | STATUS_FAILED",
         )
@@ -224,7 +224,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.payload_estimation_feedback.status.STATUS_COMPLETED
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_PAYLOAD_ESTIMATION_FEEDBACK_SET | STATUS_COMPLETED",
         )
@@ -233,7 +233,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.payload_estimation_feedback.status.STATUS_SMALL_MASS
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_PAYLOAD_ESTIMATION_FEEDBACK_SET | STATUS_SMALL_MASS",
         )
@@ -242,7 +242,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.payload_estimation_feedback.status.STATUS_ERROR
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_PAYLOAD_ESTIMATION_FEEDBACK_SET | STATUS_ERROR",
         )
@@ -251,7 +251,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.payload_estimation_feedback.status.STATUS_UNKNOWN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_PAYLOAD_ESTIMATION_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -260,7 +260,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.payload_estimation_feedback.status.STATUS_IN_PROGRESS
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_PAYLOAD_ESTIMATION_FEEDBACK_SET | STATUS_IN_PROGRESS",
         )
@@ -273,7 +273,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.constrained_manipulation_feedback.status.STATUS_RUNNING
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_CONSTRAINED_MANIPULATION_FEEDBACK_SET | STATUS_RUNNING",
         )
@@ -282,7 +282,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.constrained_manipulation_feedback.status.STATUS_GRASP_IS_LOST
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_CONSTRAINED_MANIPULATION_FEEDBACK_SET | STATUS_GRASP_IS_LOST",
         )
@@ -291,7 +291,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.constrained_manipulation_feedback.status.STATUS_ARM_IS_STUCK
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_CONSTRAINED_MANIPULATION_FEEDBACK_SET | STATUS_ARM_IS_STUCK",
         )
@@ -300,7 +300,7 @@ class SpotDriverTest(unittest.TestCase):
             fullbody_feedback.feedback.constrained_manipulation_feedback.status.STATUS_UNKNOWN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_CONSTRAINED_MANIPULATION_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -318,7 +318,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.status.STATUS_COMMAND_OVERRIDDEN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "Arm_command | COMMAND_SYNCHRONIZED_FEEDBACK_SET | STATUS_COMMAND_OVERRIDDEN",
         )
@@ -327,7 +327,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.status.STATUS_COMMAND_TIMED_OUT
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "Arm_command | COMMAND_SYNCHRONIZED_FEEDBACK_SET | STATUS_COMMAND_TIMED_OUT",
         )
@@ -336,7 +336,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.status.STATUS_ROBOT_FROZEN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "Arm_command | COMMAND_SYNCHRONIZED_FEEDBACK_SET | STATUS_ROBOT_FROZEN",
         )
@@ -345,7 +345,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.status.STATUS_INCOMPATIBLE_HARDWARE
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "Arm_command | COMMAND_SYNCHRONIZED_FEEDBACK_SET | STATUS_INCOMPATIBLE_HARDWARE",
         )
@@ -363,7 +363,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_cartesian_feedback.status.STATUS_TRAJECTORY_COMPLETE
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_ARM_CARTESIAN_FEEDBACK_SET | STATUS_TRAJECTORY_COMPLETE",
         )
@@ -372,7 +372,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_cartesian_feedback.status.STATUS_UNKNOWN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_ARM_CARTESIAN_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -381,7 +381,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_cartesian_feedback.status.STATUS_IN_PROGRESS
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_ARM_CARTESIAN_FEEDBACK_SET | STATUS_IN_PROGRESS",
         )
@@ -389,8 +389,9 @@ class SpotDriverTest(unittest.TestCase):
         feedback.command.synchronized_feedback.arm_command_feedback.feedback.arm_cartesian_feedback.status.value = (
             arm_command_feedback.feedback.arm_cartesian_feedback.status.STATUS_TRAJECTORY_CANCELLED
         )
+        
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_ARM_CARTESIAN_FEEDBACK_SET | STATUS_TRAJECTORY_CANCELLED",
         )
@@ -399,7 +400,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_cartesian_feedback.status.STATUS_TRAJECTORY_STALLED
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_ARM_CARTESIAN_FEEDBACK_SET | STATUS_TRAJECTORY_STALLED",
         )
@@ -413,7 +414,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_joint_move_feedback.status.STATUS_COMPLETE
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_ARM_JOINT_MOVE_FEEDBACK_SET | STATUS_COMPLETE",
         )
@@ -422,7 +423,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_joint_move_feedback.status.STATUS_UNKNOWN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_ARM_JOINT_MOVE_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -431,7 +432,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_joint_move_feedback.status.STATUS_IN_PROGRESS
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_ARM_JOINT_MOVE_FEEDBACK_SET | STATUS_IN_PROGRESS",
         )
@@ -440,7 +441,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_joint_move_feedback.status.STATUS_STALLED
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_ARM_JOINT_MOVE_FEEDBACK_SET | STATUS_STALLED",
         )
@@ -454,7 +455,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.named_arm_position_feedback.status.STATUS_COMPLETE
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_NAMED_ARM_POSITION_FEEDBACK_SET | STATUS_COMPLETE",
         )
@@ -463,7 +464,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.named_arm_position_feedback.status.STATUS_UNKNOWN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_NAMED_ARM_POSITION_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -472,7 +473,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.named_arm_position_feedback.status.STATUS_IN_PROGRESS
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_NAMED_ARM_POSITION_FEEDBACK_SET | STATUS_IN_PROGRESS",
         )
@@ -481,7 +482,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.named_arm_position_feedback.status.STATUS_STALLED_HOLDING_ITEM
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_NAMED_ARM_POSITION_FEEDBACK_SET | STATUS_STALLED_HOLDING_ITEM",
         )
@@ -492,7 +493,7 @@ class SpotDriverTest(unittest.TestCase):
         )
         # Arm velocity commands do not provide feedback therefore we should get a success
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_ARM_VELOCITY_FEEDBACK_SET",
         )
@@ -506,7 +507,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_gaze_feedback.status.STATUS_TRAJECTORY_COMPLETE
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_ARM_GAZE_FEEDBACK_SET | STATUS_TRAJECTORY_COMPLETE",
         )
@@ -515,7 +516,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_gaze_feedback.status.STATUS_UNKNOWN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_ARM_GAZE_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -524,7 +525,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_gaze_feedback.status.STATUS_IN_PROGRESS
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_ARM_GAZE_FEEDBACK_SET | STATUS_IN_PROGRESS",
         )
@@ -533,7 +534,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_gaze_feedback.status.STATUS_TOOL_TRAJECTORY_STALLED
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_ARM_GAZE_FEEDBACK_SET | STATUS_TOOL_TRAJECTORY_STALLED",
         )
@@ -544,7 +545,7 @@ class SpotDriverTest(unittest.TestCase):
         )
         # Arm stop commands do not provide feedback therefore we should get a success
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_ARM_STOP_FEEDBACK_SET",
         )
@@ -558,7 +559,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_drag_feedback.status.STATUS_DRAGGING
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_ARM_DRAG_FEEDBACK_SET | STATUS_DRAGGING",
         )
@@ -567,7 +568,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_drag_feedback.status.STATUS_UNKNOWN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_ARM_DRAG_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -576,7 +577,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_drag_feedback.status.STATUS_GRASP_FAILED
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_ARM_DRAG_FEEDBACK_SET | STATUS_GRASP_FAILED",
         )
@@ -585,7 +586,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_drag_feedback.status.STATUS_OTHER_FAILURE
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_ARM_DRAG_FEEDBACK_SET | STATUS_OTHER_FAILURE",
         )
@@ -598,7 +599,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_impedance_feedback.status.STATUS_UNKNOWN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_ARM_IMPEDANCE_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -607,7 +608,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_impedance_feedback.status.STATUS_TRAJECTORY_COMPLETE
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_ARM_IMPEDANCE_FEEDBACK_SET | STATUS_TRAJECTORY_COMPLETE",
         )
@@ -616,7 +617,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_impedance_feedback.status.STATUS_IN_PROGRESS
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_ARM_IMPEDANCE_FEEDBACK_SET | STATUS_IN_PROGRESS",
         )
@@ -625,7 +626,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_impedance_feedback.status.STATUS_TRAJECTORY_CANCELLED
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_ARM_IMPEDANCE_FEEDBACK_SET | STATUS_TRAJECTORY_CANCELLED",
         )
@@ -634,7 +635,7 @@ class SpotDriverTest(unittest.TestCase):
             arm_command_feedback.feedback.arm_impedance_feedback.status.STATUS_TRAJECTORY_STALLED
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_ARM_IMPEDANCE_FEEDBACK_SET | STATUS_TRAJECTORY_STALLED",
         )
@@ -642,7 +643,7 @@ class SpotDriverTest(unittest.TestCase):
         """ Testing unknown arm command """
         feedback.command.synchronized_feedback.arm_command_feedback.feedback.feedback_choice = FEEDBACK_INVALID
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "Arm Command: FEEDBACK_INVALID",
         )
@@ -658,7 +659,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.status.STATUS_COMMAND_OVERRIDDEN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "MOBILITY | COMMAND_SYNCHRONIZED_FEEDBACK | STATUS_COMMAND_OVERRIDDEN",
         )
@@ -667,7 +668,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.status.STATUS_COMMAND_TIMED_OUT
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "MOBILITY | COMMAND_SYNCHRONIZED_FEEDBACK | | STATUS_COMMAND_TIMED_OUT",
         )
@@ -676,7 +677,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.status.STATUS_ROBOT_FROZEN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "MOBILITY | COMMAND_SYNCHRONIZED_FEEDBACK | | STATUS_ROBOT_FROZEN",
         )
@@ -685,7 +686,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.status.STATUS_INCOMPATIBLE_HARDWARE
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "MOBILITY | COMMAND_SYNCHRONIZED_FEEDBACK | | STATUS_INCOMPATIBLE_HARDWARE",
         )
@@ -703,7 +704,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.feedback.se2_trajectory_feedback.status.STATUS_AT_GOAL
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_SE2_TRAJECTORY_FEEDBACK_SET | STATUS_AT_GOAL",
         )
@@ -712,7 +713,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.feedback.se2_trajectory_feedback.status.STATUS_UNKNOWN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_SE2_TRAJECTORY_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -721,7 +722,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.feedback.se2_trajectory_feedback.status.STATUS_NEAR_GOAL
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_SE2_TRAJECTORY_FEEDBACK_SET | STATUS_NEAR_GOAL",
         )
@@ -730,7 +731,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.feedback.se2_trajectory_feedback.status.STATUS_GOING_TO_GOAL
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_SE2_TRAJECTORY_FEEDBACK_SET | STATUS_GOING_TO_GOAL",
         )
@@ -741,7 +742,7 @@ class SpotDriverTest(unittest.TestCase):
         )
         # Planar velocity commands provide no feedback, therefore expect SUCCESS
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_SE2_VELOCITY_FEEDBACK_SET",
         )
@@ -755,7 +756,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.feedback.sit_feedback.status.STATUS_IS_SITTING
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_SIT_FEEDBACK_SET | STATUS_IS_SITTING",
         )
@@ -764,7 +765,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.feedback.sit_feedback.status.STATUS_UNKNOWN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_SIT_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -773,7 +774,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.feedback.sit_feedback.status.STATUS_IN_PROGRESS
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_SIT_FEEDBACK_SET | STATUS_IN_PROGRESS",
         )
@@ -787,7 +788,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.feedback.stand_feedback.status.STATUS_IS_STANDING
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_STAND_FEEDBACK_SET | STATUS_IS_STANDING",
         )
@@ -796,7 +797,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.feedback.stand_feedback.status.STATUS_UNKNOWN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_STAND_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -805,7 +806,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.feedback.stand_feedback.status.STATUS_IN_PROGRESS
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_STAND_FEEDBACK_SET | STATUS_IN_PROGRESS",
         )
@@ -819,7 +820,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.feedback.stance_feedback.status.STATUS_TOO_FAR_AWAY
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "FEEDBACK_STANCE_FEEDBACK_SET | STATUS_TOO_FAR_AWAY",
         )
@@ -828,7 +829,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.feedback.stance_feedback.status.STATUS_STANCED
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_STANCE_FEEDBACK_SET | STATUS_STANCED",
         )
@@ -837,7 +838,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.feedback.stance_feedback.status.STATUS_GOING_TO_STANCE
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_STANCE_FEEDBACK_SET | STATUS_GOING_TO_STANCE",
         )
@@ -846,7 +847,7 @@ class SpotDriverTest(unittest.TestCase):
             mobility_feedback.feedback.stance_feedback.status.STATUS_UNKNOWN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "FEEDBACK_STANCE_FEEDBACK_SET | STATUS_UNKNOWN",
         )
@@ -857,7 +858,7 @@ class SpotDriverTest(unittest.TestCase):
         )
         # Stop commands provide no feedback, therefore expect SUCCESS
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback), GoalResponse.SUCCESS, "FEEDBACK_STOP_FEEDBACK_SET"
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback), GoalResponse.SUCCESS, "FEEDBACK_STOP_FEEDBACK_SET"
         )
 
         """ Testing stop feedback """
@@ -866,7 +867,7 @@ class SpotDriverTest(unittest.TestCase):
         )
         # follow arm commands provide no feedback, therefore expect SUCCESS
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "FEEDBACK_FOLLOW_ARM_FEEDBACK_SET",
         )
@@ -878,13 +879,13 @@ class SpotDriverTest(unittest.TestCase):
         # mobility command feedback is not set, this could be caused by a command that finishes and resets the feedback status.
         # because of this case, it will return success as long as no other synchronous commands are run afterwards.
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback), GoalResponse.SUCCESS, "MOBILITY | FEEDBACK_NOT_SET"
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback), GoalResponse.SUCCESS, "MOBILITY | FEEDBACK_NOT_SET"
         )
 
         """ Testing unknown command """
         feedback.command.synchronized_feedback.mobility_command_feedback.feedback.feedback_choice = FEEDBACK_INVALID
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "MOBILITY| FEEDBACK_INVALID",
         )
@@ -900,7 +901,7 @@ class SpotDriverTest(unittest.TestCase):
             gripper_feedback.status.STATUS_COMMAND_OVERRIDDEN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "GRIPPER | COMMAND_SYNCHRONIZED_FEEDBACK | STATUS_COMMAND_OVERRIDDEN",
         )
@@ -909,7 +910,7 @@ class SpotDriverTest(unittest.TestCase):
             gripper_feedback.status.STATUS_COMMAND_TIMED_OUT
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "GRIPPER | COMMAND_SYNCHRONIZED_FEEDBACK | STATUS_COMMAND_TIMED_OUT",
         )
@@ -918,7 +919,7 @@ class SpotDriverTest(unittest.TestCase):
             gripper_feedback.status.STATUS_ROBOT_FROZEN
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "GRIPPER | COMMAND_SYNCHRONIZED_FEEDBACK | STATUS_ROBOT_FROZEN",
         )
@@ -927,7 +928,7 @@ class SpotDriverTest(unittest.TestCase):
             gripper_feedback.status.STATUS_INCOMPATIBLE_HARDWARE
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.FAILED,
             "GRIPPER | COMMAND_SYNCHRONIZED_FEEDBACK | STATUS_INCOMPATIBLE_HARDWARE",
         )
@@ -944,7 +945,7 @@ class SpotDriverTest(unittest.TestCase):
             gripper_feedback.command.claw_gripper_feedback.status.STATUS_IN_PROGRESS
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "COMMAND_CLAW_GRIPPER_FEEDBACK_SET | STATUS_IN_PROGRESS",
         )
@@ -953,7 +954,7 @@ class SpotDriverTest(unittest.TestCase):
             gripper_feedback.command.claw_gripper_feedback.status.STATUS_IN_PROGRESS
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "COMMAND_CLAW_GRIPPER_FEEDBACK_SET | STATUS_IN_PROGRESS",
         )
@@ -962,7 +963,7 @@ class SpotDriverTest(unittest.TestCase):
             gripper_feedback.command.claw_gripper_feedback.status.STATUS_AT_GOAL
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "COMMAND_CLAW_GRIPPER_FEEDBACK_SET | STATUS_AT_GOAL",
         )
@@ -971,7 +972,7 @@ class SpotDriverTest(unittest.TestCase):
             gripper_feedback.command.claw_gripper_feedback.status.STATUS_APPLYING_FORCE
         )
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.SUCCESS,
             "COMMAND_CLAW_GRIPPER_FEEDBACK_SET | STATUS_APPLYING_FORCE",
         )
@@ -979,7 +980,7 @@ class SpotDriverTest(unittest.TestCase):
         """ Testing unknown gripper command """
         feedback.command.synchronized_feedback.gripper_command_feedback.command.command_choice = FEEDBACK_INVALID
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "COMMAND_CLAW_GRIPPER_FEEDBACK_SET | FEEDBACK_INVALID",
         )
@@ -987,9 +988,25 @@ class SpotDriverTest(unittest.TestCase):
         """ Testing unknown robot command type """
         feedback.command.command_choice = FEEDBACK_INVALID
         self.assertEqual(
-            self.spot_ros2._robot_command_goal_complete(feedback),
+            self.spot_ros2._robot_command_goal_complete(dummy_command, feedback),
             GoalResponse.IN_PROGRESS,
             "COMMAND_CLAW_GRIPPER_FEEDBACK_SET | FEEDBACK_INVALID",
+        )
+
+        """ Testing battery change pose corner case """
+        feedback.command.command_choice = feedback.command.COMMAND_FULL_BODY_FEEDBACK_SET
+        feedback.command.full_body_feedback.status.value = (
+            feedback.command.full_body_feedback.status.STATUS_COMMAND_OVERRIDDEN
+        )
+
+        overriden_command = RobotCommand()
+        overriden_command.command.full_body_command.command.which = (
+            overriden_command.command.full_body_command.command.COMMAND_BATTERY_CHANGE_POSE_REQUEST_SET
+        )
+        self.assertEqual(
+            self.spot_ros2._robot_command_goal_complete(overriden_command, feedback),
+            GoalResponse.SUCCESS,
+            "NO FEEDBACK_BATTERY_CHANGE_POSE_FEEDBACK_SET | STATUS_COMMAND_OVERRIDDEN",
         )
 
 


### PR DESCRIPTION
## Change Overview

When the robot rolls over to battery change pose, it powers off automatically. That can result in the otherwise successful battery change pose command to be overridden. This patch is a best-effort approach to try and cope with this. It is a workaround, as there is currently no way to unequivocally differentiate a true override from an incidental one.

## Testing Done

On real hardware, downstream.