### PR TITLE
[SW-1316] ros2 control: auto determine if robot has an arm in launchfile

### DIFF
--- a/spot_ros2_control/README.md
+++ b/spot_ros2_control/README.md
@@ -1,28 +1,52 @@
 # spot_ros2_control
 
-This is a ROS 2 package designed to communicate with Spot's low level API through ROS 2 control. It sets up a hardware interface that can be either `mock` or connected to the robot via the `spot-cpp-sdk` (currently in progress). It also uses a standard joint state broadcaster and forward position controller provided from `ros2_control`.
+This is a ROS 2 package designed to communicate with Spot's low level API through ROS 2 control. It sets up a hardware interface that can be either `mock` or connected to the robot using Spot's C++ SDK (currently in progress). By default, it loads a standard joint state broadcaster and forward position controller provided from `ros2_control`.
 
 ## On-robot
 
-Currently, the parameters for authenticating with your robot must be set in the environment variables `BOSDYN_CLIENT_USERNAME`, `BOSDYN_CLIENT_PASSWORD`, and `SPOT_IP`.
+If your parameters for authenticating with your robot are set in the environment variables `BOSDYN_CLIENT_USERNAME`, `BOSDYN_CLIENT_PASSWORD`, and `SPOT_IP`, run:
 
-For a robot without an arm, run: `ros2 launch spot_ros2_control spot_ros2_control.launch.py hardware_interface:=spot-sdk`
+```bash
+ros2 launch spot_ros2_control spot_ros2_control.launch.py hardware_interface:=robot
+```
 
-For a robot with an arm, run: `ros2 launch spot_ros2_control spot_ros2_control.launch.py has_arm:=true controllers_config:=spot_controllers_with_arm.yaml hardware_interface:=spot-sdk`
+Login information can also be set in a configuration file, the same as in the `spot_driver` launchfile. For example, if you have a config file `spot_ros.yaml` containing the following information:
+```
+/**:
+  ros__parameters:
+    username: "username"
+    password: "password"
+    hostname: "00.00.00.00"
+```
+You can then run the launchfile with the following command:
+
+```bash
+ros2 launch spot_ros2_control spot_ros2_control.launch.py hardware_interface:=robot config_file:=path/to/spot_ros.yaml
+```
 
 This hardware interface currently does not accept commands but will stream the joint angles of the robot using the low level API at ~333 Hz. 
 
-
 ## Mock
 
-To use a mock hardware interface, run the main `spot_ros2_control.launch.py` launchfile with the launch argument `hardware_interface:=mock`.
+To use a mock hardware interface, run:
+
+```bash
+ros2 launch spot_ros2_control spot_ros2_control.launch.py hardware_interface:=mock
+```
 
 ## Examples
 
 Examples are provided to replicate [these joint control examples](https://github.com/boston-dynamics/spot-cpp-sdk/tree/master/cpp/examples/joint_control) from Boston Dynamics. They are currently only supported in `mock` mode, but are designed to show how you can send commands to the robot using the built in forward position controller.
 
 Run the following commands to test these examples:
+```bash
+ros2 launch spot_ros2_control noarm_squat.launch.py
+```
+```bash
+ros2 launch spot_ros2_control wiggle_arm.launch.py
+```
 
-`ros2 launch spot_ros2_control noarm_squat.launch.py`
-
-`ros2 launch spot_ros2_control wiggle_arm.launch.py`
+## Additional Arguments
+* `controllers_config`: If this argument is unset, a general purpose controller configuration will be loaded containing a forward position controller and a joint state publisher, that is filled appropriately based on whether or not the robot used (mock or real) has an arm. If you wish to load a different controller, this can be set here.
+* `robot_controller`: This is the name of the robot controller that will be started when the launchfile is called. The default is the simple forward position controller. The name must match a controller in the `controllers_config` file.
+* `launch_rviz`: If you do not want rviz to be launched, add the argument `launch_rviz:=False`.

--- a/spot_ros2_control/README.md
+++ b/spot_ros2_control/README.md
@@ -1,6 +1,6 @@
 # spot_ros2_control
 
-This is a ROS 2 package designed to communicate with Spot's low level API through ROS 2 control. It sets up a hardware interface that can be either `mock` or connected to the robot using Spot's C++ SDK (currently in progress). By default, it loads a standard joint state broadcaster and forward position controller provided from `ros2_control`.
+This is a ROS 2 package designed to communicate with Spot's low level API through ROS 2 control. It sets up a hardware interface that can be either `mock` or connected to the robot using the [Spot C++ SDK](https://github.com/boston-dynamics/spot-cpp-sdk) (currently in progress). By default, it loads a standard joint state broadcaster and forward position controller provided from `ros2_control`.
 
 ## On-robot
 
@@ -33,6 +33,8 @@ To use a mock hardware interface, run:
 ```bash
 ros2 launch spot_ros2_control spot_ros2_control.launch.py hardware_interface:=mock
 ```
+
+By default, this will load a robot with no arm. If you want your mock robot to have an arm, add the launch argument `mock_has_arm:=True`. 
 
 ## Examples
 

--- a/spot_ros2_control/launch/noarm_squat.launch.py
+++ b/spot_ros2_control/launch/noarm_squat.launch.py
@@ -20,8 +20,7 @@ def generate_launch_description():
                     ]
                 ),
                 launch_arguments={
-                    "has_arm": "false",
-                    "controllers_config": "spot_controllers_without_arm.yaml",
+                    "mock_has_arm": "false",
                     "robot_controller": "forward_position_controller",
                     "hardware_interface": "mock",
                 }.items(),

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -24,7 +24,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     if hardware_interface == "robot":
         config_file = LaunchConfiguration("config_file").perform(context)
         has_arm = spot_has_arm(config_file_path=config_file, spot_name="")
-        username, password, hostname, _, _ = get_login_parameters(config_file)
+        username, password, hostname = get_login_parameters(config_file)[:3]
         login_params = f" hostname:={hostname} username:={username} password:={password}"
     else:
         has_arm = mock_has_arm

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -21,14 +21,14 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     mock_has_arm: bool = IfCondition(LaunchConfiguration("mock_has_arm")).evaluate(context)
 
     # If connected to a physical robot, query if it has an arm. Otherwise, use the value in mock_has_arm.
-    login_params = ""
     if hardware_interface == "robot":
         config_file = LaunchConfiguration("config_file").perform(context)
-        has_arm = spot_has_arm(config_file_path=config_file, spot_name="Test")
+        has_arm = spot_has_arm(config_file_path=config_file, spot_name="")
         username, password, hostname, _, _ = get_login_parameters(config_file)
         login_params = f" hostname:={hostname} username:={username} password:={password}"
     else:
         has_arm = mock_has_arm
+        login_params = ""
 
     # Generate the robot description based off if the robot has an arm.
     robot_urdf = Command(

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -22,7 +22,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
 
     # If connected to a physical robot, query if it has an arm. Otherwise, use the value in mock_has_arm.
     login_info_string = ""
-    if hardware_interface == "spot-sdk":
+    if hardware_interface == "robot":
         config_file = LaunchConfiguration("config_file").perform(context)
         has_arm = spot_has_arm(config_file_path=config_file, spot_name="Test")
         username, password, hostname, _, _ = get_login_parameters(config_file)
@@ -113,7 +113,7 @@ def generate_launch_description():
                 "hardware_interface",
                 default_value="mock",
                 # Must match the xacro file options for which plugin to load
-                choices=["mock", "spot-sdk"],
+                choices=["mock", "robot"],
                 description="Hardware interface to load.",
             ),
             DeclareLaunchArgument(

--- a/spot_ros2_control/launch/wiggle_arm.launch.py
+++ b/spot_ros2_control/launch/wiggle_arm.launch.py
@@ -20,8 +20,7 @@ def generate_launch_description():
                     ]
                 ),
                 launch_arguments={
-                    "has_arm": "true",
-                    "controllers_config": "spot_controllers_with_arm.yaml",
+                    "mock_has_arm": "true",
                     "robot_controller": "forward_position_controller",
                     "hardware_interface": "mock",
                 }.items(),

--- a/spot_ros2_control/package.xml
+++ b/spot_ros2_control/package.xml
@@ -13,6 +13,7 @@
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>spot_description</depend>
+  <depend>spot_driver</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/spot_ros2_control/xacro/spot.ros2_control.xacro
+++ b/spot_ros2_control/xacro/spot.ros2_control.xacro
@@ -11,7 +11,7 @@
                 <param name="mock_sensor_commands">false</param>
                 <param name="state_following_offset">0.0</param>
             </xacro:if>
-            <xacro:if value="${interface_type == 'spot-sdk'}">
+            <xacro:if value="${interface_type == 'robot'}">
                 <plugin>spot_ros2_control/SpotHardware</plugin>
                 <!-- eventually it would be ideal to be able to optionally load these from yaml as well (with
                 xacro.load_yaml) as we support putting the login info into a config file in the spot driver.-->

--- a/spot_ros2_control/xacro/spot.ros2_control.xacro
+++ b/spot_ros2_control/xacro/spot.ros2_control.xacro
@@ -13,8 +13,6 @@
             </xacro:if>
             <xacro:if value="${interface_type == 'robot'}">
                 <plugin>spot_ros2_control/SpotHardware</plugin>
-                <!-- eventually it would be ideal to be able to optionally load these from yaml as well (with
-                xacro.load_yaml) as we support putting the login info into a config file in the spot driver.-->
                 <param name="hostname">$(optenv SPOT_IP ${hostname})</param>
                 <param name="username">$(optenv BOSDYN_CLIENT_USERNAME ${username})</param>
                 <param name="password">$(optenv BOSDYN_CLIENT_PASSWORD ${password})</param>


### PR DESCRIPTION
## Change Overview

* when connected to a robot, the launchfile will auto determine if the robot has an arm and use that to generate the URDF that gets used by the hardware interface (same as in `spot_driver`)
    * default controller config file that gets loaded is also now auto determined from if the robot has an arm. 
    * This required some reworking of the core launchfile to use an opaque function to add this extra logic
* Allows users to specify login info for the robot in a configuration yaml file, same as spot driver.
* Introduces a dependency on `spot_driver` so that the launchfile can use this code in `spot_driver.launch.spot_launch_helpers`. This could be reworked in the future if we decide we don't want these packages so coupled.
* minor changes to launch arguments to make the user interface simpler and more flexible, and updates readme

## Testing Done

- [x] tested on robot with arm
- [x] tested on robot without arm
- [x] tested examples in mock mode with and without mock'ed arm

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
