### PR TITLE
[SW-1245] : Custom Gripper Calibration Result Republisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ python3 spot_wrapper/spot_wrapper/calibrate_spot_hand_camera_cli.py --ip <IP> -u
 Then, you can run a publisher to transform the depth image into the rgb images frame with the same image
 dimensions, so that finding the 3D location of a feature found in rgb can be as easy as passing
 the image feature pixel coordinates to the registered depth image, and extracting the 3D location.
-
+For all possible command line arguments, run ```ros2 run spot_driver calibated_reregistered_hand_camera_depth_publisher.py -h```
 ```
-ros2 run spot_ros2 calibrated_reregistered_hand_camera_depth_publisher.py --tag=default --calibration_path <SAVED_CAL> --robot_name <ROBOT_NAMESPACE> --topic_name /depth_registered/hand_custom_cal/image
+ros2 run spot_driver calibrated_reregistered_hand_camera_depth_publisher.py --tag=default --calibration_path <SAVED_CAL> --robot_name <ROBOT_NAMESPACE> --topic_name /depth_registered/hand_custom_cal/image
 ```
 
 You can treat the reregistered topic, (in the above example, ```<ROBOT_NAME>/depth_registered/hand_custom_cal/image```)

--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ If your image publishing rate is very slow, you can try
 > export=FASTRTPS_DEFAULT_PROFILES_FILE=<path_to_file>/custom_dds_profile.xml
 > ```
 
+## Optional Automatic Hand Stereo Camera Calibration Routine
+A custom Automatic Hand Stereo Camera Calibration Routine exists in the ```spot_wrapper``` submodule, where the
+output results can be used with ROS 2 for better RGB to Depth correspondence. 
+See the readme at ```/spot_wrapper/spot_spot_wrapper/calibration/README.md``` for more information.
+
 ## Spot CAM
 Due to known issues with the Spot CAM, it is disabled by default. To enable publishing and usage over the driver, add the following command in your configuration YAML file:
     `initialize_spot_cam: True`

--- a/spot_driver/CMakeLists.txt
+++ b/spot_driver/CMakeLists.txt
@@ -201,6 +201,7 @@ ament_python_install_package(${PROJECT_NAME})
 install(
   PROGRAMS
   spot_driver/spot_ros2.py
+  spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
   DESTINATION lib/${PROJECT_NAME}
   RENAME spot_ros2
   )

--- a/spot_driver/CMakeLists.txt
+++ b/spot_driver/CMakeLists.txt
@@ -201,9 +201,13 @@ ament_python_install_package(${PROJECT_NAME})
 install(
   PROGRAMS
   spot_driver/spot_ros2.py
-  spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
   DESTINATION lib/${PROJECT_NAME}
   RENAME spot_ros2
+  )
+install(
+  PROGRAMS
+  spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
+  DESTINATION lib/${PROJECT_NAME}
   )
 install(
   PROGRAMS

--- a/spot_driver/spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
+++ b/spot_driver/spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
@@ -16,7 +16,7 @@ This script assumes you have a calibration generated with /spot_wrapper/spot_wra
 import argparse
 from typing import Optional
 
-import bdai_ros2_wrapper.scope as ros_scope
+import bdai_ros2_wrappers.scope as ros_scope
 import bdai_ros2_wrappers.process as ros_process
 import cv2
 import numpy as np

--- a/spot_driver/spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
+++ b/spot_driver/spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
@@ -223,8 +223,12 @@ def cli() -> argparse.ArgumentParser:
         help="A calibration saved with the multi-stereo charuco calibration utility",
     )
     parser.add_argument(
-        "--robot_name", dest="robot_name", default=None, required=False, type=str, 
-        help="Spot Robot namespace. Don't supply this argument if there's no namespace."
+        "--robot_name",
+        dest="robot_name",
+        default=None,
+        required=False,
+        type=str,
+        help="Spot Robot namespace. Don't supply this argument if there's no namespace.",
     )
     parser.add_argument(
         "--tag", dest="tag", default="default", type=str, help="What tag to load from the calibration file"

--- a/spot_driver/spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
+++ b/spot_driver/spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
@@ -16,8 +16,8 @@ This script assumes you have a calibration generated with /spot_wrapper/spot_wra
 import argparse
 from typing import Optional
 
-import bdai_ros2_wrappers.scope as ros_scope
 import bdai_ros2_wrappers.process as ros_process
+import bdai_ros2_wrappers.scope as ros_scope
 import cv2
 import numpy as np
 import open3d as o3d
@@ -158,7 +158,7 @@ class CalibratedReRegisteredHandCameraDepthPublisher:
         return depth_image.astype(np.uint16)
 
     def calculate_undistortion_parameters(self) -> None:
-        h, w = self.calibibration["depth_image_dim"]
+        h, w = self.calibration["depth_image_dim"]
         new_camera_matrix, _ = cv2.getOptimalNewCameraMatrix(
             self.calibration["camera_matrix_depth"], self.calibration["dist_coeffs_depth"], (w, h), 1, (w, h)
         )

--- a/spot_driver/spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
+++ b/spot_driver/spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
@@ -223,7 +223,8 @@ def cli() -> argparse.ArgumentParser:
         help="A calibration saved with the multi-stereo charuco calibration utility",
     )
     parser.add_argument(
-        "--robot_name", dest="robot_name", default=None, required=False, type=str, help="Spot Robot namespace"
+        "--robot_name", dest="robot_name", default=None, required=False, type=str, 
+        help="Spot Robot namespace. Don't supply this argument if there's no namespace."
     )
     parser.add_argument(
         "--tag", dest="tag", default="default", type=str, help="What tag to load from the calibration file"

--- a/spot_driver/spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
+++ b/spot_driver/spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
@@ -1,6 +1,6 @@
 # Copyreference (c) 2024 Boston Dynamics AI Institute LLC. All references reserved.
 
-'''
+"""
 This script exists as it is not currently possible to set the intrinsic and extrinsic
 parameters for the hand cameras through the bosdyn API. Currently, the registered
 depth image is published using extrinsic and intrinsic parameters that are set under the hood. 
@@ -12,45 +12,45 @@ Wile it is possible to calibrate the gripper camera entirely under the hood, but
 only set the intrinsic/extrinsic parameters.
 
 This script assumes you have a calibration generated with /spot_wrapper/spot_wrapper/calibration
-'''
+"""
+import argparse
+from typing import Optional
+
+import bdai_ros2_wrappers.process as ros_process
+import cv2
 import numpy as np
 import open3d as o3d
-import cv2
 import yaml
-from typing import Optional
-import argparse
-
 from bdai_ros2_wrappers.context import wait_for_shutdown
-import bdai_ros2_wrappers.process as ros_process
-
 from cv_bridge import CvBridge
 from sensor_msgs.msg import Image
 
-class CalibratedReRegisteredHandCameraDepthPublisher():
-    def __init__(self,
-                 calibration_path: Optional[str] = None,
-                 tag: Optional[str] = "default",
-                 robot_name: str = "spot",
-                 topic_name: str = "depth_registered/hand_custom_cal/image",
-                 undistort: bool = False,):
-        
+
+class CalibratedReRegisteredHandCameraDepthPublisher:
+    def __init__(
+        self,
+        calibration_path: Optional[str] = None,
+        tag: str = "default",
+        robot_name: str = "spot",
+        topic_name: str = "depth_registered/hand_custom_cal/image",
+        undistort: bool = False,
+    ):
         self.node = ros_process.node()
 
         if calibration_path is None:
             self.node.get_logger().warning("No calibration path found, using default calibration")
             self.calibration = {
-                    'camera_matrix_depth': np.zeros(9).tolist(),
-                    'dist_coeffs_depth': np.zeros(5).tolist(),
-                    'camera_matrix_rgb': np.zeros(9).tolist(),
-                    'dist_coeffs_rgb': np.zeros(5).tolist(),
-                    'depth_t_rgb_R': np.zeros(9).tolist(),
-                    'depth_t_rgb_T': np.zeros(3).tolist(),
-                    "rgb_image_dim": np.zeros(2).tolist()
-                }
+                "camera_matrix_depth": np.zeros(9).tolist(),
+                "dist_coeffs_depth": np.zeros(5).tolist(),
+                "camera_matrix_rgb": np.zeros(9).tolist(),
+                "dist_coeffs_rgb": np.zeros(5).tolist(),
+                "depth_t_rgb_R": np.zeros(9).tolist(),
+                "depth_t_rgb_T": np.zeros(3).tolist(),
+                "rgb_image_dim": np.zeros(2).tolist(),
+            }
         else:
-            self.calibration = extract_calibration_parameters(calibration_path=calibration_path,
-                                                              tag=tag)
-        
+            self.calibration = extract_calibration_parameters(calibration_path=calibration_path, tag=tag)
+
         self.calibration["robot_name"] = robot_name
         self.calibration["topic_name"] = topic_name
         self.calibration["undistort"] = undistort
@@ -60,7 +60,7 @@ class CalibratedReRegisteredHandCameraDepthPublisher():
             self.node.declare_parameter(param_name, param_val)
             self.calibration[param_name] = self.node.get_parameter(param_name).value
             if param_name in ["camera_matrix_depth", "camera_matrix_rgb", "depth_t_rgb_R"]:
-                self.calibration[param_name] = np.array(self.calibration[param_name]).reshape((3,3))
+                self.calibration[param_name] = np.array(self.calibration[param_name]).reshape((3, 3))
             elif "dim" not in param_name and "name" not in param_name and "undistort" not in param_name:
                 self.calibration[param_name] = np.array(self.calibration[param_name])
 
@@ -68,51 +68,52 @@ class CalibratedReRegisteredHandCameraDepthPublisher():
 
         raw_depth_topic = f"/{self.calibration['robot_name']}/depth/hand/image"
         self.node.get_logger().info(f"Creating subscriber to raw depth at {raw_depth_topic}")
-        self.raw_depth_img_sub = self.node.create_subscription(Image,
-                                                               raw_depth_topic,
-                                                               self.republish_registered_depth_callback,
-                                                               10)
-        
+        self.raw_depth_img_sub = self.node.create_subscription(
+            Image, raw_depth_topic, self.republish_registered_depth_callback, 10
+        )
+
         reregistered_depth_topic = f"/{self.calibration['robot_name']}/{topic_name}"
         self.node.get_logger().info(f"Creating reregistered depth publisher to {reregistered_depth_topic}")
-        self.reregistered_depth_img_pub = self.node.create_publisher(Image, 
-                                                                    reregistered_depth_topic,
-                                                                    10)
-        
+        self.reregistered_depth_img_pub = self.node.create_publisher(Image, reregistered_depth_topic, 10)
+
     def republish_registered_depth_callback(self, msg: Image) -> None:
-        if self.calibration['rgb_image_dim'][0] != 0:
-            raw_depth_image = self.cv_bridge.imgmsg_to_cv2(msg, desired_encoding='passthrough')
-            pointcloud_pcd = self.depth_img_to_pointcloud(raw_depth_image,
-                                                          undistort=self.calibration["undistort"])
+        if self.calibration["rgb_image_dim"][0] != 0:
+            raw_depth_image = self.cv_bridge.imgmsg_to_cv2(msg, desired_encoding="passthrough")
+            pointcloud_pcd = self.depth_img_to_pointcloud(raw_depth_image, undistort=self.calibration["undistort"])
             reregistered_depth_image = self.pointcloud_to_depth_img(pointcloud_pcd)
             reregistered_depth_msg = msg
-            reregistered_depth_msg.height = self.calibration['rgb_image_dim'][0]
-            reregistered_depth_msg.width = self.calibration['rgb_image_dim'][1]
+            reregistered_depth_msg.height = self.calibration["rgb_image_dim"][0]
+            reregistered_depth_msg.width = self.calibration["rgb_image_dim"][1]
             reregistered_depth_msg.header.frame_id = f"{self.calibration['robot_name']}/hand_color_image_sensor"
 
-            reregistered_depth_msg = self.cv_bridge.cv2_to_imgmsg(reregistered_depth_image,
-                                                                encoding="16UC1",
-                                                                header=reregistered_depth_msg.header)
+            reregistered_depth_msg = self.cv_bridge.cv2_to_imgmsg(
+                reregistered_depth_image, encoding="16UC1", header=reregistered_depth_msg.header
+            )
             self.reregistered_depth_img_pub.publish(reregistered_depth_msg)
         else:
-            self.node.get_logger().warning("Cannot republish registered depth image without populating needed parameters.")
-    
-    def depth_img_to_pointcloud(self, depth_img: np.ndarray, undistort: bool = False, 
-                                depth_scale: float = 1000.0, depth_max: float=10) -> o3d.t.geometry.PointCloud:
+            self.node.get_logger().warning(
+                "Cannot republish registered depth image without populating needed parameters."
+            )
+
+    def depth_img_to_pointcloud(
+        self, depth_img: np.ndarray, undistort: bool = False, depth_scale: float = 1000.0, depth_max: float = 10
+    ) -> o3d.t.geometry.PointCloud:
         depth_img = depth_img.astype(np.float32)
 
         if undistort:
-            camera_matrix = self.calibration['camera_matrix_depth']
-            dist_coeffs = np.array(self.calibration['dist_coeffs_depth'])
+            camera_matrix = self.calibration["camera_matrix_depth"]
+            dist_coeffs = np.array(self.calibration["dist_coeffs_depth"])
             h, w = depth_img.shape[:2]
             new_camera_matrix, _ = cv2.getOptimalNewCameraMatrix(camera_matrix, dist_coeffs, (w, h), 1, (w, h))
-            map1, map2 = cv2.initUndistortRectifyMap(camera_matrix, dist_coeffs, None, new_camera_matrix, (w, h), cv2.CV_32FC1)
+            map1, map2 = cv2.initUndistortRectifyMap(
+                camera_matrix, dist_coeffs, None, new_camera_matrix, (w, h), cv2.CV_32FC1
+            )
             undistorted_depth_img = cv2.remap(depth_img, map1, map2, interpolation=cv2.INTER_NEAREST)
         else:
             undistorted_depth_img = depth_img
-            new_camera_matrix = self.calibration['camera_matrix_depth']
+            new_camera_matrix = self.calibration["camera_matrix_depth"]
 
-        h, w = undistorted_depth_img.shape[:2] 
+        h, w = undistorted_depth_img.shape[:2]
         intrinsic_tensor = o3d.core.Tensor(new_camera_matrix, dtype=o3d.core.Dtype.Float32)
 
         depth_tensor = o3d.core.Tensor(undistorted_depth_img, dtype=o3d.core.Dtype.Float32)
@@ -125,7 +126,7 @@ class CalibratedReRegisteredHandCameraDepthPublisher():
             depth_max=depth_max,
         )
         return pointcloud_pcd
-    
+
     def pointcloud_to_depth_img(self, pointcloud: o3d.t.geometry.PointCloud) -> np.ndarray:
         # Convert the extrinsic matrix from a NumPy array to an Open3D tensor
         extrinsic_np = np.eye(4)
@@ -134,7 +135,7 @@ class CalibratedReRegisteredHandCameraDepthPublisher():
         extrinsic_tensor = o3d.core.Tensor(extrinsic_np, dtype=o3d.core.Dtype.Float32)
         intrinsic_tensor = o3d.core.Tensor(self.calibration["camera_matrix_rgb"], dtype=o3d.core.Dtype.Float32)
 
-        # Colors field needs to be populated to convert to depth image but doesn't matter for that 
+        # Colors field needs to be populated to convert to depth image but doesn't matter for that
         # purpose so add random color
         if "colors" not in pointcloud.point:
             # Create a dummy color array with the same number of points, using all white (1, 1, 1)
@@ -142,20 +143,20 @@ class CalibratedReRegisteredHandCameraDepthPublisher():
             dummy_colors = o3d.core.Tensor(np.ones((num_points, 3), dtype=np.float32), dtype=o3d.core.Dtype.Float32)
             pointcloud.point["colors"] = dummy_colors
         rgbd_image = pointcloud.project_to_rgbd_image(
-            width=self.calibration['rgb_image_dim'][1],
-            height=self.calibration['rgb_image_dim'][0],
+            width=self.calibration["rgb_image_dim"][1],
+            height=self.calibration["rgb_image_dim"][0],
             intrinsics=intrinsic_tensor,
             extrinsics=extrinsic_tensor,
-            depth_scale=1000.0,  
-            depth_max=10.0 
+            depth_scale=1000.0,
+            depth_max=10.0,
         )
-        depth_image = np.asarray(rgbd_image.depth)  
+        depth_image = np.asarray(rgbd_image.depth)
         return depth_image.astype(np.uint16)
 
-    
+
 def extract_calibration_parameters(calibration_path: str, tag: str) -> dict:
     try:
-        with open(calibration_path, 'r') as file:
+        with open(calibration_path, "r") as file:
             recorded_calibration = yaml.safe_load(file)
     except FileNotFoundError:
         raise ValueError(f"Error: The calibration file at {calibration_path} was not found.")
@@ -163,14 +164,14 @@ def extract_calibration_parameters(calibration_path: str, tag: str) -> dict:
         raise ValueError(f"Error: There was an issue parsing the calibration YAML file: {e}")
     try:
         calibration = {}
-        calibration["camera_matrix_depth"] = recorded_calibration[tag]['intrinsic'][1]['camera_matrix']
-        calibration["dist_coeffs_depth"] = recorded_calibration[tag]['intrinsic'][1]['dist_coeffs']
-        calibration["camera_matrix_rgb"] = recorded_calibration[tag]['intrinsic'][0]['camera_matrix']
-        calibration["dist_coeffs_rgb"] = recorded_calibration[tag]['intrinsic'][1]['dist_coeffs']
-        calibration["depth_t_rgb_R"] = recorded_calibration[tag]['extrinsic'][1][0]['R']
-        calibration["depth_t_rgb_T"] = recorded_calibration[tag]['extrinsic'][1][0]['T']
-        calibration["depth_image_dim"] = recorded_calibration[tag]['intrinsic'][1]['image_dim']
-        calibration['rgb_image_dim'] = recorded_calibration[tag]['intrinsic'][0]['image_dim']
+        calibration["camera_matrix_depth"] = recorded_calibration[tag]["intrinsic"][1]["camera_matrix"]
+        calibration["dist_coeffs_depth"] = recorded_calibration[tag]["intrinsic"][1]["dist_coeffs"]
+        calibration["camera_matrix_rgb"] = recorded_calibration[tag]["intrinsic"][0]["camera_matrix"]
+        calibration["dist_coeffs_rgb"] = recorded_calibration[tag]["intrinsic"][1]["dist_coeffs"]
+        calibration["depth_t_rgb_R"] = recorded_calibration[tag]["extrinsic"][1][0]["R"]
+        calibration["depth_t_rgb_T"] = recorded_calibration[tag]["extrinsic"][1][0]["T"]
+        calibration["depth_image_dim"] = recorded_calibration[tag]["intrinsic"][1]["image_dim"]
+        calibration["rgb_image_dim"] = recorded_calibration[tag]["intrinsic"][0]["image_dim"]
     except KeyError as e:
         raise ValueError(f"Error: Missing key in the calibration data: {e}")
     except TypeError as e:
@@ -180,29 +181,53 @@ def extract_calibration_parameters(calibration_path: str, tag: str) -> dict:
 
     return calibration
 
+
 def cli() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--calibration_path", "-c", "--cal", "--calibration",
-                         dest="calibration_path", required=False, type=str,
-                        help="A calibration saved with the multi-stereo charuco calibration utility")
-    parser.add_argument("--robot_name", dest="robot_name", default="spot",
-                        required=False, type=str,
-                        help="Spot Robot namespace")
-    parser.add_argument('--tag', dest="tag", default='default', type=str,
-                        help="What tag to load from the calibration file")
-    parser.add_argument('--topic', dest="topic", default='depth_registered/hand_custom_cal/image', type=str,
-                        help="what topic suffix to publish the reregistered image at.")
-    parser.add_argument('--undistort', dest="undistort", default=False,
-                        type=bool, help="Whether to undistort the depth image prior to republishing it.")
+    parser.add_argument(
+        "--calibration_path",
+        "-c",
+        "--cal",
+        "--calibration",
+        dest="calibration_path",
+        required=False,
+        type=str,
+        help="A calibration saved with the multi-stereo charuco calibration utility",
+    )
+    parser.add_argument(
+        "--robot_name", dest="robot_name", default="spot", required=False, type=str, help="Spot Robot namespace"
+    )
+    parser.add_argument(
+        "--tag", dest="tag", default="default", type=str, help="What tag to load from the calibration file"
+    )
+    parser.add_argument(
+        "--topic",
+        dest="topic",
+        default="depth_registered/hand_custom_cal/image",
+        type=str,
+        help="what topic suffix to publish the reregistered image at.",
+    )
+    parser.add_argument(
+        "--undistort",
+        dest="undistort",
+        default=False,
+        type=bool,
+        help="Whether to undistort the depth image prior to republishing it.",
+    )
     return parser
+
 
 @ros_process.main(cli())
 def main(args: argparse.Namespace) -> None:
-    CalibratedReRegisteredHandCameraDepthPublisher(calibration_path=args.calibration_path,
-                                                   tag=args.tag, robot_name=args.robot_name, 
-                                                   topic_name=args.topic,
-                                                   undistort=args.undistort)
+    CalibratedReRegisteredHandCameraDepthPublisher(
+        calibration_path=args.calibration_path,
+        tag=args.tag,
+        robot_name=args.robot_name,
+        topic_name=args.topic,
+        undistort=args.undistort,
+    )
     wait_for_shutdown()
+
 
 if __name__ == "__main__":
     main()

--- a/spot_driver/spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
+++ b/spot_driver/spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
@@ -8,8 +8,8 @@ If the updated results from the calibration in spot_wrapper/spot_wrapper/calibra
 can be populated into the underlying bosdyn API, then the default registered depth image
 could be used without this script.
 
-Wile it is possible to calibrate the gripper camera entirely under the hood, but is no way to
-only set the intrinsic/extrinsic parameters.
+While it is possible to calibrate the gripper camera entirely under the hood, there is no way to
+only set the intrinsic/extrinsic parameters (to preserve control over calibration parameters)
 
 This script assumes you have a calibration generated with /spot_wrapper/spot_wrapper/calibration
 """

--- a/spot_driver/spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
+++ b/spot_driver/spot_driver/calibrated_reregistered_hand_camera_depth_publisher.py
@@ -1,0 +1,208 @@
+# Copyreference (c) 2024 Boston Dynamics AI Institute LLC. All references reserved.
+
+'''
+This script exists as it is not currently possible to set the intrinsic and extrinsic
+parameters for the hand cameras through the bosdyn API. Currently, the registered
+depth image is published using extrinsic and intrinsic parameters that are set under the hood. 
+If the updated results from the calibration in spot_wrapper/spot_wrapper/calibration
+can be populated into the underlying bosdyn API, then the default registered depth image
+could be used without this script.
+
+Wile it is possible to calibrate the gripper camera entirely under the hood, but is no way to
+only set the intrinsic/extrinsic parameters.
+
+This script assumes you have a calibration generated with /spot_wrapper/spot_wrapper/calibration
+'''
+import numpy as np
+import open3d as o3d
+import cv2
+import yaml
+from typing import Optional
+import argparse
+
+from bdai_ros2_wrappers.context import wait_for_shutdown
+import bdai_ros2_wrappers.process as ros_process
+
+from cv_bridge import CvBridge
+from sensor_msgs.msg import Image
+
+class CalibratedReRegisteredHandCameraDepthPublisher():
+    def __init__(self,
+                 calibration_path: Optional[str] = None,
+                 tag: Optional[str] = "default",
+                 robot_name: str = "spot",
+                 topic_name: str = "depth_registered/hand_custom_cal/image",
+                 undistort: bool = False,):
+        
+        self.node = ros_process.node()
+
+        if calibration_path is None:
+            self.node.get_logger().warning("No calibration path found, using default calibration")
+            self.calibration = {
+                    'camera_matrix_depth': np.zeros(9).tolist(),
+                    'dist_coeffs_depth': np.zeros(5).tolist(),
+                    'camera_matrix_rgb': np.zeros(9).tolist(),
+                    'dist_coeffs_rgb': np.zeros(5).tolist(),
+                    'depth_t_rgb_R': np.zeros(9).tolist(),
+                    'depth_t_rgb_T': np.zeros(3).tolist(),
+                    "rgb_image_dim": np.zeros(2).tolist()
+                }
+        else:
+            self.calibration = extract_calibration_parameters(calibration_path=calibration_path,
+                                                              tag=tag)
+        
+        self.calibration["robot_name"] = robot_name
+        self.calibration["topic_name"] = topic_name
+        self.calibration["undistort"] = undistort
+
+        for param_name, param_val in self.calibration.items():
+            self.node.get_logger().info(f"Setting the parameter {param_name} to a default value of {param_val}")
+            self.node.declare_parameter(param_name, param_val)
+            self.calibration[param_name] = self.node.get_parameter(param_name).value
+            if param_name in ["camera_matrix_depth", "camera_matrix_rgb", "depth_t_rgb_R"]:
+                self.calibration[param_name] = np.array(self.calibration[param_name]).reshape((3,3))
+            elif "dim" not in param_name and "name" not in param_name and "undistort" not in param_name:
+                self.calibration[param_name] = np.array(self.calibration[param_name])
+
+        self.cv_bridge = CvBridge()
+
+        raw_depth_topic = f"/{self.calibration['robot_name']}/depth/hand/image"
+        self.node.get_logger().info(f"Creating subscriber to raw depth at {raw_depth_topic}")
+        self.raw_depth_img_sub = self.node.create_subscription(Image,
+                                                               raw_depth_topic,
+                                                               self.republish_registered_depth_callback,
+                                                               10)
+        
+        reregistered_depth_topic = f"/{self.calibration['robot_name']}/{topic_name}"
+        self.node.get_logger().info(f"Creating reregistered depth publisher to {reregistered_depth_topic}")
+        self.reregistered_depth_img_pub = self.node.create_publisher(Image, 
+                                                                    reregistered_depth_topic,
+                                                                    10)
+        
+    def republish_registered_depth_callback(self, msg: Image) -> None:
+        if self.calibration['rgb_image_dim'][0] != 0:
+            raw_depth_image = self.cv_bridge.imgmsg_to_cv2(msg, desired_encoding='passthrough')
+            pointcloud_pcd = self.depth_img_to_pointcloud(raw_depth_image,
+                                                          undistort=self.calibration["undistort"])
+            reregistered_depth_image = self.pointcloud_to_depth_img(pointcloud_pcd)
+            reregistered_depth_msg = msg
+            reregistered_depth_msg.height = self.calibration['rgb_image_dim'][0]
+            reregistered_depth_msg.width = self.calibration['rgb_image_dim'][1]
+            reregistered_depth_msg.header.frame_id = f"{self.calibration['robot_name']}/hand_color_image_sensor"
+
+            reregistered_depth_msg = self.cv_bridge.cv2_to_imgmsg(reregistered_depth_image,
+                                                                encoding="16UC1",
+                                                                header=reregistered_depth_msg.header)
+            self.reregistered_depth_img_pub.publish(reregistered_depth_msg)
+        else:
+            self.node.get_logger().warning("Cannot republish registered depth image without populating needed parameters.")
+    
+    def depth_img_to_pointcloud(self, depth_img: np.ndarray, undistort: bool = False, 
+                                depth_scale: float = 1000.0, depth_max: float=10) -> o3d.t.geometry.PointCloud:
+        depth_img = depth_img.astype(np.float32)
+
+        if undistort:
+            camera_matrix = self.calibration['camera_matrix_depth']
+            dist_coeffs = np.array(self.calibration['dist_coeffs_depth'])
+            h, w = depth_img.shape[:2]
+            new_camera_matrix, _ = cv2.getOptimalNewCameraMatrix(camera_matrix, dist_coeffs, (w, h), 1, (w, h))
+            map1, map2 = cv2.initUndistortRectifyMap(camera_matrix, dist_coeffs, None, new_camera_matrix, (w, h), cv2.CV_32FC1)
+            undistorted_depth_img = cv2.remap(depth_img, map1, map2, interpolation=cv2.INTER_NEAREST)
+        else:
+            undistorted_depth_img = depth_img
+            new_camera_matrix = self.calibration['camera_matrix_depth']
+
+        h, w = undistorted_depth_img.shape[:2] 
+        intrinsic_tensor = o3d.core.Tensor(new_camera_matrix, dtype=o3d.core.Dtype.Float32)
+
+        depth_tensor = o3d.core.Tensor(undistorted_depth_img, dtype=o3d.core.Dtype.Float32)
+        depth_image = o3d.t.geometry.Image(depth_tensor)
+
+        pointcloud_pcd = o3d.t.geometry.PointCloud.create_from_depth_image(
+            depth=depth_image,
+            intrinsics=intrinsic_tensor,
+            depth_scale=depth_scale,
+            depth_max=depth_max,
+        )
+        return pointcloud_pcd
+    
+    def pointcloud_to_depth_img(self, pointcloud: o3d.t.geometry.PointCloud) -> np.ndarray:
+        # Convert the extrinsic matrix from a NumPy array to an Open3D tensor
+        extrinsic_np = np.eye(4)
+        extrinsic_np[:3, :3] = self.calibration["depth_t_rgb_R"]
+        extrinsic_np[:3, -1:] = self.calibration["depth_t_rgb_T"].reshape(3, 1)
+        extrinsic_tensor = o3d.core.Tensor(extrinsic_np, dtype=o3d.core.Dtype.Float32)
+        intrinsic_tensor = o3d.core.Tensor(self.calibration["camera_matrix_rgb"], dtype=o3d.core.Dtype.Float32)
+
+        # Colors field needs to be populated to convert to depth image but doesn't matter for that 
+        # purpose so add random color
+        if "colors" not in pointcloud.point:
+            # Create a dummy color array with the same number of points, using all white (1, 1, 1)
+            num_points = pointcloud.point["positions"].shape[0]
+            dummy_colors = o3d.core.Tensor(np.ones((num_points, 3), dtype=np.float32), dtype=o3d.core.Dtype.Float32)
+            pointcloud.point["colors"] = dummy_colors
+        rgbd_image = pointcloud.project_to_rgbd_image(
+            width=self.calibration['rgb_image_dim'][1],
+            height=self.calibration['rgb_image_dim'][0],
+            intrinsics=intrinsic_tensor,
+            extrinsics=extrinsic_tensor,
+            depth_scale=1000.0,  
+            depth_max=10.0 
+        )
+        depth_image = np.asarray(rgbd_image.depth)  
+        return depth_image.astype(np.uint16)
+
+    
+def extract_calibration_parameters(calibration_path: str, tag: str) -> dict:
+    try:
+        with open(calibration_path, 'r') as file:
+            recorded_calibration = yaml.safe_load(file)
+    except FileNotFoundError:
+        raise ValueError(f"Error: The calibration file at {calibration_path} was not found.")
+    except yaml.YAMLError as e:
+        raise ValueError(f"Error: There was an issue parsing the calibration YAML file: {e}")
+    try:
+        calibration = {}
+        calibration["camera_matrix_depth"] = recorded_calibration[tag]['intrinsic'][1]['camera_matrix']
+        calibration["dist_coeffs_depth"] = recorded_calibration[tag]['intrinsic'][1]['dist_coeffs']
+        calibration["camera_matrix_rgb"] = recorded_calibration[tag]['intrinsic'][0]['camera_matrix']
+        calibration["dist_coeffs_rgb"] = recorded_calibration[tag]['intrinsic'][1]['dist_coeffs']
+        calibration["depth_t_rgb_R"] = recorded_calibration[tag]['extrinsic'][1][0]['R']
+        calibration["depth_t_rgb_T"] = recorded_calibration[tag]['extrinsic'][1][0]['T']
+        calibration["depth_image_dim"] = recorded_calibration[tag]['intrinsic'][1]['image_dim']
+        calibration['rgb_image_dim'] = recorded_calibration[tag]['intrinsic'][0]['image_dim']
+    except KeyError as e:
+        raise ValueError(f"Error: Missing key in the calibration data: {e}")
+    except TypeError as e:
+        raise ValueError(f"Error: Incorrect data type or structure in the calibration data: {e}")
+    except ValueError as e:
+        raise ValueError(f"Error: Invalid value in calibration data: {e}")
+
+    return calibration
+
+def cli() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--calibration_path", "-c", "--cal", "--calibration",
+                         dest="calibration_path", required=False, type=str,
+                        help="A calibration saved with the multi-stereo charuco calibration utility")
+    parser.add_argument("--robot_name", dest="robot_name", default="spot",
+                        required=False, type=str,
+                        help="Spot Robot namespace")
+    parser.add_argument('--tag', dest="tag", default='default', type=str,
+                        help="What tag to load from the calibration file")
+    parser.add_argument('--topic', dest="topic", default='depth_registered/hand_custom_cal/image', type=str,
+                        help="what topic suffix to publish the reregistered image at.")
+    parser.add_argument('--undistort', dest="undistort", default=False,
+                        type=bool, help="Whether to undistort the depth image prior to republishing it.")
+    return parser
+
+@ros_process.main(cli())
+def main(args: argparse.Namespace) -> None:
+    CalibratedReRegisteredHandCameraDepthPublisher(calibration_path=args.calibration_path,
+                                                   tag=args.tag, robot_name=args.robot_name, 
+                                                   topic_name=args.topic,
+                                                   undistort=args.undistort)
+    wait_for_shutdown()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Change Overview
This allows Spot to use a calibration to register the depth image to the rgb frame
in the hand


[SW-1245] This builds on capability created in https://github.com/bdaiinstitute/spot_wrapper/pull/131#issue-2473965414
(This allows Spot to automatically calibrate the hand cameras, coming up with a stereo pair correspondence for the ToF and RGB cameras.)

## Testing Done
### On Robot Testing
Tested the calibration sequence on a few different spots, varying the calibration parameters. Conducted drop in tests with ROS 2 bags (see below), as well as just testing running the publisher alongside all other other nodes. Verified that republished depth image creates a Point Cloud is in the same frame and orientation as the default depth image.

### Replacing default publisher with drop in replacement test
Recording relevant topics
```
ROBOT_NAME=ROBOT_NAME
ros2 bag record --output drop_in_test --topics /tf /tf_static /${ROBOT_NAME}/depth/hand/image /${ROBOT_NAME}/camera/hand/camera_info /${ROBOT_NAME}/joint_states /${ROBOT_NAME}/camera/hand/image
```
Playing it back, and adding the republisher (in separate terminals)
```
ros2 bag play drop_in_test
python3 calibrated_reregistered_hand_camera_depth_publisher.py --robot_name $ROBOT_NAME --calibration_path $CALIBRATION_PATH --topic depth_registered/hand/image
```
Then, recreating the point cloud 
```
ros2 launch spot_driver point_cloud_xyzrgb.launch.py spot_name:=ROBOT_NAME camera:=hand
```
Then, the point cloud can be viewed in RViz as it would be normally (when the QoS drop down is set to BEST EFFORT instead of RELIABLE

[SW-1245]: https://theaiinstitute.atlassian.net/browse/SW-1245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ