### PR TITLE
[N/A] update velocity limits in URDF with more accurate values

### DIFF
--- a/spot_description/urdf/spot_arm_macro.urdf
+++ b/spot_description/urdf/spot_arm_macro.urdf
@@ -41,7 +41,7 @@
       <axis xyz="0 0 1" />
       <parent link="${tf_prefix}body" />
       <child link="${tf_prefix}arm_link_sh0" />
-      <limit effort="90.9" velocity="1000.00" lower="-2.61799387799149441136"
+      <limit effort="90.9" velocity="10.0" lower="-2.61799387799149441136"
         upper="3.14159265358979311599" />
     </joint>
 
@@ -68,7 +68,7 @@
       <axis xyz="0 1 0" />
       <parent link="${tf_prefix}arm_link_sh0" />
       <child link="${tf_prefix}arm_link_sh1" />
-      <limit effort="181.8" velocity="1000.00" lower="-3.14159265358979311599"
+      <limit effort="181.8" velocity="10.0" lower="-3.14159265358979311599"
         upper="0.52359877559829881565" />
     </joint>
 
@@ -129,7 +129,7 @@
       <axis xyz="0 1 0" />
       <parent link="${tf_prefix}arm_link_hr0" />
       <child link="${tf_prefix}arm_link_el0" />
-      <limit effort="90.9" velocity="1000.00" lower="0" upper="3.14159265358979311599" />
+      <limit effort="90.9" velocity="10.0" lower="0" upper="3.14159265358979311599" />
     </joint>
 
     <link name="${tf_prefix}arm_link_el1">
@@ -165,7 +165,7 @@
       <axis xyz="1 0 0" />
       <parent link="${tf_prefix}arm_link_el0" />
       <child link="${tf_prefix}arm_link_el1" />
-      <limit effort="30.3" velocity="1000.00" lower="-2.79252680319092716487"
+      <limit effort="30.3" velocity="10.0" lower="-2.79252680319092716487"
         upper="2.79252680319092716487" />
     </joint>
 
@@ -197,7 +197,7 @@
       <axis xyz="0 1 0" />
       <parent link="${tf_prefix}arm_link_el1" />
       <child link="${tf_prefix}arm_link_wr0" />
-      <limit effort="30.3" velocity="1000.00" lower="-1.83259571459404613236"
+      <limit effort="30.3" velocity="10.0" lower="-1.83259571459404613236"
         upper="1.83259571459404613236" />
     </joint>
 
@@ -244,7 +244,7 @@
       <axis xyz="1 0 0" />
       <parent link="${tf_prefix}arm_link_wr0" />
       <child link="${tf_prefix}arm_link_wr1" />
-      <limit effort="30.3" velocity="1000.00" lower="-2.87979326579064354163"
+      <limit effort="30.3" velocity="10.0" lower="-2.87979326579064354163"
         upper="2.87979326579064354163" />
     </joint>
 
@@ -301,7 +301,7 @@
       <axis xyz="0.0 1.0 0.0" />
       <parent link="${tf_prefix}arm_link_wr1" />
       <child link="${tf_prefix}arm_link_fngr" />
-      <limit effort="15.32" velocity="1000.00" lower="-1.57" upper="0.0" />
+      <limit effort="15.32" velocity="10.0" lower="-1.57" upper="0.0" />
     </joint>
   </xacro:macro>
 </robot>

--- a/spot_description/urdf/spot_macro.xacro
+++ b/spot_description/urdf/spot_macro.xacro
@@ -81,7 +81,7 @@
             <axis xyz="1 0 0" />
             <parent link="${tf_prefix}body" />
             <child link="${tf_prefix}front_left_hip" />
-            <limit effort="45" velocity="1000.00" lower="-0.78539816339744827899"
+            <limit effort="45" velocity="17.647" lower="-0.78539816339744827899"
                 upper="0.78539816339744827899" />
         </joint>
         <link name="${tf_prefix}front_left_upper_leg">
@@ -110,7 +110,7 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}front_left_hip" />
             <child link="${tf_prefix}front_left_upper_leg" />
-            <limit effort="45" velocity="1000.00" lower="-0.89884456477707963539"
+            <limit effort="45" velocity="17.647" lower="-0.89884456477707963539"
                 upper="2.2951079663725435509" />
         </joint>
         <link name="${tf_prefix}front_left_lower_leg">
@@ -145,7 +145,7 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}front_left_upper_leg" />
             <child link="${tf_prefix}front_left_lower_leg" />
-            <limit effort="115" velocity="1000.00" lower="-2.7929" upper="-0.254801" />
+            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.254801" />
         </joint>
         <link name="${tf_prefix}front_right_hip">
             <visual>
@@ -167,7 +167,7 @@
             <axis xyz="1 0 0" />
             <parent link="${tf_prefix}body" />
             <child link="${tf_prefix}front_right_hip" />
-            <limit effort="45" velocity="1000.00" lower="-0.78539816339744827899"
+            <limit effort="45" velocity="17.647" lower="-0.78539816339744827899"
                 upper="0.78539816339744827899" />
         </joint>
         <link name="${tf_prefix}front_right_upper_leg">
@@ -196,7 +196,7 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}front_right_hip" />
             <child link="${tf_prefix}front_right_upper_leg" />
-            <limit effort="45" velocity="1000.00" lower="-0.89884456477707963539"
+            <limit effort="45" velocity="17.647" lower="-0.89884456477707963539"
                 upper="2.2951079663725435509" />
         </joint>
         <link name="${tf_prefix}front_right_lower_leg">
@@ -231,7 +231,7 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}front_right_upper_leg" />
             <child link="${tf_prefix}front_right_lower_leg" />
-            <limit effort="115" velocity="1000.00" lower="-2.7929" upper="-0.247563" />
+            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.247563" />
         </joint>
         <link name="${tf_prefix}rear_left_hip">
             <visual>
@@ -253,7 +253,7 @@
             <axis xyz="1 0 0" />
             <parent link="${tf_prefix}body" />
             <child link="${tf_prefix}rear_left_hip" />
-            <limit effort="45" velocity="1000.00" lower="-0.78539816339744827899"
+            <limit effort="45" velocity="17.647" lower="-0.78539816339744827899"
                 upper="0.78539816339744827899" />
         </joint>
         <link name="${tf_prefix}rear_left_upper_leg">
@@ -282,7 +282,7 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}rear_left_hip" />
             <child link="${tf_prefix}rear_left_upper_leg" />
-            <limit effort="45" velocity="1000.00" lower="-0.89884456477707963539"
+            <limit effort="45" velocity="17.647" lower="-0.89884456477707963539"
                 upper="2.2951079663725435509" />
         </joint>
         <link name="${tf_prefix}rear_left_lower_leg">
@@ -317,7 +317,7 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}rear_left_upper_leg" />
             <child link="${tf_prefix}rear_left_lower_leg" />
-            <limit effort="115" velocity="1000.00" lower="-2.7929" upper="-0.267153" />
+            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.267153" />
         </joint>
         <link name="${tf_prefix}rear_right_hip">
             <visual>
@@ -339,7 +339,7 @@
             <axis xyz="1 0 0" />
             <parent link="${tf_prefix}body" />
             <child link="${tf_prefix}rear_right_hip" />
-            <limit effort="45" velocity="1000.00" lower="-0.78539816339744827899"
+            <limit effort="45" velocity="17.647" lower="-0.78539816339744827899"
                 upper="0.78539816339744827899" />
         </joint>
         <link name="${tf_prefix}rear_right_upper_leg">
@@ -368,7 +368,7 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}rear_right_hip" />
             <child link="${tf_prefix}rear_right_upper_leg" />
-            <limit effort="45" velocity="1000.00" lower="-0.89884456477707963539"
+            <limit effort="45" velocity="17.647" lower="-0.89884456477707963539"
                 upper="2.2951079663725435509" />
         </joint>
         <link name="${tf_prefix}rear_right_lower_leg">
@@ -403,7 +403,7 @@
             <axis xyz="0 1 0" />
             <parent link="${tf_prefix}rear_right_upper_leg" />
             <child link="${tf_prefix}rear_right_lower_leg" />
-            <limit effort="115" velocity="1000.00" lower="-2.7929" upper="-0.257725" />
+            <limit effort="115" velocity="12.0" lower="-2.7929" upper="-0.257725" />
         </joint>
 
         <!-- Standard accessories. -->


### PR DESCRIPTION
## Change Overview

Updates velocity limits in URDF following this response from BD support:

"Regarding the maximum velocity limits, unfortunately we do not have any hard numbers on this. For the hip joints we use an internal value of 900/51 rad/s as a limit for jointspace planning. The knee is more complex due to the variable transmission, but an average value of 900/75 rad/s is a reasonable value. For the arm we use a value of 10 rad/s for jointspace planning. Note: these are not no-load speeds, but software limits."

## Testing Done

N/A