### PR TITLE
Joint Passthrough node for Action Stack Integration

### DIFF
--- a/spot_ros2_control/CMakeLists.txt
+++ b/spot_ros2_control/CMakeLists.txt
@@ -73,7 +73,13 @@ ament_target_dependencies(wiggle_arm
   ${THIS_PACKAGE_INCLUDE_DEPENDS}
 )
 target_link_libraries(wiggle_arm spot_ros2_control)
-install(TARGETS noarm_squat wiggle_arm
+add_executable(joint_command_passthrough examples/src/joint_command_passthrough.cpp)
+ament_target_dependencies(joint_command_passthrough
+  ${THIS_PACKAGE_INCLUDE_DEPENDS}
+)
+target_link_libraries(joint_command_passthrough spot_ros2_control)
+
+install(TARGETS noarm_squat wiggle_arm joint_command_passthrough
   DESTINATION lib/${PROJECT_NAME})
 
 install(

--- a/spot_ros2_control/examples/src/joint_command_passthrough.cpp
+++ b/spot_ros2_control/examples/src/joint_command_passthrough.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+
+// Note(llee): I think I would like to move this to `action_stack_spot` because so far it's pretty specific to Spot
+
+#include <chrono>
+#include <functional>
+#include <map>
+#include <memory>
+#include <ranges>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/joint_state.hpp"
+#include "spot_ros2_control/spot_joint_map.hpp"
+#include "std_msgs/msg/float64_multi_array.hpp"
+
+class JointCommandPassthrough : public rclcpp::Node {
+  public:
+    JointCommandPassthrough() : Node("joint_passthrough") {
+        joint_states_sub_ = create_subscription<sensor_msgs::msg::JointState>(
+            "Ethernet0/joint_states", 10,
+            std::bind(&JointCommandPassthrough::joint_states_callback, this,
+                      std::placeholders::_1)); // todo (llee): make this topic name a parameter
+
+        joint_commands_sub_ = create_subscription<sensor_msgs::msg::JointState>(
+            "Ethernet0/joint_commands", 10,
+            std::bind(&JointCommandPassthrough::joint_commands_callback, this,
+                      std::placeholders::_1)); // todo (llee): make this topic name a parameter
+
+        command_pub_ = create_publisher<std_msgs::msg::Float64MultiArray>(
+            "/Ethernet0/forward_position_controller/commands", 10); // todo (llee): make this topic name a parameter
+
+        spot_command_.data.reserve(spot_ros2_control::kNjointsArm);
+    }
+
+  private:
+    rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_states_sub_;
+    rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_commands_sub_;
+    rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr command_pub_;
+    std_msgs::msg::Float64MultiArray spot_command_;
+
+    int count_ = 0;
+
+    void joint_states_callback(const sensor_msgs::msg::JointState &msg) {
+        // Keep track of the current joint positions
+        if (msg.name.size() != static_cast<std::vector<int>::size_type>(spot_ros2_control::kNjointsArm)) {
+            RCLCPP_ERROR(get_logger(), "Expected %i dofs, but got %li", spot_ros2_control::kNjointsArm,
+                         msg.name.size());
+            return;
+        }
+
+        spot_command_.data.clear();
+        spot_command_.data.resize(spot_ros2_control::kNjointsArm);
+
+        for (int i = 0; i < spot_ros2_control::kNjointsArm; ++i) {
+            int joint_idx = spot_ros2_control::get_joint_index(msg.name[i]);
+            if (joint_idx < 0) {
+                return;
+            }
+
+            spot_command_.data[joint_idx] = msg.position[i];
+        }
+    }
+
+    void joint_commands_callback(const sensor_msgs::msg::JointState &msg) {
+        // Update provided joints with their desired
+
+        int command_dofs = msg.name.size();
+
+        for (int i = 0; i < command_dofs; ++i) {
+            int joint_idx = spot_ros2_control::get_joint_index(msg.name[i]);
+            if (joint_idx < 0) {
+                return;
+            }
+            spot_command_.data[joint_idx] = msg.position[i];
+        }
+
+        count_++;
+        RCLCPP_INFO(get_logger(), "Forwarding command %i", count_);
+
+        command_pub_->publish(spot_command_);
+    }
+};
+
+int main(int argc, char *argv[]) {
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<JointCommandPassthrough>());
+    rclcpp::shutdown();
+    return 0;
+}

--- a/spot_ros2_control/examples/src/joint_command_passthrough.cpp
+++ b/spot_ros2_control/examples/src/joint_command_passthrough.cpp
@@ -16,76 +16,75 @@
 #include "std_msgs/msg/float64_multi_array.hpp"
 
 class JointCommandPassthrough : public rclcpp::Node {
-  public:
-    JointCommandPassthrough() : Node("joint_passthrough") {
-        joint_states_sub_ = create_subscription<sensor_msgs::msg::JointState>(
-            "Ethernet0/joint_states", 10,
-            std::bind(&JointCommandPassthrough::joint_states_callback, this,
-                      std::placeholders::_1)); // todo (llee): make this topic name a parameter
+ public:
+  JointCommandPassthrough() : Node("joint_passthrough") {
+    joint_states_sub_ = create_subscription<sensor_msgs::msg::JointState>(
+        "Ethernet0/joint_states", 10,
+        std::bind(&JointCommandPassthrough::joint_states_callback, this,
+                  std::placeholders::_1));  // todo (llee): make this topic name a parameter
 
-        joint_commands_sub_ = create_subscription<sensor_msgs::msg::JointState>(
-            "Ethernet0/joint_commands", 10,
-            std::bind(&JointCommandPassthrough::joint_commands_callback, this,
-                      std::placeholders::_1)); // todo (llee): make this topic name a parameter
+    joint_commands_sub_ = create_subscription<sensor_msgs::msg::JointState>(
+        "Ethernet0/joint_commands", 10,
+        std::bind(&JointCommandPassthrough::joint_commands_callback, this,
+                  std::placeholders::_1));  // todo (llee): make this topic name a parameter
 
-        command_pub_ = create_publisher<std_msgs::msg::Float64MultiArray>(
-            "/Ethernet0/forward_position_controller/commands", 10); // todo (llee): make this topic name a parameter
+    command_pub_ = create_publisher<std_msgs::msg::Float64MultiArray>(
+        "/Ethernet0/forward_position_controller/commands", 10);  // todo (llee): make this topic name a parameter
 
-        spot_command_.data.reserve(spot_ros2_control::kNjointsArm);
+    spot_command_.data.reserve(spot_ros2_control::kNjointsArm);
+  }
+
+ private:
+  rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_states_sub_;
+  rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_commands_sub_;
+  rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr command_pub_;
+  std_msgs::msg::Float64MultiArray spot_command_;
+
+  int count_ = 0;
+
+  void joint_states_callback(const sensor_msgs::msg::JointState& msg) {
+    // Keep track of the current joint positions
+    if (msg.name.size() != static_cast<std::vector<int>::size_type>(spot_ros2_control::kNjointsArm)) {
+      RCLCPP_ERROR(get_logger(), "Expected %i dofs, but got %li", spot_ros2_control::kNjointsArm, msg.name.size());
+      return;
     }
 
-  private:
-    rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_states_sub_;
-    rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_commands_sub_;
-    rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr command_pub_;
-    std_msgs::msg::Float64MultiArray spot_command_;
+    spot_command_.data.clear();
+    spot_command_.data.resize(spot_ros2_control::kNjointsArm);
 
-    int count_ = 0;
+    for (int i = 0; i < spot_ros2_control::kNjointsArm; ++i) {
+      int joint_idx = spot_ros2_control::get_joint_index(msg.name[i]);
+      if (joint_idx < 0) {
+        return;
+      }
 
-    void joint_states_callback(const sensor_msgs::msg::JointState &msg) {
-        // Keep track of the current joint positions
-        if (msg.name.size() != static_cast<std::vector<int>::size_type>(spot_ros2_control::kNjointsArm)) {
-            RCLCPP_ERROR(get_logger(), "Expected %i dofs, but got %li", spot_ros2_control::kNjointsArm,
-                         msg.name.size());
-            return;
-        }
+      spot_command_.data[joint_idx] = msg.position[i];
+    }
+  }
 
-        spot_command_.data.clear();
-        spot_command_.data.resize(spot_ros2_control::kNjointsArm);
+  void joint_commands_callback(const sensor_msgs::msg::JointState& msg) {
+    // Update provided joints with their desired
 
-        for (int i = 0; i < spot_ros2_control::kNjointsArm; ++i) {
-            int joint_idx = spot_ros2_control::get_joint_index(msg.name[i]);
-            if (joint_idx < 0) {
-                return;
-            }
+    int command_dofs = msg.name.size();
 
-            spot_command_.data[joint_idx] = msg.position[i];
-        }
+    for (int i = 0; i < command_dofs; ++i) {
+      int joint_idx = spot_ros2_control::get_joint_index(msg.name[i]);
+      if (joint_idx < 0) {
+        return;
+      }
+      spot_command_.data[joint_idx] = msg.position[i];
     }
 
-    void joint_commands_callback(const sensor_msgs::msg::JointState &msg) {
-        // Update provided joints with their desired
+    count_++;
+    RCLCPP_INFO(get_logger(), "Forwarding command %i", count_);
 
-        int command_dofs = msg.name.size();
-
-        for (int i = 0; i < command_dofs; ++i) {
-            int joint_idx = spot_ros2_control::get_joint_index(msg.name[i]);
-            if (joint_idx < 0) {
-                return;
-            }
-            spot_command_.data[joint_idx] = msg.position[i];
-        }
-
-        count_++;
-        RCLCPP_INFO(get_logger(), "Forwarding command %i", count_);
-
-        command_pub_->publish(spot_command_);
-    }
+    command_pub_->publish(spot_command_);
+  }
 };
 
-int main(int argc, char *argv[]) {
-    rclcpp::init(argc, argv);
-    rclcpp::spin(std::make_shared<JointCommandPassthrough>());
-    rclcpp::shutdown();
-    return 0;
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<JointCommandPassthrough>());
+  rclcpp::shutdown();
+  return 0;
 }

--- a/spot_ros2_control/hardware/include/spot_ros2_control/spot_joint_map.hpp
+++ b/spot_ros2_control/hardware/include/spot_ros2_control/spot_joint_map.hpp
@@ -68,65 +68,64 @@ static const std::vector<float> arm_kd = {5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.
 /// @param msg JointStates message
 /// @param ordered_joint_angles_ Joint positions from the joint state message following the correct order.
 /// @return boolean indicating if the joint angles got ordered successfully.
-bool order_joints(const sensor_msgs::msg::JointState &msg, std::vector<double> &ordered_joint_angles) {
-    const auto njoints = msg.position.size();
-    ordered_joint_angles.resize(njoints);
-    // Different joint index maps for arm-full and arm-less
-    switch (njoints) {
+bool order_joints(const sensor_msgs::msg::JointState& msg, std::vector<double>& ordered_joint_angles) {
+  const auto njoints = msg.position.size();
+  ordered_joint_angles.resize(njoints);
+  // Different joint index maps for arm-full and arm-less
+  switch (njoints) {
     // case without arm
     case kNjointsNoArm:
-        for (size_t i = 0; i < njoints; i++) {
-            // get the joint name
-            const auto joint_name = msg.name.at(i);
-            try {
-                const auto joint_index = kJointNameToIndexWithoutArm.at(joint_name);
-                ordered_joint_angles.at(joint_index) = msg.position.at(i);
-            } catch (const std::out_of_range &e) {
-                RCLCPP_INFO_STREAM(rclcpp::get_logger("SpotJointMap"), "Invalid joint: " << joint_name);
-                return false;
-            }
+      for (size_t i = 0; i < njoints; i++) {
+        // get the joint name
+        const auto joint_name = msg.name.at(i);
+        try {
+          const auto joint_index = kJointNameToIndexWithoutArm.at(joint_name);
+          ordered_joint_angles.at(joint_index) = msg.position.at(i);
+        } catch (const std::out_of_range& e) {
+          RCLCPP_INFO_STREAM(rclcpp::get_logger("SpotJointMap"), "Invalid joint: " << joint_name);
+          return false;
         }
-        return true;
+      }
+      return true;
 
     // case with arm
     case kNjointsArm:
-        for (size_t i = 0; i < njoints; i++) {
-            // get the joint name
-            const auto joint_name = msg.name.at(i);
-            try {
-                const auto joint_index = kJointNameToIndexWithArm.at(joint_name);
-                ordered_joint_angles.at(joint_index) = msg.position.at(i);
-            } catch (const std::out_of_range &e) {
-                RCLCPP_INFO_STREAM(rclcpp::get_logger("SpotHardware"), "Invalid joint: " << joint_name);
-                return false;
-            }
+      for (size_t i = 0; i < njoints; i++) {
+        // get the joint name
+        const auto joint_name = msg.name.at(i);
+        try {
+          const auto joint_index = kJointNameToIndexWithArm.at(joint_name);
+          ordered_joint_angles.at(joint_index) = msg.position.at(i);
+        } catch (const std::out_of_range& e) {
+          RCLCPP_INFO_STREAM(rclcpp::get_logger("SpotHardware"), "Invalid joint: " << joint_name);
+          return false;
         }
-        return true;
+      }
+      return true;
 
     default:
-        RCLCPP_INFO_STREAM(rclcpp::get_logger("SpotHardware"), "Invalid number of joints: " << njoints);
-        return false;
-    }
+      RCLCPP_INFO_STREAM(rclcpp::get_logger("SpotHardware"), "Invalid number of joints: " << njoints);
+      return false;
+  }
 }
 
 /// @brief Given a joint name (possibly with namespace), return the joint index
 /// @param joint_str string name of joint
 /// @param has_arm whether or not the spot has an arm (default true)
 /// @return int joint index
-int get_joint_index(const std::string &joint_str, bool has_arm = true) {
-    // Check if the joint_str has a namespace - if so, remove it
-    size_t namespace_pos = joint_str.find("/");
-    std::string joint_name = (namespace_pos != std::string::npos) ? joint_str.substr(namespace_pos + 1) : joint_str;
+int get_joint_index(const std::string& joint_str, bool has_arm = true) {
+  // Check if the joint_str has a namespace - if so, remove it
+  size_t namespace_pos = joint_str.find("/");
+  std::string joint_name = (namespace_pos != std::string::npos) ? joint_str.substr(namespace_pos + 1) : joint_str;
 
-    if (kJointNameToIndexWithArm.find(joint_name) == kJointNameToIndexWithArm.end() &&
-        kJointNameToIndexWithoutArm.find(joint_name) == kJointNameToIndexWithoutArm.end()) {
-        RCLCPP_ERROR(rclcpp::get_logger("SpotHardware"), "Cannot find joint %s in joint map.",
-                           joint_name.c_str());
-        return -1;
-    }
-    int joint_idx = has_arm ? kJointNameToIndexWithArm.at(joint_name) : kJointNameToIndexWithoutArm.at(joint_name);
+  if (kJointNameToIndexWithArm.find(joint_name) == kJointNameToIndexWithArm.end() &&
+      kJointNameToIndexWithoutArm.find(joint_name) == kJointNameToIndexWithoutArm.end()) {
+    RCLCPP_ERROR(rclcpp::get_logger("SpotHardware"), "Cannot find joint %s in joint map.", joint_name.c_str());
+    return -1;
+  }
+  int joint_idx = has_arm ? kJointNameToIndexWithArm.at(joint_name) : kJointNameToIndexWithoutArm.at(joint_name);
 
-    return joint_idx;
+  return joint_idx;
 }
 
-} // namespace spot_ros2_control
+}  // namespace spot_ros2_control


### PR DESCRIPTION
## Change Overview

Node for Maple Action Stack integration:
`joint_command_passthrough` is a node that listens to `joint_states` and saves all the current states, but then pass through any new `/joint_commands` received to the `forward_position_controller`

## Testing Done

Will test on robot in the morning
