### PR TITLE
Add simple JointState msg support

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2528,17 +2528,16 @@ class SpotROS(Node):
             self.get_logger().info(f"Mock mode, received arm joint commdn {data}")
             return
         self.get_logger().info("Received joint command!")
-        arm_joint_names = ["arm_sh0", "arm_sh1", "arm_el0", "arm_el1", "arm_wr0", "arm_wr1"]
-        arm_joints: List[float] = []
 
-        for joint in zip(data.name, data.position, strict=False):
-            self.get_logger().info(f"Found joint {joint[0]}")
-            joint_name = joint[0].split("/", 1)[1]
-            self.get_logger().info(f"Found joint {joint_name}")
-            if joint_name in arm_joint_names:
-                self.get_logger().info(f"Adding {joint_name}")
-                arm_joints[arm_joint_names.index(joint_name)] = joint[1]
-        # self.spot_wrapper.arm_joint_cmd()
+        arm_joint_map = {"sh0": 0.0, "sh1": 0.0, "el0": 0.0, "el1": 0.0, "wr0": 0.0, "wr1": 0.0}
+
+        for joint in zip(data.name, data.position):
+            for joint_name in arm_joint_map.keys():
+                if joint_name in joint[0]:
+                    arm_joint_map[joint_name] = joint[1]
+                    continue
+
+        self.spot_wrapper.arm_joint_cmd()
 
     def handle_graph_nav_get_localization_pose(
         self,

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -59,7 +59,6 @@ from geometry_msgs.msg import (
     PoseStamped,
     Twist,
 )
-from sensor_msgs.msg import JointState
 from rclpy import Parameter
 from rclpy.action import ActionServer
 from rclpy.action.server import ServerGoalHandle
@@ -68,6 +67,7 @@ from rclpy.clock import Clock
 from rclpy.impl import rcutils_logger
 from rclpy.publisher import Publisher
 from rclpy.timer import Rate
+from sensor_msgs.msg import JointState
 from std_srvs.srv import SetBool, Trigger
 
 import spot_driver.robot_command_util as robot_command_util
@@ -458,7 +458,9 @@ class SpotROS(Node):
 
         self.create_subscription(Twist, "cmd_vel", self.cmd_velocity_callback, 1, callback_group=self.group)
         self.create_subscription(Pose, "body_pose", self.body_pose_callback, 1, callback_group=self.group)
-        self.create_subscription(JointState, "arm_joint_commands", self.arm_joint_cmd_callback, 100, callback_group=self.group)
+        self.create_subscription(
+            JointState, "arm_joint_commands", self.arm_joint_cmd_callback, 100, callback_group=self.group
+        )
         self.create_service(
             Trigger,
             "claim",
@@ -2539,12 +2541,12 @@ class SpotROS(Node):
                     continue
 
         self.spot_wrapper.arm_joint_cmd(
-            arm_joint_map["sh0"], 
-            arm_joint_map["sh1"], 
-            arm_joint_map["el0"], 
-            arm_joint_map["el1"], 
-            arm_joint_map["wr0"], 
-            arm_joint_map["wr1"]
+            arm_joint_map["sh0"],
+            arm_joint_map["sh1"],
+            arm_joint_map["el0"],
+            arm_joint_map["el1"],
+            arm_joint_map["wr0"],
+            arm_joint_map["wr1"],
         )
 
     def handle_graph_nav_get_localization_pose(

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2537,8 +2537,8 @@ class SpotROS(Node):
 
         # Need to match the joint names in the JointState message to the joint names in the order we expect for spot.
         # Depending on how the Spot is launched, the joint names could come in with a namespace or arm precusor such as
-        # `Spot/arm_sh0` or "arm_sh0" or simply just "sh0" 
-        for (name, position) in zip(data.name, data.position):
+        # `Spot/arm_sh0` or "arm_sh0" or simply just "sh0"
+        for name, position in zip(data.name, data.position):
             for joint_name in arm_joint_map.keys():
                 if joint_name in name:
                     arm_joint_map[joint_name] = position

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2534,20 +2534,13 @@ class SpotROS(Node):
             self.get_logger().warning(f"Expected {len(arm_joint_map)} joints, but received {len(data.name)}")
             return
 
-        for joint in zip(data.name, data.position):
+        for (name, position) in zip(data.name, data.position):
             for joint_name in arm_joint_map.keys():
-                if joint_name in joint[0]:
-                    arm_joint_map[joint_name] = joint[1]
+                if joint_name in name:
+                    arm_joint_map[joint_name] = position
                     continue
 
-        self.spot_wrapper.arm_joint_cmd(
-            arm_joint_map["sh0"],
-            arm_joint_map["sh1"],
-            arm_joint_map["el0"],
-            arm_joint_map["el1"],
-            arm_joint_map["wr0"],
-            arm_joint_map["wr1"],
-        )
+        self.spot_wrapper.arm_joint_cmd(**arm_joint_map)
 
     def handle_graph_nav_get_localization_pose(
         self,


### PR DESCRIPTION
## Change Overview

Adds a subscriber to `spot_ros2` to accept `JointState` messages on the `/arm_joint_commands` topic to execute (as fast as possible)
Goes along with https://github.com/bdaiinstitute/spot_wrapper/pull/139

## Testing Done

Tested with the Maple `action_stack_spot` package sending joint trajectories
