### PR TITLE
Add the ability to use ccache

### DIFF
--- a/spot_driver/CMakeLists.txt
+++ b/spot_driver/CMakeLists.txt
@@ -10,6 +10,12 @@ endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    set(CMAKE_CUDA_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+endif()
+
 set(THIS_PACKAGE_INCLUDE_ROS_DEPENDS
   bosdyn_api_msgs
   bosdyn_spot_api_msgs


### PR DESCRIPTION
## Change Overview

- If ccache is installed now it can be used to speed up rebuilds of the spot_driver

## Testing Done

- Built the driver (plus this is standard)

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
