### PR TITLE
Bump Spot SDK from `4.0.2` to `4.1.0`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,7 +30,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
 RUN source "/opt/ros/${ROS_DISTRO}/setup.bash"
 
 ARG SPOT_SDK_VERSION="4.1.0"
-ARG SPOT_MSG_VERSION="${SPOT_SDK_VERSION}-2"
+ARG SPOT_MSG_VERSION="${SPOT_SDK_VERSION}-3"
 
 # Install bosdyn_msgs package
 RUN curl -sL https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/${SPOT_MSG_VERSION}/ros-humble-bosdyn_msgs_${SPOT_MSG_VERSION}-jammy_amd64.run --output /tmp/ros-humble-bosdyn_msgs_${SPOT_MSG_VERSION}-jammy_amd64.run --silent \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,16 +29,19 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
 
 RUN source "/opt/ros/${ROS_DISTRO}/setup.bash"
 
+ARG SPOT_SDK_VERSION="4.1.0"
+ARG SPOT_MSG_VERSION="${SPOT_SDK_VERSION}-1"
+
 # Install bosdyn_msgs package
-RUN curl -sL https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/4.1.0/ros-humble-bosdyn_msgs_4.1.0-jammy_amd64.run --output /tmp/ros-humble-bosdyn_msgs_4.1.0-jammy_amd64.run --silent \
-  && chmod +x /tmp/ros-humble-bosdyn_msgs_4.1.0-jammy_amd64.run \
-  && ((yes || true) | /tmp/ros-humble-bosdyn_msgs_4.1.0-jammy_amd64.run) \
-  && rm /tmp/ros-humble-bosdyn_msgs_4.1.0-jammy_amd64.run
+RUN curl -sL https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/${SPOT_MSG_VERSION}/ros-humble-bosdyn_msgs_${SPOT_MSG_VERSION}-jammy_amd64.run --output /tmp/ros-humble-bosdyn_msgs_${SPOT_MSG_VERSION}-jammy_amd64.run --silent \
+  && chmod +x /tmp/ros-humble-bosdyn_msgs_${SPOT_MSG_VERSION}-jammy_amd64.run \
+  && ((yes || true) | /tmp/ros-humble-bosdyn_msgs_${SPOT_MSG_VERSION}-jammy_amd64.run) \
+  && rm /tmp/ros-humble-bosdyn_msgs_${SPOT_MSG_VERSION}-jammy_amd64.run
 
 # Install spot_cpp_sdk package
-RUN curl -sL https://github.com/bdaiinstitute/spot-cpp-sdk/releases/download/v4.1.0/spot-cpp-sdk_4.1.0_amd64.deb --output /tmp/spot-cpp-sdk_4.1.0_amd64.deb --silent \
-  && dpkg -i /tmp/spot-cpp-sdk_4.1.0_amd64.deb \
-  && rm /tmp/spot-cpp-sdk_4.1.0_amd64.deb
+RUN curl -sL https://github.com/bdaiinstitute/spot-cpp-sdk/releases/download/v${SPOT_SDK_VERSION}/spot-cpp-sdk_${SPOT_SDK_VERSION}_amd64.deb --output /tmp/spot-cpp-sdk_${SPOT_SDK_VERSION}_amd64.deb --silent \
+  && dpkg -i /tmp/spot-cpp-sdk_${SPOT_SDK_VERSION}_amd64.deb \
+  && rm /tmp/spot-cpp-sdk_${SPOT_SDK_VERSION}_amd64.deb
 
 # Install bosdyn_msgs missing dependencies
 RUN python -m pip install --no-cache-dir --upgrade pip==22.3.1 \
@@ -46,11 +49,11 @@ RUN python -m pip install --no-cache-dir --upgrade pip==22.3.1 \
     numpy==1.24.1 \
     pytest-cov==4.1.0 \
     pytest-xdist==3.5.0 \
-    bosdyn-api==4.1.0 \
-    bosdyn-core==4.1.0 \
-    bosdyn-client==4.1.0 \
-    bosdyn-mission==4.1.0 \
-    bosdyn-choreography-client==4.1.0 \
+    bosdyn-api==${SPOT_SDK_VERSION} \
+    bosdyn-core==${SPOT_SDK_VERSION} \
+    bosdyn-client==${SPOT_SDK_VERSION} \
+    bosdyn-mission==${SPOT_SDK_VERSION} \
+    bosdyn-choreography-client==${SPOT_SDK_VERSION} \
     pip cache purge
 
 # Install spot_wrapper requirements

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,7 +30,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
 RUN source "/opt/ros/${ROS_DISTRO}/setup.bash"
 
 ARG SPOT_SDK_VERSION="4.1.0"
-ARG SPOT_MSG_VERSION="${SPOT_SDK_VERSION}-1"
+ARG SPOT_MSG_VERSION="${SPOT_SDK_VERSION}-2"
 
 # Install bosdyn_msgs package
 RUN curl -sL https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/${SPOT_MSG_VERSION}/ros-humble-bosdyn_msgs_${SPOT_MSG_VERSION}-jammy_amd64.run --output /tmp/ros-humble-bosdyn_msgs_${SPOT_MSG_VERSION}-jammy_amd64.run --silent \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,7 +30,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
 RUN source "/opt/ros/${ROS_DISTRO}/setup.bash"
 
 ARG SPOT_SDK_VERSION="4.1.0"
-ARG SPOT_MSG_VERSION="${SPOT_SDK_VERSION}-3"
+ARG SPOT_MSG_VERSION="${SPOT_SDK_VERSION}-4"
 
 # Install bosdyn_msgs package
 RUN curl -sL https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/${SPOT_MSG_VERSION}/ros-humble-bosdyn_msgs_${SPOT_MSG_VERSION}-jammy_amd64.run --output /tmp/ros-humble-bosdyn_msgs_${SPOT_MSG_VERSION}-jammy_amd64.run --silent \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,15 +30,15 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
 RUN source "/opt/ros/${ROS_DISTRO}/setup.bash"
 
 # Install bosdyn_msgs package
-RUN curl -sL https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/4.0.2/ros-humble-bosdyn_msgs_4.0.2-jammy_amd64.run --output /tmp/ros-humble-bosdyn_msgs_4.0.2-jammy_amd64.run --silent \
-  && chmod +x /tmp/ros-humble-bosdyn_msgs_4.0.2-jammy_amd64.run \
-  && ((yes || true) | /tmp/ros-humble-bosdyn_msgs_4.0.2-jammy_amd64.run) \
-  && rm /tmp/ros-humble-bosdyn_msgs_4.0.2-jammy_amd64.run
+RUN curl -sL https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/4.1.0/ros-humble-bosdyn_msgs_4.1.0-jammy_amd64.run --output /tmp/ros-humble-bosdyn_msgs_4.1.0-jammy_amd64.run --silent \
+  && chmod +x /tmp/ros-humble-bosdyn_msgs_4.1.0-jammy_amd64.run \
+  && ((yes || true) | /tmp/ros-humble-bosdyn_msgs_4.1.0-jammy_amd64.run) \
+  && rm /tmp/ros-humble-bosdyn_msgs_4.1.0-jammy_amd64.run
 
 # Install spot_cpp_sdk package
-RUN curl -sL https://github.com/bdaiinstitute/spot-cpp-sdk/releases/download/v4.0.2/spot-cpp-sdk_4.0.2_amd64.deb --output /tmp/spot-cpp-sdk_4.0.2_amd64.deb --silent \
-  && dpkg -i /tmp/spot-cpp-sdk_4.0.2_amd64.deb \
-  && rm /tmp/spot-cpp-sdk_4.0.2_amd64.deb
+RUN curl -sL https://github.com/bdaiinstitute/spot-cpp-sdk/releases/download/v4.1.0/spot-cpp-sdk_4.1.0_amd64.deb --output /tmp/spot-cpp-sdk_4.1.0_amd64.deb --silent \
+  && dpkg -i /tmp/spot-cpp-sdk_4.1.0_amd64.deb \
+  && rm /tmp/spot-cpp-sdk_4.1.0_amd64.deb
 
 # Install bosdyn_msgs missing dependencies
 RUN python -m pip install --no-cache-dir --upgrade pip==22.3.1 \
@@ -46,11 +46,11 @@ RUN python -m pip install --no-cache-dir --upgrade pip==22.3.1 \
     numpy==1.24.1 \
     pytest-cov==4.1.0 \
     pytest-xdist==3.5.0 \
-    bosdyn-api==4.0.2 \
-    bosdyn-core==4.0.2 \
-    bosdyn-client==4.0.2 \
-    bosdyn-mission==4.0.2 \
-    bosdyn-choreography-client==4.0.2 \
+    bosdyn-api==4.1.0 \
+    bosdyn-core==4.1.0 \
+    bosdyn-client==4.1.0 \
+    bosdyn-mission==4.1.0 \
+    bosdyn-choreography-client==4.1.0 \
     pip cache purge
 
 # Install spot_wrapper requirements

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
     strategy:
       matrix:
         config:
-        - { python: "3.8" }
-        - { python: "3.9" }
         - { python: "3.10" }
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 # Overview
 This is a ROS 2 package for Boston Dynamics' Spot. The package contains all necessary topics, services and actions to teleoperate or navigate Spot.
-This package is derived from this [ROS 1 package](https://github.com/heuristicus/spot_ros). This package currently corresponds to version 4.0.2 of the [spot-sdk](https://github.com/boston-dynamics/spot-sdk/releases/tag/v4.0.2).
+This package is derived from this [ROS 1 package](https://github.com/heuristicus/spot_ros). This package currently corresponds to version 4.1.0 of the [spot-sdk](https://github.com/boston-dynamics/spot-sdk/releases/tag/v4.1.0).
 
 ## Prerequisites
 This package is tested for Ubuntu 22.04 and ROS 2 Humble, which can be installed following [this guide](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html). 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="spot.png" width="350">
   <h1 align="center">Spot ROS 2 Driver</h1>
   <p align="center">
-    <img src="https://img.shields.io/badge/python-3.8|3.9|3.10-blue"/>
+    <img src="https://img.shields.io/badge/python-3.10-blue"/>
     <a href="https://github.com/astral-sh/ruff">
       <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json"/>
     </a>

--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -1,5 +1,5 @@
 ARCH="amd64"
-SDK_VERSION="4.0.2"
+SDK_VERSION="4.1.0"
 MSG_VERSION="${SDK_VERSION}"
 ROS_DISTRO=humble
 HELP=$'--arm64: Installs ARM64 version'

--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -1,6 +1,6 @@
 ARCH="amd64"
 SDK_VERSION="4.1.0"
-MSG_VERSION="${SDK_VERSION}-2"
+MSG_VERSION="${SDK_VERSION}-3"
 ROS_DISTRO=humble
 HELP=$'--arm64: Installs ARM64 version'
 REQUIREMENTS_FILE=spot_wrapper/requirements.txt

--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -1,6 +1,6 @@
 ARCH="amd64"
 SDK_VERSION="4.1.0"
-MSG_VERSION="${SDK_VERSION}-1"
+MSG_VERSION="${SDK_VERSION}-2"
 ROS_DISTRO=humble
 HELP=$'--arm64: Installs ARM64 version'
 REQUIREMENTS_FILE=spot_wrapper/requirements.txt

--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -1,6 +1,6 @@
 ARCH="amd64"
 SDK_VERSION="4.1.0"
-MSG_VERSION="${SDK_VERSION}-3"
+MSG_VERSION="${SDK_VERSION}-4"
 ROS_DISTRO=humble
 HELP=$'--arm64: Installs ARM64 version'
 REQUIREMENTS_FILE=spot_wrapper/requirements.txt

--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -1,6 +1,6 @@
 ARCH="amd64"
 SDK_VERSION="4.1.0"
-MSG_VERSION="${SDK_VERSION}"
+MSG_VERSION="${SDK_VERSION}-1"
 ROS_DISTRO=humble
 HELP=$'--arm64: Installs ARM64 version'
 REQUIREMENTS_FILE=spot_wrapper/requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 line-length = 120
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-target-version = "py38"
+target-version = "py310"
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
@@ -39,7 +39,7 @@ max-complexity = 10
 
 [tool.black]
 line-length = 120
-target-version = ['py38']
+target-version = ['py310']
 include = '\.pyi?$'
 force-exclude = '''
 /(
@@ -48,7 +48,7 @@ force-exclude = '''
 preview = true
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 disallow_untyped_defs = true
 ignore_missing_imports = true
 explicit_package_bases = true

--- a/spot_driver/CMakeLists.txt
+++ b/spot_driver/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
 
-list(APPEND CMAKE_PREFIX_PATH /opt/spot-cpp-sdk)
-
 project(spot_driver)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -18,6 +16,7 @@ endif()
 
 set(THIS_PACKAGE_INCLUDE_ROS_DEPENDS
   bosdyn_api_msgs
+  bosdyn_cmake_module
   bosdyn_spot_api_msgs
   cv_bridge
   geometry_msgs
@@ -36,11 +35,13 @@ set(THIS_PACKAGE_INCLUDE_ROS_DEPENDS
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
-find_package(bosdyn REQUIRED)
-find_package(OpenCV 4 REQUIRED)
+
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_ROS_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
+
+find_package(bosdyn REQUIRED)
+find_package(OpenCV 4 REQUIRED)
 
 ###
 # Spot API
@@ -85,7 +86,7 @@ target_include_directories(spot_api PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(spot_api PUBLIC bosdyn::bosdyn_client_static)
+target_link_libraries(spot_api PUBLIC bosdyn::bosdyn_client)
 set_property(TARGET spot_api PROPERTY POSITION_INDEPENDENT_CODE ON)
 ament_target_dependencies(spot_api PUBLIC ${THIS_PACKAGE_INCLUDE_ROS_DEPENDS})
 

--- a/spot_driver/package.xml
+++ b/spot_driver/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>bosdyn</depend>
+  <depend>bosdyn_cmake_module</depend>
   <depend>bosdyn_msgs</depend>
   <depend>common_interfaces</depend>
   <depend>cv_bridge</depend>

--- a/spot_ros2_control/CMakeLists.txt
+++ b/spot_ros2_control/CMakeLists.txt
@@ -5,9 +5,6 @@ cmake_minimum_required(VERSION 3.22)
 # This is here so we can use jthread from C++ 20
 set(CMAKE_CXX_STANDARD 20)
 
-# Taken from spot_driver CMakeLists
-list(APPEND CMAKE_PREFIX_PATH /opt/spot-cpp-sdk)
-
 project(spot_ros2_control)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -16,8 +13,8 @@ endif()
 
 # Dependencies
 find_package(ament_cmake REQUIRED)
-find_package(bosdyn REQUIRED)
 set(THIS_PACKAGE_INCLUDE_DEPENDS
+  bosdyn_cmake_module
   hardware_interface
   controller_manager
   pluginlib
@@ -31,6 +28,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
+find_package(bosdyn REQUIRED)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -51,7 +49,7 @@ target_include_directories(spot_ros2_control PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/hardware/include>
   $<INSTALL_INTERFACE:include/spot_ros2_control>
 )
-target_link_libraries(spot_ros2_control PUBLIC bosdyn::bosdyn_client_static)
+target_link_libraries(spot_ros2_control PUBLIC bosdyn::bosdyn_client)
 ament_target_dependencies(
   spot_ros2_control PUBLIC
   ${THIS_PACKAGE_INCLUDE_DEPENDS}

--- a/spot_ros2_control/hardware/src/spot_hardware_interface.cpp
+++ b/spot_ros2_control/hardware/src/spot_hardware_interface.cpp
@@ -487,8 +487,10 @@ bool SpotHardware::start_command_stream() {
       return false;
   }
 
-  joint_cmd->mutable_gains()->mutable_k_q_p()->Assign(kp.begin(), kp.end());
-  joint_cmd->mutable_gains()->mutable_k_qd_p()->Assign(kd.begin(), kd.end());
+  joint_cmd->mutable_gains()->mutable_k_q_p()->Clear();
+  joint_cmd->mutable_gains()->mutable_k_q_p()->Add(kp.begin(), kp.end());
+  joint_cmd->mutable_gains()->mutable_k_qd_p()->Clear();
+  joint_cmd->mutable_gains()->mutable_k_qd_p()->Add(kd.begin(), kd.end());
 
   // Let it extrapolate the command a little
   joint_cmd->mutable_extrapolation_duration()->CopyFrom(
@@ -518,9 +520,12 @@ void SpotHardware::send_command(const JointStates& joint_commands) {
   // build protobuf
   auto* joint_cmd = joint_request_.mutable_joint_command();
 
-  joint_cmd->mutable_position()->Assign(position.begin(), position.end());
-  joint_cmd->mutable_velocity()->Assign(velocity.begin(), velocity.end());
-  joint_cmd->mutable_load()->Assign(load.begin(), load.end());
+  joint_cmd->mutable_position()->Clear();
+  joint_cmd->mutable_position()->Add(position.begin(), position.end());
+  joint_cmd->mutable_velocity()->Clear();
+  joint_cmd->mutable_velocity()->Add(velocity.begin(), velocity.end());
+  joint_cmd->mutable_load()->Clear();
+  joint_cmd->mutable_load()->Add(load.begin(), load.end());
 
   if (endpoint_ == nullptr) {
     auto endpoint_result = robot_->StartTimeSyncAndGetEndpoint();

--- a/spot_ros2_control/package.xml
+++ b/spot_ros2_control/package.xml
@@ -17,6 +17,7 @@ Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>bosdyn</depend>
+  <depend>bosdyn_cmake_module</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
 


### PR DESCRIPTION
## Change Overview

Precisely what the title says. This patch updates both C++ and Python SDKs, as well as `bosdyn_msgs`  for ROS 2 integration.

## Testing Done

Relying on CI and downstream tests.
