### PR TITLE
[SW-1465] Fix image stitching for greyscale images

### DIFF
--- a/spot_driver/src/image_stitcher/image_stitcher.cpp
+++ b/spot_driver/src/image_stitcher/image_stitcher.cpp
@@ -327,8 +327,8 @@ Image::SharedPtr MiddleCamera::stitch(const std::shared_ptr<const Image>& left,
   // While the image is coming from the camera on the left of the robot, it sees the right side
   // of the scene and vice versa. This may need to be extracted if this code is to be generalized
   // for something other than the Boston Dynamics Spot Robot, as well as checking the homographies.
-  const auto scene_right = cv_bridge::toCvShare(left);
-  const auto scene_left = cv_bridge::toCvShare(right);
+  const auto scene_right = cv_bridge::toCvShare(left, sensor_msgs::image_encodings::BGR8);
+  const auto scene_left = cv_bridge::toCvShare(right, sensor_msgs::image_encodings::BGR8);
 
   // Transform the images into the virtual center camera space
   cv::warpPerspective(scene_left->image, warped_images_[0], homography_[0], result_size_);


### PR DESCRIPTION
## Change Overview

Image stitcher currently crashes if run on a spot with greyscale cameras, this should resolve that error.
See: https://github.com/bdaiinstitute/spot_ros2/issues/448

## Testing Done

- [x] image stitcher on a spot with RGB cameras still works as expected
- [x] image stitcher on a spot with greyscale cameras doesn't crash and produces meaningful stitched images.