### PR TITLE
[SW-1466] ability to take joint gains in through a parameter file

### DIFF
--- a/spot_description/urdf/spot.ros2_control.xacro
+++ b/spot_description/urdf/spot.ros2_control.xacro
@@ -20,10 +20,6 @@
                 <param name="min">${-effort_max}</param>
                 <param name="max">${effort_max}</param>
             </command_interface>
-            <!-- TODO at some point, this should be a part of the command interface so we can have a 
-            one-to-one mapping to the spot sdk implementation. -->
-            <!-- <command_interface name="k_q_p" />
-            <command_interface name="k_qd_p" /> -->
         </joint>
     </xacro:macro>
 
@@ -65,7 +61,7 @@
 
     </xacro:macro>
 
-    <xacro:macro name="spot_ros2_control" params="interface_type has_arm hostname username password tf_prefix">
+    <xacro:macro name="spot_ros2_control" params="interface_type has_arm hostname username password tf_prefix kp kd">
         <!-- Currently implements a simple system interface that covers all joints of the robot.
         In the future, we could make different hardware interfaces for the body, arm, etc. -->
         <ros2_control name="SpotSystem" type="system">
@@ -80,6 +76,8 @@
                 <param name="hostname">$(optenv SPOT_IP ${hostname})</param>
                 <param name="username">$(optenv BOSDYN_CLIENT_USERNAME ${username})</param>
                 <param name="password">$(optenv BOSDYN_CLIENT_PASSWORD ${password})</param>
+                <param name="kp">${kp}</param>
+                <param name="kd">${kd}</param>
             </xacro:if>
             </hardware>
             <!-- Add the legs -->

--- a/spot_description/urdf/spot.ros2_control.xacro
+++ b/spot_description/urdf/spot.ros2_control.xacro
@@ -61,7 +61,7 @@
 
     </xacro:macro>
 
-    <xacro:macro name="spot_ros2_control" params="interface_type has_arm hostname username password tf_prefix kp kd">
+    <xacro:macro name="spot_ros2_control" params="interface_type has_arm hostname username password tf_prefix k_q_p k_qd_p">
         <!-- Currently implements a simple system interface that covers all joints of the robot.
         In the future, we could make different hardware interfaces for the body, arm, etc. -->
         <ros2_control name="SpotSystem" type="system">
@@ -76,8 +76,8 @@
                 <param name="hostname">$(optenv SPOT_IP ${hostname})</param>
                 <param name="username">$(optenv BOSDYN_CLIENT_USERNAME ${username})</param>
                 <param name="password">$(optenv BOSDYN_CLIENT_PASSWORD ${password})</param>
-                <param name="kp">${kp}</param>
-                <param name="kd">${kd}</param>
+                <param name="k_q_p">${k_q_p}</param>
+                <param name="k_qd_p">${k_qd_p}</param>
             </xacro:if>
             </hardware>
             <!-- Add the legs -->

--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -17,8 +17,8 @@
   <xacro:arg name="hostname" default="10.0.0.3" />
   <xacro:arg name="username" default="username" />
   <xacro:arg name="password" default="password" />
-  <xacro:arg name="kp" default="" />
-  <xacro:arg name="kd" default="" />
+  <xacro:arg name="k_q_p" default="" />
+  <xacro:arg name="k_qd_p" default="" />
 
   <!-- Load Spot -->
   <xacro:load_spot
@@ -34,8 +34,8 @@
                                username="$(arg username)" 
                                password="$(arg password)" 
                                tf_prefix="$(arg tf_prefix)" 
-                               kd="$(arg kd)" 
-                               kp="$(arg kp)" />
+                               k_q_p="$(arg k_q_p)" 
+                               k_qd_p="$(arg k_qd_p)" />
   </xacro:if>
 
 </robot>

--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -14,10 +14,11 @@
   <!-- Parameters for ROS 2 control -->
   <xacro:arg name="add_ros2_control_tag" default="false" />
   <xacro:arg name="hardware_interface_type" default="mock" />
-  <xacro:arg name="tf_prefix" default="" />
   <xacro:arg name="hostname" default="10.0.0.3" />
   <xacro:arg name="username" default="username" />
   <xacro:arg name="password" default="password" />
+  <xacro:arg name="kp" default="" />
+  <xacro:arg name="kd" default="" />
 
   <!-- Load Spot -->
   <xacro:load_spot
@@ -32,7 +33,9 @@
                                hostname="$(arg hostname)" 
                                username="$(arg username)" 
                                password="$(arg password)" 
-                               tf_prefix="$(arg tf_prefix)" />
+                               tf_prefix="$(arg tf_prefix)" 
+                               kd="$(arg kd)" 
+                               kp="$(arg kp)" />
   </xacro:if>
 
 </robot>

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_constants.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_constants.hpp
@@ -26,8 +26,8 @@ inline constexpr int kNjointsNoArm = 12;
 /// @brief Number of joints we expect if the robot has an arm
 inline constexpr int kNjointsArm = 19;
 
-// Gain values https://github.com/boston-dynamics/spot-cpp-sdk/blob/master/cpp/examples/joint_control/constants.hpp
-// This will be handled via a parameter in the future so there is the option to change them, for now they are hardcoded
+// Default gain values obtained from
+// https://github.com/boston-dynamics/spot-cpp-sdk/blob/master/cpp/examples/joint_control/constants.hpp
 
 /// @brief Default k_q_p gains for robot without an arm
 inline constexpr float kDefaultKqpNoArm[] = {624.0, 936.0, 286.0, 624.0, 936.0, 286.0,
@@ -36,11 +36,13 @@ inline constexpr float kDefaultKqpNoArm[] = {624.0, 936.0, 286.0, 624.0, 936.0, 
 /// @brief Default k_qd_p gains for robot without an arm
 inline constexpr float kDefaultKqdpNoArm[] = {5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04};
 
-/// @brief Default k_q_p gains for robot with an arm
+/// @brief Default k_q_p gains for robot with an arm (note that the first 12 elements that correspond to the leg joints
+/// are the same as `kDefaultKqpNoArm`)
 inline constexpr float kDefaultKqpArm[] = {624.0, 936.0, 286.0,  624.0, 936.0, 286.0, 624.0, 936.0, 286.0, 624.0,
                                            936.0, 286.0, 1020.0, 255.0, 204.0, 102.0, 102.0, 102.0, 16.0};
 
-/// @brief Default k_qd_p gains for robot with an arm
+/// @brief Default k_qd_p gains for robot with an arm (note that the first 12 elements that correspond to the leg joints
+/// are the same as `kDefaultKqdpNoArm`)
 inline constexpr float kDefaultKqdpArm[] = {5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20,
                                             5.20, 2.04, 10.2, 15.3, 10.2, 2.04, 2.04, 2.04, 0.32};
 

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_constants.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_constants.hpp
@@ -29,19 +29,19 @@ inline constexpr int kNjointsArm = 19;
 // Gain values https://github.com/boston-dynamics/spot-cpp-sdk/blob/master/cpp/examples/joint_control/constants.hpp
 // This will be handled via a parameter in the future so there is the option to change them, for now they are hardcoded
 
-/// @brief Default Kp gains for robot without an arm
-inline constexpr float kDefaultKpNoArm[] = {624.0, 936.0, 286.0, 624.0, 936.0, 286.0,
-                                            624.0, 936.0, 286.0, 624.0, 936.0, 286.0};
+/// @brief Default k_q_p gains for robot without an arm
+inline constexpr float kDefaultKqpNoArm[] = {624.0, 936.0, 286.0, 624.0, 936.0, 286.0,
+                                             624.0, 936.0, 286.0, 624.0, 936.0, 286.0};
 
-/// @brief Default Kd gains for robot without an arm
-inline constexpr float kDefaultKdNoArm[] = {5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04};
+/// @brief Default k_qd_p gains for robot without an arm
+inline constexpr float kDefaultKqdpNoArm[] = {5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04};
 
-/// @brief Default Kp gains for robot with an arm
-inline constexpr float kDefaultKpArm[] = {624.0, 936.0, 286.0,  624.0, 936.0, 286.0, 624.0, 936.0, 286.0, 624.0,
-                                          936.0, 286.0, 1020.0, 255.0, 204.0, 102.0, 102.0, 102.0, 16.0};
+/// @brief Default k_q_p gains for robot with an arm
+inline constexpr float kDefaultKqpArm[] = {624.0, 936.0, 286.0,  624.0, 936.0, 286.0, 624.0, 936.0, 286.0, 624.0,
+                                           936.0, 286.0, 1020.0, 255.0, 204.0, 102.0, 102.0, 102.0, 16.0};
 
-/// @brief Default Kd gains for robot with an arm
-inline constexpr float kDefaultKdArm[] = {5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20,
-                                          5.20, 2.04, 10.2, 15.3, 10.2, 2.04, 2.04, 2.04, 0.32};
+/// @brief Default k_qd_p gains for robot with an arm
+inline constexpr float kDefaultKqdpArm[] = {5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20,
+                                            5.20, 2.04, 10.2, 15.3, 10.2, 2.04, 2.04, 2.04, 0.32};
 
 }  // namespace spot_hardware_interface

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -20,6 +20,7 @@
 
 #include <functional>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -127,6 +128,9 @@ class SpotHardware : public hardware_interface::SystemInterface {
   std::string hostname_;
   std::string username_;
   std::string password_;
+
+  std::vector<float> kp_;
+  std::vector<float> kd_;
 
   // Power status
   bool powered_on_ = false;

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -162,6 +162,17 @@ class SpotHardware : public hardware_interface::SystemInterface {
 
   ::bosdyn::api::JointControlStreamRequest joint_request_;
 
+  /// @brief Gains are passed in as hardware parameters as a space separated string. This function translates this
+  /// information into the corresponding std::vector to be used in constructing the robot streaming command.
+  /// @param gain_string Space separated string of k_q_p or k_qd_p values  -- e.g., "1.0 2.0 3.0"
+  /// @param default_gains Vector of default gains to fall back to if the input is not formatted correctly.
+  /// @param gain_name Human readable name of the parameter parsed -- e.g., "k_q_p". Used in logging a warning if the
+  /// input is malformed.
+  /// @return The input gain_string formatted as an std::vector if it is the appropriate number of elements, and
+  /// default_gains if not.
+  std::vector<float> parse_gains_parameter(const std::string gains_string, const std::vector<float>& default_gains,
+                                           const std::string gain_name);
+
   // The following are functions that interact with the BD SDK to set up the robot and get the robot states.
 
   /**

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -129,8 +129,9 @@ class SpotHardware : public hardware_interface::SystemInterface {
   std::string username_;
   std::string password_;
 
-  std::vector<float> kp_;
-  std::vector<float> kd_;
+  // Stores gains to be used in the joint level command
+  std::vector<float> k_q_p_;
+  std::vector<float> k_qd_p_;
 
   // Power status
   bool powered_on_ = false;

--- a/spot_hardware_interface/src/spot_hardware_interface.cpp
+++ b/spot_hardware_interface/src/spot_hardware_interface.cpp
@@ -60,6 +60,12 @@ hardware_interface::CallbackReturn SpotHardware::on_init(const hardware_interfac
   username_ = info_.hardware_parameters["username"];
   password_ = info_.hardware_parameters["password"];
 
+  const auto kp = info_.hardware_parameters["kp"];
+  const auto kd = info_.hardware_parameters["kd"];
+
+  std::cout << "\n\n\n\n\nKP " << kp << std::endl;
+  std::cout << "\n\n\n\n\nKD " << kd << std::endl;
+
   hw_states_.resize(info_.joints.size() * interfaces_per_joint_, std::numeric_limits<double>::quiet_NaN());
   hw_commands_.resize(info_.joints.size() * interfaces_per_joint_, std::numeric_limits<double>::quiet_NaN());
 

--- a/spot_hardware_interface/src/spot_hardware_interface.cpp
+++ b/spot_hardware_interface/src/spot_hardware_interface.cpp
@@ -77,25 +77,23 @@ hardware_interface::CallbackReturn SpotHardware::on_init(const hardware_interfac
     if (kp_.size() != kNjointsArm) {
       RCLCPP_WARN(rclcpp::get_logger("SpotHardware"), "Kp has %ld entries, expected %d. Falling back to default gains.",
                   kp_.size(), kNjointsArm);
-      kp_.assign(std::begin(spot_hardware_interface::kDefaultKpArm), std::end(spot_hardware_interface::kDefaultKpArm));
+      kp_.assign(std::begin(kDefaultKpArm), std::end(kDefaultKpArm));
     }
     if (kd_.size() != kNjointsArm) {
       RCLCPP_WARN(rclcpp::get_logger("SpotHardware"), "Kd has %ld entries, expected %d. Falling back to default gains.",
                   kd_.size(), kNjointsArm);
-      kd_.assign(std::begin(spot_hardware_interface::kDefaultKdArm), std::end(spot_hardware_interface::kDefaultKdArm));
+      kd_.assign(std::begin(kDefaultKdArm), std::end(kDefaultKdArm));
     }
   } else if (njoints_ == kNjointsNoArm) {
     if (kp_.size() != kNjointsNoArm) {
       RCLCPP_WARN(rclcpp::get_logger("SpotHardware"), "Kp has %ld entries, expected %d. Falling back to default gains.",
                   kp_.size(), kNjointsNoArm);
-      kp_.assign(std::begin(spot_hardware_interface::kDefaultKpNoArm),
-                 std::end(spot_hardware_interface::kDefaultKpNoArm));
+      kp_.assign(std::begin(kDefaultKpNoArm), std::end(kDefaultKpNoArm));
     }
     if (kd_.size() != kNjointsNoArm) {
       RCLCPP_WARN(rclcpp::get_logger("SpotHardware"), "Kd has %ld entries, expected %d. Falling back to default gains.",
                   kd_.size(), kNjointsArm);
-      kd_.assign(std::begin(spot_hardware_interface::kDefaultKdNoArm),
-                 std::end(spot_hardware_interface::kDefaultKdNoArm));
+      kd_.assign(std::begin(kDefaultKdNoArm), std::end(kDefaultKdNoArm));
     }
   } else {
     RCLCPP_ERROR(rclcpp::get_logger("SpotHardware"),

--- a/spot_hardware_interface/src/spot_hardware_interface.cpp
+++ b/spot_hardware_interface/src/spot_hardware_interface.cpp
@@ -61,26 +61,26 @@ hardware_interface::CallbackReturn SpotHardware::on_init(const hardware_interfac
   password_ = info_.hardware_parameters["password"];
 
   // Get the user-passed in KP and KD values.
-  const auto kp_string = info_.hardware_parameters["kp"];
-  const auto kd_string = info_.hardware_parameters["kd"];
-  std::istringstream kp_stream(kp_string);
-  kp_.assign(std::istream_iterator<float>(kp_stream), std::istream_iterator<float>());
-  std::istringstream kd_stream(kd_string);
-  kd_.assign(std::istream_iterator<float>(kd_stream), std::istream_iterator<float>());
+  const auto k_q_p_string = info_.hardware_parameters["k_q_p"];
+  const auto k_qd_p_string = info_.hardware_parameters["k_qd_p"];
+  std::istringstream k_q_p_stream(k_q_p_string);
+  k_q_p_.assign(std::istream_iterator<float>(k_q_p_stream), std::istream_iterator<float>());
+  std::istringstream k_qd_p_stream(k_qd_p_string);
+  k_qd_p_.assign(std::istream_iterator<float>(k_qd_p_stream), std::istream_iterator<float>());
 
   hw_states_.resize(info_.joints.size() * interfaces_per_joint_, std::numeric_limits<double>::quiet_NaN());
   hw_commands_.resize(info_.joints.size() * interfaces_per_joint_, std::numeric_limits<double>::quiet_NaN());
 
   njoints_ = hw_states_.size() / interfaces_per_joint_;
 
-  // check that the number of joints matches what we expect, and determine default kp/kd from this
-  std::vector<float> default_kp, default_kd;
+  // check that the number of joints matches what we expect, and determine default k_q_p/k_qd_p from this
+  std::vector<float> default_k_q_p, default_k_qd_p;
   if (njoints_ == kNjointsArm) {
-    default_kp.assign(std::begin(kDefaultKpArm), std::end(kDefaultKpArm));
-    default_kd.assign(std::begin(kDefaultKdArm), std::end(kDefaultKdArm));
+    default_k_q_p.assign(std::begin(kDefaultKqpArm), std::end(kDefaultKqpArm));
+    default_k_qd_p.assign(std::begin(kDefaultKqdpArm), std::end(kDefaultKqdpArm));
   } else if (njoints_ == kNjointsNoArm) {
-    default_kp.assign(std::begin(kDefaultKpNoArm), std::end(kDefaultKpNoArm));
-    default_kd.assign(std::begin(kDefaultKdNoArm), std::end(kDefaultKdNoArm));
+    default_k_q_p.assign(std::begin(kDefaultKqpNoArm), std::end(kDefaultKqpNoArm));
+    default_k_qd_p.assign(std::begin(kDefaultKqdpNoArm), std::end(kDefaultKqdpNoArm));
   } else {
     RCLCPP_ERROR(rclcpp::get_logger("SpotHardware"),
                  "Got %ld joints, expected either %d (Spot with arm) or %d (Spot without arm)!!", njoints_, kNjointsArm,
@@ -89,23 +89,23 @@ hardware_interface::CallbackReturn SpotHardware::on_init(const hardware_interfac
   }
 
   // Check if the gains are the correct size given the defaults, and fall back to defaults if not.
-  // If no parameter is specified, the defaults will automatically be used as kp_ and kd_ will be of size 0.
-  if (kp_.size() != njoints_) {
-    if (!kp_.empty()) {
+  // If no parameter is specified, the defaults will automatically be used as k_q_p_ and k_qd_p_ will be of size 0.
+  if (k_q_p_.size() != njoints_) {
+    if (!k_q_p_.empty()) {
       RCLCPP_WARN(rclcpp::get_logger("SpotHardware"),
                   "Kp has %ld entries, expected %ld. Check your config file! Falling back to default gains.",
-                  kp_.size(), njoints_);
+                  k_q_p_.size(), njoints_);
     }
-    kp_.assign(std::begin(default_kp), std::end(default_kp));
+    k_q_p_.assign(std::begin(default_k_q_p), std::end(default_k_q_p));
   }
 
-  if (kd_.size() != njoints_) {
-    if (!kd_.empty()) {
+  if (k_qd_p_.size() != njoints_) {
+    if (!k_qd_p_.empty()) {
       RCLCPP_WARN(rclcpp::get_logger("SpotHardware"),
                   "Kd has %ld entries, expected %ld. Check your config file! Falling back to default gains.",
-                  kd_.size(), njoints_);
+                  k_qd_p_.size(), njoints_);
     }
-    kd_.assign(std::begin(default_kd), std::end(default_kd));
+    k_qd_p_.assign(std::begin(default_k_qd_p), std::end(default_k_qd_p));
   }
 
   for (const hardware_interface::ComponentInfo& joint : info_.joints) {
@@ -513,9 +513,9 @@ bool SpotHardware::start_command_stream() {
   auto* joint_cmd = joint_request_.mutable_joint_command();
 
   joint_cmd->mutable_gains()->mutable_k_q_p()->Clear();
-  joint_cmd->mutable_gains()->mutable_k_q_p()->Add(kp_.begin(), kp_.end());
+  joint_cmd->mutable_gains()->mutable_k_q_p()->Add(k_q_p_.begin(), k_q_p_.end());
   joint_cmd->mutable_gains()->mutable_k_qd_p()->Clear();
-  joint_cmd->mutable_gains()->mutable_k_qd_p()->Add(kd_.begin(), kd_.end());
+  joint_cmd->mutable_gains()->mutable_k_qd_p()->Add(k_qd_p_.begin(), k_qd_p_.end());
 
   // Let it extrapolate the command a little
   joint_cmd->mutable_extrapolation_duration()->CopyFrom(

--- a/spot_ros2_control/README.md
+++ b/spot_ros2_control/README.md
@@ -24,6 +24,14 @@ You can then run the launchfile with the following command:
 ros2 launch spot_ros2_control spot_ros2_control.launch.py hardware_interface:=robot config_file:=path/to/spot_ros.yaml
 ```
 
+Joint level gains can also be specified in this same config file under the parameter names `k_q_p` and `k_qd_p`. If you do not specify these parameters, the default gains from the `spot-sdk` joint control examples are used during command streaming. The example below shows a valid configuration for a robot with an arm as each list contains 19 elements. More information on how these gains are used by Spot can be found [here](https://dev.bostondynamics.com/docs/concepts/joint_control/readme).
+```
+/**:
+  ros__parameters:
+    k_q_p: [624.0, 936.0, 286.0,  624.0, 936.0, 286.0, 624.0, 936.0, 286.0, 624.0, 936.0, 286.0, 1020.0, 255.0, 204.0, 102.0, 102.0, 102.0, 16.0]
+    k_qd_p: [5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 10.2, 15.3, 10.2, 2.04, 2.04, 2.04, 0.32]
+```
+
 If you wish to launch these nodes in a namespace, add the argument `spot_name:=<Robot Name>`.
 
 This hardware interface will stream the joint angles of the robot at 333 Hz onto the topic `/<Robot Name>/low_level/joint_states`.

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -20,8 +20,8 @@ from launch_ros.substitutions import FindPackageShare
 from spot_driver.launch.spot_launch_helpers import (
     IMAGE_PUBLISHER_ARGS,
     declare_image_publisher_args,
-    get_ros_param_dict,
     get_login_parameters,
+    get_ros_param_dict,
     spot_has_arm,
 )
 
@@ -107,19 +107,15 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
 
     # If connected to a physical robot, query if it has an arm. Otherwise, use the value in mock_arm.
     if hardware_interface == "robot":
-        # arm = spot_has_arm(config_file_path=config_file, spot_name="")
-        arm = True
-        # username, password, hostname = get_login_parameters(config_file)[:3]
-        username = "user"
-        password = "password"
-        hostname = "hostname"
+        arm = spot_has_arm(config_file_path=config_file, spot_name="")
+        username, password, hostname = get_login_parameters(config_file)[:3]
         login_params = f" hostname:={hostname} username:={username} password:={password} "
         param_dict = get_ros_param_dict(config_file)
         gains_str = ""
         if "kp" in param_dict and "kd" in param_dict:
             kp = " ".join(map(str, param_dict["kp"]))
             kd = " ".join(map(str, param_dict["kd"]))
-            gains_str = f"kp:=\"{kp}\" kd:=\"{kd}\" "
+            gains_str = f'kp:="{kp}" kd:="{kd}" '
     else:
         arm = mock_arm
         login_params = ""

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -121,10 +121,10 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
             # of its hardware parameters as strings and reduces the amount of parsing necessary there.
             # eg: k_q_p: [1, 2, 3] in the config file will get translated to the string "1 2 3" here
             k_q_p = " ".join(map(str, param_dict["k_q_p"]))
-            gain_params += f'k_q_p:="{k_q_p}" '
+            gain_params += f' k_q_p:="{k_q_p}"'
         if "k_qd_p" in param_dict:
             k_qd_p = " ".join(map(str, param_dict["k_qd_p"]))
-            gain_params += f'k_qd_p:="{k_qd_p}" '
+            gain_params += f' k_qd_p:="{k_qd_p}"'
 
     tf_prefix = f"{spot_name}/" if spot_name else ""
 

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -117,8 +117,8 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
         param_dict = get_ros_param_dict(config_file)
         gains_str = ""
         if "kp" in param_dict and "kd" in param_dict:
-            kp = ' '.join(map(str, param_dict["kp"]))
-            kd = ' '.join(map(str, param_dict["kd"]))
+            kp = " ".join(map(str, param_dict["kp"]))
+            kd = " ".join(map(str, param_dict["kd"]))
             gains_str = f"kp:=\"{kp}\" kd:=\"{kd}\" "
     else:
         arm = mock_arm

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -117,14 +117,14 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
         login_params = f" hostname:={hostname} username:={username} password:={password} "
         param_dict = get_ros_param_dict(config_file)
         if "k_q_p" in param_dict:
-            # we pass the gains to the xacro as space-separated strings as the hardware interface already reads in all
-            # of its hardware parameters as strings and reduces the amount of parsing necessary there.
+            # we pass the gains to the xacro as space-separated strings as the hardware interface needs to read in all
+            # of its hardware parameters as strings, and it is easier to parse them out from the config file here.
             # eg: k_q_p: [1, 2, 3] in the config file will get translated to the string "1 2 3" here
             k_q_p = " ".join(map(str, param_dict["k_q_p"]))
-            gain_params += f' k_q_p:="{k_q_p}"'
+            gain_params += f' k_q_p:="{k_q_p}" '
         if "k_qd_p" in param_dict:
             k_qd_p = " ".join(map(str, param_dict["k_qd_p"]))
-            gain_params += f' k_qd_p:="{k_qd_p}"'
+            gain_params += f' k_qd_p:="{k_qd_p}" '
 
     tf_prefix = f"{spot_name}/" if spot_name else ""
 

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -116,15 +116,15 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
         username, password, hostname = get_login_parameters(config_file)[:3]
         login_params = f" hostname:={hostname} username:={username} password:={password} "
         param_dict = get_ros_param_dict(config_file)
-        if "kp" in param_dict:
+        if "k_q_p" in param_dict:
             # we pass the gains to the xacro as space-separated strings as the hardware interface already reads in all
             # of its hardware parameters as strings and reduces the amount of parsing necessary there.
-            # eg: kp: [1, 2, 3] in the config file will get translated to the string "1 2 3" here
-            kp = " ".join(map(str, param_dict["kp"]))
-            gain_params += f'kp:="{kp}" '
-        if "kd" in param_dict:
-            kd = " ".join(map(str, param_dict["kd"]))
-            gain_params += f'kd:="{kd}" '
+            # eg: k_q_p: [1, 2, 3] in the config file will get translated to the string "1 2 3" here
+            k_q_p = " ".join(map(str, param_dict["k_q_p"]))
+            gain_params += f'k_q_p:="{k_q_p}" '
+        if "k_qd_p" in param_dict:
+            k_qd_p = " ".join(map(str, param_dict["k_qd_p"]))
+            gain_params += f'k_qd_p:="{k_qd_p}" '
 
     tf_prefix = f"{spot_name}/" if spot_name else ""
 

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -20,6 +20,7 @@ from launch_ros.substitutions import FindPackageShare
 from spot_driver.launch.spot_launch_helpers import (
     IMAGE_PUBLISHER_ARGS,
     declare_image_publisher_args,
+    get_ros_param_dict,
     get_login_parameters,
     spot_has_arm,
 )
@@ -106,9 +107,19 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
 
     # If connected to a physical robot, query if it has an arm. Otherwise, use the value in mock_arm.
     if hardware_interface == "robot":
-        arm = spot_has_arm(config_file_path=config_file, spot_name="")
-        username, password, hostname = get_login_parameters(config_file)[:3]
-        login_params = f" hostname:={hostname} username:={username} password:={password}"
+        # arm = spot_has_arm(config_file_path=config_file, spot_name="")
+        arm = True
+        # username, password, hostname = get_login_parameters(config_file)[:3]
+        username = "user"
+        password = "password"
+        hostname = "hostname"
+        login_params = f" hostname:={hostname} username:={username} password:={password} "
+        param_dict = get_ros_param_dict(config_file)
+        gains_str = ""
+        if "kp" in param_dict and "kd" in param_dict:
+            kp = ' '.join(map(str, param_dict["kp"]))
+            kd = ' '.join(map(str, param_dict["kd"]))
+            gains_str = f"kp:=\"{kp}\" kd:=\"{kd}\" "
     else:
         arm = mock_arm
         login_params = ""
@@ -128,8 +139,10 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
             " hardware_interface_type:=",
             LaunchConfiguration("hardware_interface"),
             login_params,
+            gains_str,
         ]
     )
+    # print(robot_urdf.perform(context))
     robot_description = {"robot_description": robot_urdf}
 
     # If no controller config file is selected, use the appropriate default. Else, just use the yaml that is passed in.


### PR DESCRIPTION
## Change Overview

1. standardizes gain names in the hardware interface to `k_q_p` and `k_qd_p`, same as spot sdk (https://dev.bostondynamics.com/docs/concepts/joint_control/readme)

2. allows taking in `k_q_p` and `k_qd_p` through a a parameter file. If you have a yaml that looks like this
```
/**:
  ros__parameters:
    k_q_p: [624.0, 936.0, 286.0,  624.0, 936.0, 286.0, 624.0, 936.0, 286.0, 624.0, 936.0, 286.0, 1020.0, 255.0, 204.0, 102.0, 102.0, 102.0, 16.0]
    k_qd_p: [5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 10.2, 15.3, 10.2, 2.04, 2.04, 2.04, 0.32]
```
and pass it to the `spot_ros2_control.launch.py` launchfile with the arg `config_file:=<file path>`, these gains will get used in the hardware interface to stream commands.
[Because ros2 control hardware interfaces don't have "true" support for parameters, ](https://github.com/ros-controls/ros2_control/issues/347)the gains have to be passed in as a [string through the xacro](https://github.com/ros-controls/ros2_control/blob/cb91599f8f66aaf39b7485a2f7e131157f633474/hardware_interface/include/hardware_interface/hardware_info.hpp#L182), so this also adds a helper function to assist with this conversion back to a usable vector. 

edge case handling:
1. if either of these params isn't set (or no config file is specified) then the default gains are used. 
2. if either the gain lists defined in the parameter file is the wrong number of elements, the hardware interface will fall back to using the default gains, and a warning will be logged about this.

## Testing Done

* The wiggle arm example has some slightly jerky gripper motion using the default gains.
I changed the `k_qd_p` gain for the gripper joint in my parameter file from `0.32` to `1.32` and reran the example, and the gripper looked a lot smoother. 

* Checked edge case handling manually 

### Next steps

The function to translate the gains as a string into a usable vector in the hardware interface should get unit tested (SW-1148)