### PR TITLE
[SW-1507] gripperless URDF for Spot

### DIFF
--- a/spot_description/launch/description.launch.py
+++ b/spot_description/launch/description.launch.py
@@ -40,6 +40,12 @@ def generate_launch_description() -> launch.LaunchDescription:
                 description="Flag to enable putting frames at the feet",
             ),
             DeclareLaunchArgument(
+                name="gripperless",
+                default_value="False",
+                choices=["True", "true", "False", "false"],
+                description="Flag to remove the gripper from the arm model",
+            ),
+            DeclareLaunchArgument(
                 "tf_prefix", default_value='""', description="Apply namespace prefix to robot links and joints"
             ),
             DeclareLaunchArgument("namespace", default_value="", description="Namespace for robot tf topic"),
@@ -56,6 +62,8 @@ def generate_launch_description() -> launch.LaunchDescription:
                                 LaunchConfiguration("arm"),
                                 " feet:=",
                                 LaunchConfiguration("feet"),
+                                " gripperless:=",
+                                LaunchConfiguration("gripperless"),
                                 " tf_prefix:=",
                                 LaunchConfiguration("tf_prefix"),
                             ]

--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -7,12 +7,18 @@
   <xacro:include filename="$(find spot_description)/urdf/spot.ros2_control.xacro" />
 
   <!-- General parameters -->
-  <xacro:arg name="arm" default="false" />
-  <xacro:arg name="feet" default="false" />
+
+  <!-- String that will be prepended to all joints and links-->
   <xacro:arg name="tf_prefix" default="" />
 
-  <!-- Parameters used if Spot has an arm but not a gripper, or is outfitted with a custom gripper. -->
+  <!-- Set to true if Spot has an arm -->
+  <xacro:arg name="arm" default="false" />
+
+  <!-- Set to true if Spot has an arm but not a gripper -->
   <xacro:arg name="gripperless" default="false" />
+
+  <!-- Set to true to put links at the feet of Spot -->
+  <xacro:arg name="feet" default="false" />
 
   <!-- Parameters for ROS 2 control -->
   <xacro:arg name="add_ros2_control_tag" default="false" />
@@ -28,8 +34,7 @@
     arm="$(arg arm)"
     feet="$(arg feet)"
     tf_prefix="$(arg tf_prefix)" 
-    gripperless="$(arg gripperless)"
-    custom_gripper_base_link=""/>
+    gripperless="$(arg gripperless)"/>
 
   <!-- Adding the ROS 2 control tags -->
   <xacro:if value="$(arg add_ros2_control_tag)">

--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -8,9 +8,12 @@
 
   <!-- General parameters -->
   <xacro:arg name="arm" default="false" />
-  <xacro:arg name="gripperless" default="false" />
   <xacro:arg name="feet" default="false" />
   <xacro:arg name="tf_prefix" default="" />
+
+  <!-- Parameters used if Spot has an arm but not a gripper, or is outfitted with a custom gripper. -->
+  <xacro:arg name="gripperless" default="false" />
+  <xacro:arg name="custom_gripper_base_link" default="" />
 
   <!-- Parameters for ROS 2 control -->
   <xacro:arg name="add_ros2_control_tag" default="false" />
@@ -24,9 +27,10 @@
   <!-- Load Spot -->
   <xacro:load_spot
     arm="$(arg arm)"
-    gripperless="$(arg gripperless)"
     feet="$(arg feet)"
-    tf_prefix="$(arg tf_prefix)" />
+    tf_prefix="$(arg tf_prefix)" 
+    gripperless="$(arg gripperless)"
+    custom_gripper_base_link="$(arg custom_gripper_base_link)"/>
 
   <!-- Adding the ROS 2 control tags -->
   <xacro:if value="$(arg add_ros2_control_tag)">

--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -8,6 +8,7 @@
 
   <!-- General parameters -->
   <xacro:arg name="arm" default="false" />
+  <xacro:arg name="gripperless" default="false" />
   <xacro:arg name="feet" default="false" />
   <xacro:arg name="tf_prefix" default="" />
 
@@ -23,6 +24,7 @@
   <!-- Load Spot -->
   <xacro:load_spot
     arm="$(arg arm)"
+    gripperless="$(arg gripperless)"
     feet="$(arg feet)"
     tf_prefix="$(arg tf_prefix)" />
 

--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -13,7 +13,6 @@
 
   <!-- Parameters used if Spot has an arm but not a gripper, or is outfitted with a custom gripper. -->
   <xacro:arg name="gripperless" default="false" />
-  <xacro:arg name="custom_gripper_base_link" default="" />
 
   <!-- Parameters for ROS 2 control -->
   <xacro:arg name="add_ros2_control_tag" default="false" />
@@ -30,7 +29,7 @@
     feet="$(arg feet)"
     tf_prefix="$(arg tf_prefix)" 
     gripperless="$(arg gripperless)"
-    custom_gripper_base_link="$(arg custom_gripper_base_link)"/>
+    custom_gripper_base_link=""/>
 
   <!-- Adding the ROS 2 control tags -->
   <xacro:if value="$(arg add_ros2_control_tag)">

--- a/spot_description/urdf/spot_arm_macro.urdf
+++ b/spot_description/urdf/spot_arm_macro.urdf
@@ -1,7 +1,10 @@
 <?xml version="1.0"?>
 <robot name="spot_arm" xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:macro name="load_arm" params="
-    tf_prefix gripperless">
+    tf_prefix gripperless custom_gripper_base_link">
+
+    <!-- Useful boolean variable for determining if custom gripper base link should be used in the xacro -->
+    <xacro:property name="use_custom_gripper_base_link" value="${gripperless and custom_gripper_base_link!=''}"/>
 
     <link name="${tf_prefix}arm_link_sh0">
       <visual>
@@ -202,9 +205,11 @@
     </joint>
 
     <xacro:if value="${gripperless}">
-      <!-- This link needs to still be defined as to not break WR1 joint but can't include the meshes below, as these
-      includes parts of the gripper. -->
-      <link name="${tf_prefix}arm_link_wr1" />
+      <xacro:unless value="${use_custom_gripper_base_link}">
+        <!-- Here this link needs to still be defined as to not break WR1 joint but can't include the meshes below, as
+        these include parts of the gripper. Otherwise custom gripper base link will be used as the child of WR1 -->
+        <link name="${tf_prefix}arm_link_wr1" />
+      </xacro:unless>
     </xacro:if>
     <xacro:unless value="${gripperless}">
       <link name="${tf_prefix}arm_link_wr1">
@@ -250,11 +255,20 @@
       <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       <axis xyz="1 0 0" />
       <parent link="${tf_prefix}arm_link_wr0" />
-      <child link="${tf_prefix}arm_link_wr1" />
+      <!-- Child link can be different depending on gripperless status: -->
+      <xacro:if value="${use_custom_gripper_base_link}">
+        <!-- can optionally be the custom link specified via arg -->
+        <child link="${custom_gripper_base_link}" />
+      </xacro:if>
+      <xacro:unless value="${use_custom_gripper_base_link}">
+        <!-- else defaults to normal arm_link_wr1 -->
+        <child link="${tf_prefix}arm_link_wr1" />
+      </xacro:unless>
       <limit effort="30.3" velocity="10.0" lower="-2.87979326579064354163"
         upper="2.87979326579064354163" />
     </joint>
 
+    <!-- Finger joint and link shouldn't be included if gripperless -->
     <xacro:unless value="${gripperless}">
       <link name="${tf_prefix}arm_link_fngr">
         <visual>

--- a/spot_description/urdf/spot_arm_macro.urdf
+++ b/spot_description/urdf/spot_arm_macro.urdf
@@ -201,44 +201,51 @@
         upper="1.83259571459404613236" />
     </joint>
 
-    <link name="${tf_prefix}arm_link_wr1">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://spot_description/meshes/arm/visual/arm_link_wr1.obj" />
-        </geometry>
-        <material name="arm_link_wr1">
-          <color rgba="0.2 0.2 0.2 1" />
-        </material>
-      </visual>
-      <collision>
-        <geometry>
-          <mesh filename="package://spot_description/meshes/arm/collision/arm_link_wr1.obj" />
-        </geometry>
-      </collision>
-      <collision>
-        <geometry>
-          <mesh filename="package://spot_description/meshes/arm/collision/front_jaw.obj" />
-        </geometry>
-      </collision>
-      <collision>
-        <geometry>
-          <mesh filename="package://spot_description/meshes/arm/collision/middle_jaw.obj" />
-        </geometry>
-      </collision>
-      <collision>
-        <geometry>
-          <mesh filename="package://spot_description/meshes/arm/collision/jaw_tooth.obj" />
-        </geometry>
-      </collision>
-      <inertial>
-        <origin rpy="0.006393076449033863 0.2928526604761865 -0.022814984050994802"
-          xyz="0.12516802549362183 0.00010137435310753062 -0.013997982256114483" />
-        <mass value="0.785" />
-        <inertia ixx="0.00076741362048185" ixy="0.0" ixz="0.0" iyy="0.0017628124054271809" iyz="0.0"
-          izz="0.0016818105865345951" />
-      </inertial>
-    </link>
+    <xacro:if value="${gripperless}">
+      <!-- This link needs to still be defined as to not break WR1 joint but can't include the meshes below, as these
+      includes parts of the gripper. -->
+      <link name="${tf_prefix}arm_link_wr1" />
+    </xacro:if>
+    <xacro:unless value="${gripperless}">
+      <link name="${tf_prefix}arm_link_wr1">
+        <visual>
+          <origin xyz="0 0 0" rpy="0 0 0" />
+          <geometry>
+            <mesh filename="package://spot_description/meshes/arm/visual/arm_link_wr1.obj" />
+          </geometry>
+          <material name="arm_link_wr1">
+            <color rgba="0.2 0.2 0.2 1" />
+          </material>
+        </visual>
+        <collision>
+          <geometry>
+            <mesh filename="package://spot_description/meshes/arm/collision/arm_link_wr1.obj" />
+          </geometry>
+        </collision>
+        <collision>
+          <geometry>
+            <mesh filename="package://spot_description/meshes/arm/collision/front_jaw.obj" />
+          </geometry>
+        </collision>
+        <collision>
+          <geometry>
+            <mesh filename="package://spot_description/meshes/arm/collision/middle_jaw.obj" />
+          </geometry>
+        </collision>
+        <collision>
+          <geometry>
+            <mesh filename="package://spot_description/meshes/arm/collision/jaw_tooth.obj" />
+          </geometry>
+        </collision>
+        <inertial>
+          <origin rpy="0.006393076449033863 0.2928526604761865 -0.022814984050994802"
+            xyz="0.12516802549362183 0.00010137435310753062 -0.013997982256114483" />
+          <mass value="0.785" />
+          <inertia ixx="0.00076741362048185" ixy="0.0" ixz="0.0" iyy="0.0017628124054271809" iyz="0.0"
+            izz="0.0016818105865345951" />
+        </inertial>
+      </link>
+    </xacro:unless>
     <joint name="${tf_prefix}arm_wr1" type="revolute">
       <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       <axis xyz="1 0 0" />

--- a/spot_description/urdf/spot_arm_macro.urdf
+++ b/spot_description/urdf/spot_arm_macro.urdf
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot name="spot_arm" xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:macro name="load_arm" params="
-    tf_prefix">
+    tf_prefix gripperless">
 
     <link name="${tf_prefix}arm_link_sh0">
       <visual>
@@ -217,9 +217,9 @@
         </geometry>
       </collision>
       <collision>
-      <geometry>
-        <mesh filename="package://spot_description/meshes/arm/collision/front_jaw.obj" />
-      </geometry>
+        <geometry>
+          <mesh filename="package://spot_description/meshes/arm/collision/front_jaw.obj" />
+        </geometry>
       </collision>
       <collision>
         <geometry>
@@ -248,60 +248,62 @@
         upper="2.87979326579064354163" />
     </joint>
 
-    <link name="${tf_prefix}arm_link_fngr">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <mesh filename="package://spot_description/meshes/arm/visual/arm_link_fngr.obj" />
-        </geometry>
-        <material name="arm_link_fngr">
-          <color rgba="0.2 0.2 0.2 1" />
-        </material>
-      </visual>
-      <collision>
-        <geometry>
-          <mesh filename="package://spot_description/meshes/arm/collision/left_hinge.obj" />
-        </geometry>
-      </collision>
-      <collision>
-        <geometry>
-          <mesh filename="package://spot_description/meshes/arm/collision/left_finger.obj" />
-        </geometry>
-      </collision>
-      <collision>
-        <geometry>
-          <mesh filename="package://spot_description/meshes/arm/collision/left_tooth.obj" />
-        </geometry>
-      </collision>
-      <collision>
-        <geometry>
-          <mesh filename="package://spot_description/meshes/arm/collision/right_hinge.obj" />
-        </geometry>
-      </collision>
-      <collision>
-        <geometry>
-          <mesh filename="package://spot_description/meshes/arm/collision/right_finger.obj" />
-        </geometry>
-      </collision>
-      <collision>
-        <geometry>
-          <mesh filename="package://spot_description/meshes/arm/collision/right_tooth.obj" />
-        </geometry>
-      </collision>
-      <inertial>
-        <origin rpy="0.0003416659657240473 0.3751670012784243 -0.004058661249495721"
-          xyz="0.04787873849272728 -0.00020676758140325546 -0.01628788933157921" />
-        <mass value="0.2" />
-        <inertia ixx="0.0001439963634171048" ixy="0.0" ixz="0.0" iyy="0.0003007126997998294"
-          iyz="0.0" izz="0.0003912783268020657" />
-      </inertial>
-    </link>
-    <joint name="${tf_prefix}arm_f1x" type="revolute">
-      <origin xyz="0.11745 0 0.014820" rpy="0 0 0" />
-      <axis xyz="0.0 1.0 0.0" />
-      <parent link="${tf_prefix}arm_link_wr1" />
-      <child link="${tf_prefix}arm_link_fngr" />
-      <limit effort="15.32" velocity="10.0" lower="-1.57" upper="0.0" />
-    </joint>
+    <xacro:unless value="${gripperless}">
+      <link name="${tf_prefix}arm_link_fngr">
+        <visual>
+          <origin xyz="0 0 0" rpy="0 0 0" />
+          <geometry>
+            <mesh filename="package://spot_description/meshes/arm/visual/arm_link_fngr.obj" />
+          </geometry>
+          <material name="arm_link_fngr">
+            <color rgba="0.2 0.2 0.2 1" />
+          </material>
+        </visual>
+        <collision>
+          <geometry>
+            <mesh filename="package://spot_description/meshes/arm/collision/left_hinge.obj" />
+          </geometry>
+        </collision>
+        <collision>
+          <geometry>
+            <mesh filename="package://spot_description/meshes/arm/collision/left_finger.obj" />
+          </geometry>
+        </collision>
+        <collision>
+          <geometry>
+            <mesh filename="package://spot_description/meshes/arm/collision/left_tooth.obj" />
+          </geometry>
+        </collision>
+        <collision>
+          <geometry>
+            <mesh filename="package://spot_description/meshes/arm/collision/right_hinge.obj" />
+          </geometry>
+        </collision>
+        <collision>
+          <geometry>
+            <mesh filename="package://spot_description/meshes/arm/collision/right_finger.obj" />
+          </geometry>
+        </collision>
+        <collision>
+          <geometry>
+            <mesh filename="package://spot_description/meshes/arm/collision/right_tooth.obj" />
+          </geometry>
+        </collision>
+        <inertial>
+          <origin rpy="0.0003416659657240473 0.3751670012784243 -0.004058661249495721"
+            xyz="0.04787873849272728 -0.00020676758140325546 -0.01628788933157921" />
+          <mass value="0.2" />
+          <inertia ixx="0.0001439963634171048" ixy="0.0" ixz="0.0" iyy="0.0003007126997998294"
+            iyz="0.0" izz="0.0003912783268020657" />
+        </inertial>
+      </link>
+      <joint name="${tf_prefix}arm_f1x" type="revolute">
+        <origin xyz="0.11745 0 0.014820" rpy="0 0 0" />
+        <axis xyz="0.0 1.0 0.0" />
+        <parent link="${tf_prefix}arm_link_wr1" />
+        <child link="${tf_prefix}arm_link_fngr" />
+        <limit effort="15.32" velocity="10.0" lower="-1.57" upper="0.0" />
+      </joint>
+    </xacro:unless>
   </xacro:macro>
 </robot>

--- a/spot_description/urdf/spot_macro.xacro
+++ b/spot_description/urdf/spot_macro.xacro
@@ -4,6 +4,7 @@
     <xacro:macro name="load_spot" params="
     arm:=false
     feet:=false
+    gripperless:=false
     tf_prefix">
 
         <link name="${tf_prefix}body">
@@ -417,7 +418,7 @@
         <!-- Include Arm if necessary-->
         <xacro:if value="${arm}">
             <xacro:include filename="$(find spot_description)/urdf/spot_arm_macro.urdf" />
-            <xacro:load_arm tf_prefix="${tf_prefix}" />
+            <xacro:load_arm tf_prefix="${tf_prefix}" gripperless="${gripperless}" />
         </xacro:if>
 
         <!-- Include links at feet if necessary -->

--- a/spot_description/urdf/spot_macro.xacro
+++ b/spot_description/urdf/spot_macro.xacro
@@ -5,7 +5,7 @@
     arm:=false
     feet:=false
     gripperless:=false
-    custom_gripper_base_link
+    custom_gripper_base_link:=''
     tf_prefix">
 
         <link name="${tf_prefix}body">

--- a/spot_description/urdf/spot_macro.xacro
+++ b/spot_description/urdf/spot_macro.xacro
@@ -5,6 +5,7 @@
     arm:=false
     feet:=false
     gripperless:=false
+    custom_gripper_base_link
     tf_prefix">
 
         <link name="${tf_prefix}body">
@@ -418,7 +419,9 @@
         <!-- Include Arm if necessary-->
         <xacro:if value="${arm}">
             <xacro:include filename="$(find spot_description)/urdf/spot_arm_macro.urdf" />
-            <xacro:load_arm tf_prefix="${tf_prefix}" gripperless="${gripperless}" />
+            <xacro:load_arm tf_prefix="${tf_prefix}"
+                            gripperless="${gripperless}"
+                            custom_gripper_base_link="${custom_gripper_base_link}" />
         </xacro:if>
 
         <!-- Include links at feet if necessary -->


### PR DESCRIPTION
## Change Overview

Adds support for the `gripperless` parameter at the URDF level, with the option to connect a new child link to joint `arm_wr1` (which would be the case when using a custom gripper)

related to https://github.com/bdaiinstitute/spot_ros2/pull/518

## Testing Done

 - [x] default URDF is unchanged
 - [x] ran updated spot description launchfile with `gripperless:=True`, model looks right

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Xynj6CBpA3NqqBFfE8Q9/4eb6af86-8305-4132-83e9-59a9fcc8cf16.png)




- [x] tested a new xacro skeleton using the `custom_gripper_base_link` arg. This same structure could be used to specify the base link of a custom gripper and then connect the spot model to the gripper model. 

```
<?xml version="1.0" ?>
<robot name="gripperless_test" xmlns:xacro="http://www.ros.org/wiki/xacro">

  <xacro:include filename="$(find spot_description)/urdf/spot_macro.xacro" />

  <xacro:load_spot
    arm="true"
    gripperless="true"
    tf_prefix=""
    custom_gripper_base_link="gripper_base_link"/>

  <!-- custom gripper could be loaded after this, here we just have a stand in link as proof of concept -->
  <link name="gripper_base_link" />

</robot>

```
