### PR TITLE
[N/A] bugfix: give new xacro arguments default values

### DIFF
--- a/spot_description/urdf/spot_arm_macro.urdf
+++ b/spot_description/urdf/spot_arm_macro.urdf
@@ -1,7 +1,9 @@
 <?xml version="1.0"?>
 <robot name="spot_arm" xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:macro name="load_arm" params="
-    tf_prefix gripperless custom_gripper_base_link">
+    tf_prefix
+    gripperless:=false
+    custom_gripper_base_link:=''">
 
     <!-- Useful boolean variable for determining if custom gripper base link should be used in the xacro -->
     <xacro:property name="use_custom_gripper_base_link" value="${gripperless and custom_gripper_base_link!=''}"/>


### PR DESCRIPTION
## Change Overview

fixes an issue where new gripperless arguments needed to be specified for loading the arm URDF. now if they aren't specified, defaults are used instead of throwing an error. 

## Testing Done

- [x] standalone arm URDF can be loaded properly if these arguments aren't specifically set