### PR TITLE
Fixes TimeSync with robot

### DIFF
--- a/spot_driver/src/api/default_time_sync_api.cpp
+++ b/spot_driver/src/api/default_time_sync_api.cpp
@@ -1,8 +1,8 @@
 // Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
 
+#include <chrono>
 #include <spot_driver/api/default_time_sync_api.hpp>
 #include <tl_expected/expected.hpp>
-#include <chrono>
 
 namespace spot_ros2 {
 

--- a/spot_driver/src/api/default_time_sync_api.cpp
+++ b/spot_driver/src/api/default_time_sync_api.cpp
@@ -2,6 +2,7 @@
 
 #include <spot_driver/api/default_time_sync_api.hpp>
 #include <tl_expected/expected.hpp>
+#include <chrono>
 
 namespace spot_ros2 {
 
@@ -11,6 +12,9 @@ DefaultTimeSyncApi::DefaultTimeSyncApi(std::shared_ptr<::bosdyn::client::TimeSyn
 tl::expected<google::protobuf::Duration, std::string> DefaultTimeSyncApi::getClockSkew() {
   if (!time_sync_thread_) {
     return tl::make_unexpected("Time sync thread was not initialized.");
+  }
+  if (!time_sync_thread_->WaitForSync(std::chrono::seconds(5))) {
+    return tl::make_unexpected("Failed to establish time sync before timing out.");
   }
   if (!time_sync_thread_->HasEstablishedTimeSync()) {
     return tl::make_unexpected("Time sync not yet established between Spot and the local system.");

--- a/spot_driver/src/image_stitcher/image_stitcher.cpp
+++ b/spot_driver/src/image_stitcher/image_stitcher.cpp
@@ -362,7 +362,8 @@ Image::SharedPtr MiddleCamera::stitch(const std::shared_ptr<const Image>& left,
 
   // Convert the image back to the BGR color space
   result_.convertTo(result_, CV_8U);
-  // Return the image in a format that can be published
+  // Rotate the result image 90 degrees clockwise and return it in a format that can be published
+  cv::rotate(result_, result_, cv::ROTATE_90_CLOCKWISE);
   return cv_bridge::CvImage(std_msgs::msg::Header{}, "bgr8", result_.getMat(cv::ACCESS_READ)).toImageMsg();
 }
 

--- a/spot_driver/src/image_stitcher/image_stitcher.cpp
+++ b/spot_driver/src/image_stitcher/image_stitcher.cpp
@@ -362,8 +362,7 @@ Image::SharedPtr MiddleCamera::stitch(const std::shared_ptr<const Image>& left,
 
   // Convert the image back to the BGR color space
   result_.convertTo(result_, CV_8U);
-  // Rotate the result image 90 degrees clockwise and return it in a format that can be published
-  cv::rotate(result_, result_, cv::ROTATE_90_CLOCKWISE);
+  // Return the image in a format that can be published
   return cv_bridge::CvImage(std_msgs::msg::Header{}, "bgr8", result_.getMat(cv::ACCESS_READ)).toImageMsg();
 }
 


### PR DESCRIPTION
## Change Overview
The DefaultTimeSyncApi is missing the `WaitForSync` call from Spot SDK. As a result the timesync cannot be established, especially when connecting via WIFI.

I added the  `WaitForSync` call to the DefaultTimeSyncApi with a timeout of 5 seconds (maybe create a config param for that) before checking the timesync with `HasEstablishedTimeSync`

This results in a successful timesync even via WIFI over VPNs. 

![Screenshot from 2025-01-03 17-41-07](https://github.com/user-attachments/assets/98b3a7b4-3d39-4423-ba66-15138cf635b0)

Corresponding issue:
https://github.com/bdaiinstitute/spot_ros2/issues/527

## Testing Done

1. Launched the driver with various parameters
2. Tested the image services
3. Tested robot commands such as dock and undock