### PR TITLE
[SW-1712] Pin ubuntu version in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   lint:
     name: Lint spot_ros2 packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         config:
@@ -47,7 +47,7 @@ jobs:
         uses: pre-commit/action@v3.0.1
   prepare_container:
     name: Prepare Humble container for tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: lint
     permissions:
       contents: read
@@ -91,7 +91,7 @@ jobs:
           cache-to: type=gha,mode=max
   build_and_test_package_and_docs:
     name: Build and test spot_ros2 packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: prepare_container
     container:
       image: ${{ needs.prepare_container.outputs.image }}

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   clean-ghcr:
     name: Prune old images from Github Container Registry
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Delete old pull request images
         uses: snok/container-retention-policy@v2


### PR DESCRIPTION
## Change Overview

This is simply a find/replace of `ubuntu-latest` -> `ubuntu-22.04`.  Because `ubuntu-latest` will become 24.04 soon.  We should pin to 22.04 which matches our development environment.

## Testing Done

None. This PR is the test.  (Assuming this repo has CI)

