### PR TITLE
[N/A] better error message if robot is missing joint level api license

### DIFF
--- a/spot_hardware_interface/src/spot_hardware_interface.cpp
+++ b/spot_hardware_interface/src/spot_hardware_interface.cpp
@@ -428,7 +428,8 @@ void state_stream_loop(std::stop_token stop_token, ::bosdyn::client::RobotStateS
     // Get robot state stream
     auto robot_state_stream = stateStreamClient->GetRobotStateStream();
     if (!robot_state_stream) {
-      RCLCPP_ERROR(rclcpp::get_logger("SpotHardware"), "Failed to get robot state");
+      RCLCPP_ERROR(rclcpp::get_logger("SpotHardware"),
+                   "Failed to get robot state. Does the robot have a valid joint level control license?");
       continue;
     }
     latest_state_stream_response = std::move(robot_state_stream.response);


### PR DESCRIPTION
## Change Overview

This came up recently when running the ros2 control stack on a robot that had an expired joint level control license. The error message spammed in this state is just "Failed to get robot state" which is not very helpful. Now this tells the user to double check for the license. 

## Testing Done

N/A