### PR TITLE
[N/A] revert update_sigterm_sigkill_timeouts

### DIFF
--- a/spot_driver/launch/point_cloud_xyz.launch.py
+++ b/spot_driver/launch/point_cloud_xyz.launch.py
@@ -36,7 +36,6 @@ import launch_ros.descriptions
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from synchros2.launch.actions import update_sigterm_sigkill_timeout
 
 
 def generate_launch_description() -> LaunchDescription:
@@ -74,5 +73,4 @@ def generate_launch_description() -> LaunchDescription:
             ),
         ]
     )
-    update_sigterm_sigkill_timeout(ld)
     return ld

--- a/spot_driver/launch/point_cloud_xyzrgb.launch.py
+++ b/spot_driver/launch/point_cloud_xyzrgb.launch.py
@@ -36,7 +36,6 @@ import launch_ros.descriptions
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from synchros2.launch.actions import update_sigterm_sigkill_timeout
 
 
 def generate_launch_description() -> LaunchDescription:
@@ -77,5 +76,4 @@ def generate_launch_description() -> LaunchDescription:
             ),
         ]
     )
-    update_sigterm_sigkill_timeout(ld)
     return ld

--- a/spot_driver/launch/rviz.launch.py
+++ b/spot_driver/launch/rviz.launch.py
@@ -13,7 +13,6 @@ from launch.substitutions import (
     PathJoinSubstitution,
 )
 from launch_ros.substitutions import FindPackageShare
-from synchros2.launch.actions import update_sigterm_sigkill_timeout
 
 THIS_PACKAGE = "spot_driver"
 
@@ -44,7 +43,6 @@ def create_rviz_config(robot_name: str) -> None:
 
 
 def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
-    update_sigterm_sigkill_timeout(ld)
     rviz_config_file = LaunchConfiguration("rviz_config_file").perform(context)
     spot_name = LaunchConfiguration("spot_name").perform(context)
 

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -9,7 +9,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution, TextSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-from synchros2.launch.actions import DeclareBooleanLaunchArgument, update_sigterm_sigkill_timeout
+from synchros2.launch.actions import DeclareBooleanLaunchArgument
 
 from spot_driver.launch.spot_launch_helpers import IMAGE_PUBLISHER_ARGS, declare_image_publisher_args, spot_has_arm
 
@@ -17,7 +17,6 @@ THIS_PACKAGE = "spot_driver"
 
 
 def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
-    update_sigterm_sigkill_timeout(ld)
     config_file = LaunchConfiguration("config_file")
     launch_rviz = LaunchConfiguration("launch_rviz")
     rviz_config_file = LaunchConfiguration("rviz_config_file").perform(context)

--- a/spot_driver/launch/spot_image_publishers.launch.py
+++ b/spot_driver/launch/spot_image_publishers.launch.py
@@ -9,7 +9,6 @@ from launch import LaunchContext, LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from synchros2.launch.actions import update_sigterm_sigkill_timeout
 
 from spot_driver.launch.spot_launch_helpers import (
     DepthRegisteredMode,
@@ -92,7 +91,6 @@ def create_point_cloud_nodelets(
 
 
 def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
-    update_sigterm_sigkill_timeout(ld)
     config_file = LaunchConfiguration("config_file")
     spot_name = LaunchConfiguration("spot_name").perform(context)
     depth_registered_mode_config = LaunchConfiguration("depth_registered_mode")

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -16,7 +16,7 @@ from launch.substitutions import (
 )
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-from synchros2.launch.actions import DeclareBooleanLaunchArgument, update_sigterm_sigkill_timeout
+from synchros2.launch.actions import DeclareBooleanLaunchArgument
 
 from spot_driver.launch.spot_launch_helpers import (
     IMAGE_PUBLISHER_ARGS,
@@ -301,6 +301,5 @@ def generate_launch_description():
         + declare_image_publisher_args()
     )
     # Add nodes to launch description
-    update_sigterm_sigkill_timeout(ld)
     ld.add_action(OpaqueFunction(function=launch_setup, args=[ld]))
     return ld


### PR DESCRIPTION
## Change Overview

Reverts the calls to `update_sigterm_sigkill_timeout` introduced in https://github.com/bdaiinstitute/spot_ros2/pull/537. I have a very strong hunch that this is tanking CI execution time in our internal repo (after this change, we are only able to complete 17% of relevant tests before timing out, which is blocking my PR to bring in the latest changes from this repo).

## Testing Done

N/A