### PR TITLE
[SW-1890] changed take_lease_handler to acquire lease if possible, not force take

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -226,7 +226,7 @@ class SpotROS(Node):
         self.declare_parameter("auto_power_on", False)
         self.declare_parameter("auto_stand", False)
 
-        self.declare_parameter("use_take_lease", True)
+        self.declare_parameter("use_take_lease", False)
         self.declare_parameter("get_lease_on_action", True)
         self.declare_parameter("continually_try_stand", False)
 
@@ -1000,13 +1000,13 @@ class SpotROS(Node):
             response.message = "spot_ros2 is running in mock mode."
             return response
 
-        have_new_lease, lease = self.spot_wrapper.takeLease()
-        if have_new_lease:
+        try:
+            lease = self.spot_wrapper.getLease() # acquires lease if available, not forcefully take
             response.success = True
             response.message = str(lease.lease_proto)
-        else:
+        except Exception as e:
             response.success = False
-            response.message = ""
+            response.message = str(e)
 
         return response
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1001,7 +1001,7 @@ class SpotROS(Node):
             return response
 
         try:
-            lease = self.spot_wrapper.getLease() # acquires lease if available, not forcefully take
+            lease = self.spot_wrapper.getLease()  # acquires lease if available, not forcefully take
             response.success = True
             response.message = str(lease.lease_proto)
         except Exception as e:

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -226,7 +226,10 @@ class SpotROS(Node):
         self.declare_parameter("auto_power_on", False)
         self.declare_parameter("auto_stand", False)
 
+        # Setting this param to True will allow the driver to forcefully take the lease
+        # Not recommended if using mixed-level API
         self.declare_parameter("use_take_lease", False)
+
         self.declare_parameter("get_lease_on_action", True)
         self.declare_parameter("continually_try_stand", False)
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -1009,7 +1009,7 @@ class SpotROS(Node):
             response.message = str(lease.lease_proto)
         except Exception as e:
             response.success = False
-            response.message = str(e)
+            response.message = "Failed to acquire lease: " + str(e)
 
         return response
 


### PR DESCRIPTION
## Change Overview

`spot_driver` will acquire the lease (if available) instead of forcefully taking it. If lease is not available, print an error message. Tablet can still take the lease away but needs to be manually released from the tablet for the driver to acquire it.

Related to https://github.com/bdaiinstitute/spot_wrapper/pull/154

## Testing Done

Tested on robot with a few simple trigger services

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
