### PR TITLE
[SW-1891] Complete `spot_ros2_control` initialization

### DIFF
--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -20,6 +20,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -126,6 +127,8 @@ class SpotHardware : public hardware_interface::SystemInterface {
 
   // Login info
   std::string hostname_;
+  std::optional<int> port_;
+  std::optional<std::string> certificate_;
   std::string username_;
   std::string password_;
 
@@ -180,9 +183,13 @@ class SpotHardware : public hardware_interface::SystemInterface {
    * @param hostname IP address of the robot
    * @param username Username for robot login
    * @param password Password for robot login
+   * @param port Optional user-defined port for robot comms
+   * @param certificate Optional user-defined SSL certificate for robot comms
    * @return True if robot object is successfully created and authenticated, false otherwise.
    */
-  bool authenticate_robot(const std::string& hostname, const std::string& username, const std::string& password);
+  bool authenticate_robot(const std::string& hostname, const std::string& username, const std::string& password,
+                          const std::optional<int>& port, const std::optional<std::string>& certificate);
+
   /**
    * @brief Start time sync threads with the ::bosdyn::client::Robot object
    * @return True if time sync successfully initialized and started, false otherwise.

--- a/spot_ros2_control/config/spot_default_controllers_with_arm.yaml
+++ b/spot_ros2_control/config/spot_default_controllers_with_arm.yaml
@@ -15,7 +15,7 @@ controller_manager:
       type: spot_controllers/ForwardStateController
 
     hardware_components_initial_state:
-      inactive:
+      unconfigured:
         - SpotSystem
 
 forward_position_controller:

--- a/spot_ros2_control/config/spot_default_controllers_without_arm.yaml
+++ b/spot_ros2_control/config/spot_default_controllers_without_arm.yaml
@@ -15,7 +15,7 @@ controller_manager:
       type: spot_controllers/ForwardStateController
 
     hardware_components_initial_state:
-      inactive:
+      unconfigured:
         - SpotSystem
 
 forward_position_controller:

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -115,9 +115,11 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     if hardware_interface == "robot":
         arm = spot_has_arm(config_file_path=config_file, spot_name="")
         username, password, hostname, port, certificate = get_login_parameters(config_file)
-        login_params = (
-            f" hostname:={hostname} username:={username} password:={password} port:={port} certificate:={certificate}"
-        )
+        login_params = f" hostname:={hostname} username:={username} password:={password}"
+        if port is not None:
+            login_params += f" port:={port}"
+        if certificate is not None:
+            login_params += f" certificate:={certificate}"
         param_dict = get_ros_param_dict(config_file)
         if "k_q_p" in param_dict:
             # we pass the gains to the xacro as space-separated strings as the hardware interface needs to read in all

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -185,23 +185,23 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
             executable="hardware_spawner",
             arguments=["-c", "controller_manager", "--activate", "SpotSystem"],
             namespace=spot_name,
-            condition=IfCondition(LaunchConfiguration("auto_start")),
-        )
-    )
-    ld.add_action(
-        Node(
-            package="controller_manager",
-            executable="spawner",
-            arguments=[
-                "-c",
-                "controller_manager",
-                "joint_state_broadcaster",
-                LaunchConfiguration("robot_controller"),
+            on_exit=[
+                Node(
+                    package="controller_manager",
+                    executable="spawner",
+                    arguments=[
+                        "-c",
+                        "controller_manager",
+                        "joint_state_broadcaster",
+                        LaunchConfiguration("robot_controller"),
+                    ],
+                    namespace=spot_name,
+                )
             ],
-            namespace=spot_name,
             condition=IfCondition(LaunchConfiguration("auto_start")),
         )
     )
+
     # Generate rviz configuration file based on the chosen namespace
     ld.add_action(
         Node(


### PR DESCRIPTION
## Change Overview

Follow-up to #567. This patch:

- loads hardware interfaces unconfigured
- ensures user-defined port and SSL certificate are picked up
- allows `spot_ros2_control` to be launched on its own (no `rviz`, no `robot_state_publisher`, etc.)

## Testing Done

Integration tests, downstream. Local tests to ensure there have been no regressions are pending.
