### PR TITLE
[SW-957] make decorator for trigger services

### DIFF
--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -1,6 +1,7 @@
 import os
 import time
 from typing import Any, Callable, List, Optional, Tuple, Union
+from dataclasses import dataclass
 
 import builtin_interfaces.msg
 import cv2
@@ -20,6 +21,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from rclpy.node import Node
 from sensor_msgs.msg import CameraInfo, CompressedImage, Image
 from tf2_msgs.msg import TFMessage
+from std_srvs.srv import SetBool, Trigger
 
 from spot_wrapper.wrapper import SpotWrapper
 
@@ -328,3 +330,16 @@ def lookup_a_tform_b(
                 raise e
             time.sleep(0.01)
     return None
+
+@dataclass
+class TriggerServiceDescriptor:
+    service_name: str
+    def __get__(self, obj, type=None):
+        def handler(request: Trigger.Request, response: Trigger.Response):
+            if obj.spot_wrapper is None:
+                response.success = False
+                response.message = "Spot wrapper is undefined"
+                return response
+            response.success, response.message = getattr(obj.spot_wrapper, self.service_name)()
+            return response
+        return handler

--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -357,7 +357,7 @@ class TriggerServiceWrapper:  # TODO: caching of spot_ros might be funky with mu
             response.success = True
             response.message = "Mock spot success"
             return response
-        
+
         if self.spot_ros.spot_wrapper is None:
             response.success = False
             response.message = "Spot wrapper is undefined"

--- a/spot_driver/spot_driver/ros_helpers.py
+++ b/spot_driver/spot_driver/ros_helpers.py
@@ -353,6 +353,11 @@ class TriggerServiceWrapper:  # TODO: caching of spot_ros might be funky with mu
         obj.create_service(Trigger, self.service_name, self.callback, callback_group=group)
 
     def callback(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+        if self.spot_ros.mock:
+            response.success = True
+            response.message = "Mock spot success"
+            return response
+        
         if self.spot_ros.spot_wrapper is None:
             response.success = False
             response.message = "Spot wrapper is undefined"

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -432,117 +432,8 @@ class SpotROS(Node):
         self.create_subscription(Pose, "body_pose", self.body_pose_callback, 1, callback_group=self.group)
 
         self.create_trigger_services()
-        # self.create_service(
-        #     Trigger,
-        #     "claim",
-        #     self.handle_claim,
-        #     callback_group=self.group,
-        # )
-        # self.create_service(
-        #     Trigger,
-        #     "release",
-        #     self.handle_release,
-        #     callback_group=self.group,
-        # )
-        # self.create_service(
-        #     Trigger,
-        #     "stop",
-        #     self.handle_stop,
-        #     callback_group=self.group,
-        # )
-        # self.create_service(
-        #     Trigger,
-        #     "self_right",
-        #     self.handle_self_right,
-        #     callback_group=self.group,
-        # )
-        # self.create_service(
-        #     Trigger,
-        #     "sit",
-        #     self.handle_sit,
-        #     callback_group=self.group,
-        # )
-        # self.create_service(
-        #     Trigger,
-        #     "stand",
-        #     self.handle_stand,
-        #     callback_group=self.group,
-        # )
-        # self.create_service(
-        #     Trigger,
-        #     "crouch",
-        #     self.handle_crouch,
-        #     callback_group=self.group,
-        # )
-        # self.create_service(
-        #     Trigger,
-        #     "rollover",
-        #     self.handle_rollover,
-        #     callback_group=self.group,
-        # )
-        # self.create_service(
-        #     Trigger,
-        #     "power_on",
-        #     self.handle_power_on,
-        #     callback_group=self.group,
-        # )
-        # self.create_service(
-        #     Trigger,
-        #     "power_off",
-        #     self.handle_safe_power_off,
-        #     callback_group=self.group,
-        # )
-        # self.create_service(
-        #     Trigger,
-        #     "estop/hard",
-        #     self.handle_estop_hard,
-        #     callback_group=self.group,
-        # )
-        # self.create_service(
-        #     Trigger,
-        #     "estop/gentle",
-        #     self.handle_estop_soft,
-        #     callback_group=self.group,
-        # )
-        # self.create_service(
-        #     Trigger,
-        #     "estop/release",
-        #     self.handle_estop_disengage,
-        #     callback_group=self.group,
-        # )
-        # self.create_service(
-        #     Trigger,
-        #     "undock",
-        #     self.handle_undock,
-        #     callback_group=self.group,
-        # )
-
-        # self.create_service(
-        #     Trigger,
-        #     "spot_check",
-        #     self.handle_spot_check,
-        #     callback_group=self.group,
-        # )
 
         if self.has_arm:
-            #     self.create_service(
-            #         Trigger,
-            #         "arm_stow",
-            #         self.handle_arm_stow,
-            #         callback_group=self.group,
-            #     )
-            #     self.create_service(
-            #         Trigger,
-            #         "arm_unstow",
-            #         self.handle_arm_unstow,
-            #         callback_group=self.group,
-            #     )
-            #     self.create_service(
-            #         Trigger,
-            #         "arm_carry",
-            #         self.handle_arm_carry,
-            #         callback_group=self.group,
-            #     )
             self.create_subscription(
                 JointState, "arm_joint_commands", self.arm_joint_cmd_callback, 100, callback_group=self.group
             )
@@ -551,18 +442,6 @@ class SpotROS(Node):
             )
 
             if not self.gripperless:
-                #         self.create_service(
-                #             Trigger,
-                #             "open_gripper",
-                #             self.handle_open_gripper,
-                #             callback_group=self.group,
-                #         )
-                #         self.create_service(
-                #             Trigger,
-                #             "close_gripper",
-                #             self.handle_close_gripper,
-                #             callback_group=self.group,
-                #         )
                 self.create_service(
                     SetGripperAngle,
                     "set_gripper_angle",
@@ -985,7 +864,7 @@ class SpotROS(Node):
 
         return response
 
-    def create_trigger_services(self):
+    def create_trigger_services(self) -> None:
         services = [
             self.handle_claim,
             self.handle_release,

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -70,10 +70,7 @@ import spot_driver.robot_command_util as robot_command_util
 
 # DEBUG/RELEASE: RELATIVE PATH NOT WORKING IN DEBUG
 # Release
-from spot_driver.ros_helpers import (
-    get_from_env_and_fall_back_to_param,
-    TriggerServiceDescriptor
-)
+from spot_driver.ros_helpers import TriggerServiceDescriptor, get_from_env_and_fall_back_to_param
 from spot_msgs.action import (  # type: ignore
     ExecuteDance,
     Manipulation,
@@ -437,94 +434,91 @@ class SpotROS(Node):
             Trigger,
             "claim",
             self.handle_claim,
-            # lambda request, response: self.service_wrapper("claim", self.handle_claim, request, response),
             callback_group=self.group,
         )
         self.create_service(
             Trigger,
             "release",
-            lambda request, response: self.service_wrapper("release", self.handle_release, request, response),
+            self.handle_release,
             callback_group=self.group,
         )
         self.create_service(
             Trigger,
             "stop",
-            lambda request, response: self.service_wrapper("stop", self.handle_stop, request, response),
+            self.handle_stop,
             callback_group=self.group,
         )
         self.create_service(
             Trigger,
             "self_right",
-            lambda request, response: self.service_wrapper("self_right", self.handle_self_right, request, response),
+            self.handle_self_right,
             callback_group=self.group,
         )
         self.create_service(
             Trigger,
             "sit",
-            lambda request, response: self.service_wrapper("sit", self.handle_sit, request, response),
+            self.handle_sit,
             callback_group=self.group,
         )
         self.create_service(
             Trigger,
             "stand",
-            lambda request, response: self.service_wrapper("stand", self.handle_stand, request, response),
+            self.handle_stand,
             callback_group=self.group,
         )
         self.create_service(
             Trigger,
             "crouch",
-            lambda request, response: self.service_wrapper("crouch", self.handle_crouch, request, response),
+            self.handle_crouch,
             callback_group=self.group,
         )
         self.create_service(
             Trigger,
             "rollover",
-            lambda request, response: self.service_wrapper("rollover", self.handle_rollover, request, response),
+            self.handle_rollover,
             callback_group=self.group,
         )
         self.create_service(
             Trigger,
             "power_on",
-            lambda request, response: self.service_wrapper("power_on", self.handle_power_on, request, response),
+            self.handle_power_on,
             callback_group=self.group,
         )
         self.create_service(
             Trigger,
             "power_off",
-            lambda request, response: self.service_wrapper("power_off", self.handle_safe_power_off, request, response),
+            self.handle_safe_power_off,
             callback_group=self.group,
         )
         self.create_service(
             Trigger,
             "estop/hard",
-            lambda request, response: self.service_wrapper("estop/hard", self.handle_estop_hard, request, response),
+            self.handle_estop_hard,
             callback_group=self.group,
         )
         self.create_service(
             Trigger,
             "estop/gentle",
-            lambda request, response: self.service_wrapper("estop/gentle", self.handle_estop_soft, request, response),
+            self.handle_estop_soft,
             callback_group=self.group,
         )
         self.create_service(
             Trigger,
             "estop/release",
-            lambda request, response: self.service_wrapper(
-                "estop/release", self.handle_estop_disengage, request, response
-            ),
+            self.handle_estop_disengage,
             callback_group=self.group,
         )
         self.create_service(
             Trigger,
             "undock",
-            lambda request, response: self.service_wrapper("undock", self.handle_undock, request, response),
+            self.handle_undock,
             callback_group=self.group,
         )
 
         self.create_service(
             Trigger,
             "spot_check",
-            lambda request, response: self.service_wrapper("spot_check", self.handle_spot_check, request, response),
+            self.handle_spot_check,
             callback_group=self.group,
         )
 
@@ -532,19 +526,19 @@ class SpotROS(Node):
             self.create_service(
                 Trigger,
                 "arm_stow",
-                lambda request, response: self.service_wrapper("arm_stow", self.handle_arm_stow, request, response),
+                self.handle_arm_stow,
                 callback_group=self.group,
             )
             self.create_service(
                 Trigger,
                 "arm_unstow",
-                lambda request, response: self.service_wrapper("arm_unstow", self.handle_arm_unstow, request, response),
+                self.handle_arm_unstow,
                 callback_group=self.group,
             )
             self.create_service(
                 Trigger,
                 "arm_carry",
-                lambda request, response: self.service_wrapper("arm_carry", self.handle_arm_carry, request, response),
+                self.handle_arm_carry,
                 callback_group=self.group,
             )
             self.create_subscription(
@@ -558,17 +552,13 @@ class SpotROS(Node):
                 self.create_service(
                     Trigger,
                     "open_gripper",
-                    lambda request, response: self.service_wrapper(
-                        "open_gripper", self.handle_open_gripper, request, response
-                    ),
+                    self.handle_open_gripper,
                     callback_group=self.group,
                 )
                 self.create_service(
                     Trigger,
                     "close_gripper",
-                    lambda request, response: self.service_wrapper(
-                        "close_gripper", self.handle_close_gripper, request, response
-                    ),
+                    self.handle_close_gripper,
                     callback_group=self.group,
                 )
                 self.create_service(
@@ -1113,205 +1103,33 @@ class SpotROS(Node):
         return handler(request, response)
 
     handle_claim = TriggerServiceDescriptor("claim")
-    # def handle_claim(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler for the claim service"""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.claim()
-    #     return response
-
     handle_release = TriggerServiceDescriptor("release")
-    # def handle_release(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler for the release service"""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.release()
-    #     return response
-
     handle_stop = TriggerServiceDescriptor("stop")
-    # def handle_stop(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler for the stop service"""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.stop()
-    #     return response
-
     handle_self_right = TriggerServiceDescriptor("self_right")
-    # def handle_self_right(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler for the self-right service"""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.self_right()
-    #     return response
-
     handle_sit = TriggerServiceDescriptor("sit")
-    # def handle_sit(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler for the sit service"""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.sit()
-    #     return response
-
     handle_stand = TriggerServiceDescriptor("stand")
-    # def handle_stand(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler for the stand service"""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.stand()
-    #     return response
-
-    handle_crouch = TriggerServiceDescriptor("crouch")
-    def handle_crouch(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler for the crouch service (standing as low as possible)"""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.stand(body_height=-0.15) # TODO
-        return response
-
+    handle_crouch = TriggerServiceDescriptor(
+        "stand", kwargs={"body_height": -0.15}
+    )  # "crouch" is just stand with height = -0.15
     handle_rollover = TriggerServiceDescriptor("battery_change_pose")
-    # def handle_rollover(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler for the rollover service"""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.battery_change_pose()
-    #     return response
-
     handle_power_on = TriggerServiceDescriptor("power_on")
-    # def handle_power_on(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler for the power-on service"""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.power_on()
-    #     return response
-
     handle_safe_power_off = TriggerServiceDescriptor("safe_power_off")
-    # def handle_safe_power_off(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler for the safe-power-off service"""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.safe_power_off()
-    #     return response
 
-    handle_estop_hard = TriggerServiceDescriptor("assertEStop")
-    def handle_estop_hard(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler to hard-eStop the robot.  The robot will immediately cut power to the motors"""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.assertEStop(True)
-        return response
-
-    handle_estop_soft = TriggerServiceDescriptor("assertEStop")
-    def handle_estop_soft(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler to soft-eStop the robot.  The robot will try to settle on the ground before cutting
-        power to the motors"""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.assertEStop(False)
-        return response
+    # TODO: Neither estop call appears to be functional atm (functions called in wrapper return a "no attribute" error)
+    handle_estop_hard = TriggerServiceDescriptor("assertEStop", kwargs={"severe": True})
+    handle_estop_soft = TriggerServiceDescriptor("assertEStop", kwargs={"severe": False})
 
     handle_estop_disengage = TriggerServiceDescriptor("disengageEStop")
-    # def handle_estop_disengage(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler to disengage the eStop on the robot."""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.disengageEStop()
-    #     return response
-
     handle_undock = TriggerServiceDescriptor("undock")
-    # def handle_undock(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler to undock the robot."""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.spot_docking.undock()
-    #     return response
 
     handle_spot_check = TriggerServiceDescriptor("spot_check.start_check")
-    # def handle_spot_check(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler to run spot check on the robot."""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.spot_check.start_check()
-    #     return response
 
     handle_arm_stow = TriggerServiceDescriptor("spot_arm.arm_stow")
-    # def handle_arm_stow(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler to stow the arm on the robot."""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.spot_arm.arm_stow()
-    #     return response
-
     handle_arm_unstow = TriggerServiceDescriptor("spot_arm.arm_unstow")
-    # def handle_arm_unstow(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler to ready (unstow) the arm on the robot."""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.spot_arm.arm_unstow()
-    #     return response
-
     handle_arm_carry = TriggerServiceDescriptor("spot_arm.arm_carry")
-    # def handle_arm_carry(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler to carry an object the robot has already grasped."""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.spot_arm.arm_carry()
-    #     return response
 
     handle_open_gripper = TriggerServiceDescriptor("spot_arm.gripper_open")
-    # def handle_open_gripper(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler to open the gripper."""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.spot_arm.gripper_open()
-    #     return response
-
     handle_close_gripper = TriggerServiceDescriptor("spot_arm.gripper_close")
-    # def handle_close_gripper(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-    #     """ROS service handler to close the gripper."""
-    #     if self.spot_wrapper is None:
-    #         response.success = False
-    #         response.message = "Spot wrapper is undefined"
-    #         return response
-    #     response.success, response.message = self.spot_wrapper.spot_arm.gripper_close()
-    #     return response
 
     def handle_gripper_angle(
         self, request: SetGripperAngle.Request, response: SetGripperAngle.Response

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -864,38 +864,6 @@ class SpotROS(Node):
 
         return response
 
-    def create_trigger_services(self) -> None:
-        services = [
-            self.handle_claim,
-            self.handle_release,
-            self.handle_stop,
-            self.handle_self_right,
-            self.handle_sit,
-            self.handle_stand,
-            self.handle_crouch,
-            self.handle_rollover,
-            self.handle_power_on,
-            self.handle_safe_power_off,
-            self.handle_estop_hard,
-            self.handle_estop_soft,
-            self.handle_estop_disengage,
-            self.handle_undock,
-            self.handle_spot_check,
-            self.handle_stop_dance,
-        ]
-        if self.has_arm:
-            services.extend(
-                [
-                    self.handle_arm_stow,
-                    self.handle_arm_carry,
-                    self.handle_arm_unstow,
-                ]
-            )
-            if not self.gripperless:
-                services.extend([self.handle_open_gripper, self.handle_close_gripper])
-        for srv in services:
-            srv.create_service(self, self.group)
-
     def metrics_callback(self, results: Any) -> None:
         """Callback for when the Spot Wrapper gets new metrics data.
         Args:
@@ -995,6 +963,38 @@ class SpotROS(Node):
             response.success = True
             return response
         return handler(request, response)
+
+    def create_trigger_services(self) -> None:
+        services = [
+            self.handle_claim,
+            self.handle_release,
+            self.handle_stop,
+            self.handle_self_right,
+            self.handle_sit,
+            self.handle_stand,
+            self.handle_crouch,
+            self.handle_rollover,
+            self.handle_power_on,
+            self.handle_safe_power_off,
+            self.handle_estop_hard,
+            self.handle_estop_soft,
+            self.handle_estop_disengage,
+            self.handle_undock,
+            self.handle_spot_check,
+            self.handle_stop_dance,
+        ]
+        if self.has_arm:
+            services.extend(
+                [
+                    self.handle_arm_stow,
+                    self.handle_arm_carry,
+                    self.handle_arm_unstow,
+                ]
+            )
+            if not self.gripperless:
+                services.extend([self.handle_open_gripper, self.handle_close_gripper])
+        for srv in services:
+            srv.create_service(self, self.group)
 
     handle_claim = TriggerServiceWrapper(SpotWrapper.claim, "claim")
     handle_release = TriggerServiceWrapper(SpotWrapper.release, "release")

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -72,6 +72,7 @@ import spot_driver.robot_command_util as robot_command_util
 # Release
 from spot_driver.ros_helpers import (
     get_from_env_and_fall_back_to_param,
+    TriggerServiceDescriptor
 )
 from spot_msgs.action import (  # type: ignore
     ExecuteDance,
@@ -435,7 +436,8 @@ class SpotROS(Node):
         self.create_service(
             Trigger,
             "claim",
-            lambda request, response: self.service_wrapper("claim", self.handle_claim, request, response),
+            self.handle_claim,
+            # lambda request, response: self.service_wrapper("claim", self.handle_claim, request, response),
             callback_group=self.group,
         )
         self.create_service(
@@ -1110,96 +1112,107 @@ class SpotROS(Node):
             return response
         return handler(request, response)
 
-    def handle_claim(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler for the claim service"""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.claim()
-        return response
+    handle_claim = TriggerServiceDescriptor("claim")
+    # def handle_claim(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler for the claim service"""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.claim()
+    #     return response
 
-    def handle_release(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler for the release service"""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.release()
-        return response
+    handle_release = TriggerServiceDescriptor("release")
+    # def handle_release(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler for the release service"""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.release()
+    #     return response
 
-    def handle_stop(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler for the stop service"""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.stop()
-        return response
+    handle_stop = TriggerServiceDescriptor("stop")
+    # def handle_stop(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler for the stop service"""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.stop()
+    #     return response
 
-    def handle_self_right(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler for the self-right service"""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.self_right()
-        return response
+    handle_self_right = TriggerServiceDescriptor("self_right")
+    # def handle_self_right(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler for the self-right service"""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.self_right()
+    #     return response
 
-    def handle_sit(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler for the sit service"""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.sit()
-        return response
+    handle_sit = TriggerServiceDescriptor("sit")
+    # def handle_sit(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler for the sit service"""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.sit()
+    #     return response
 
-    def handle_stand(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler for the stand service"""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.stand()
-        return response
+    handle_stand = TriggerServiceDescriptor("stand")
+    # def handle_stand(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler for the stand service"""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.stand()
+    #     return response
 
+    handle_crouch = TriggerServiceDescriptor("crouch")
     def handle_crouch(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
         """ROS service handler for the crouch service (standing as low as possible)"""
         if self.spot_wrapper is None:
             response.success = False
             response.message = "Spot wrapper is undefined"
             return response
-        response.success, response.message = self.spot_wrapper.stand(body_height=-0.15)
+        response.success, response.message = self.spot_wrapper.stand(body_height=-0.15) # TODO
         return response
 
-    def handle_rollover(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler for the rollover service"""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.battery_change_pose()
-        return response
+    handle_rollover = TriggerServiceDescriptor("battery_change_pose")
+    # def handle_rollover(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler for the rollover service"""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.battery_change_pose()
+    #     return response
 
-    def handle_power_on(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler for the power-on service"""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.power_on()
-        return response
+    handle_power_on = TriggerServiceDescriptor("power_on")
+    # def handle_power_on(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler for the power-on service"""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.power_on()
+    #     return response
 
-    def handle_safe_power_off(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler for the safe-power-off service"""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.safe_power_off()
-        return response
+    handle_safe_power_off = TriggerServiceDescriptor("safe_power_off")
+    # def handle_safe_power_off(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler for the safe-power-off service"""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.safe_power_off()
+    #     return response
 
+    handle_estop_hard = TriggerServiceDescriptor("assertEStop")
     def handle_estop_hard(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
         """ROS service handler to hard-eStop the robot.  The robot will immediately cut power to the motors"""
         if self.spot_wrapper is None:
@@ -1209,6 +1222,7 @@ class SpotROS(Node):
         response.success, response.message = self.spot_wrapper.assertEStop(True)
         return response
 
+    handle_estop_soft = TriggerServiceDescriptor("assertEStop")
     def handle_estop_soft(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
         """ROS service handler to soft-eStop the robot.  The robot will try to settle on the ground before cutting
         power to the motors"""
@@ -1219,77 +1233,85 @@ class SpotROS(Node):
         response.success, response.message = self.spot_wrapper.assertEStop(False)
         return response
 
-    def handle_estop_disengage(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler to disengage the eStop on the robot."""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.disengageEStop()
-        return response
+    handle_estop_disengage = TriggerServiceDescriptor("disengageEStop")
+    # def handle_estop_disengage(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler to disengage the eStop on the robot."""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.disengageEStop()
+    #     return response
 
-    def handle_undock(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler to undock the robot."""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.spot_docking.undock()
-        return response
+    handle_undock = TriggerServiceDescriptor("undock")
+    # def handle_undock(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler to undock the robot."""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.spot_docking.undock()
+    #     return response
 
-    def handle_spot_check(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler to run spot check on the robot."""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.spot_check.start_check()
-        return response
+    handle_spot_check = TriggerServiceDescriptor("spot_check.start_check")
+    # def handle_spot_check(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler to run spot check on the robot."""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.spot_check.start_check()
+    #     return response
 
-    def handle_arm_stow(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler to stow the arm on the robot."""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.spot_arm.arm_stow()
-        return response
+    handle_arm_stow = TriggerServiceDescriptor("spot_arm.arm_stow")
+    # def handle_arm_stow(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler to stow the arm on the robot."""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.spot_arm.arm_stow()
+    #     return response
 
-    def handle_arm_unstow(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler to ready (unstow) the arm on the robot."""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.spot_arm.arm_unstow()
-        return response
+    handle_arm_unstow = TriggerServiceDescriptor("spot_arm.arm_unstow")
+    # def handle_arm_unstow(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler to ready (unstow) the arm on the robot."""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.spot_arm.arm_unstow()
+    #     return response
 
-    def handle_arm_carry(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler to carry an object the robot has already grasped."""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.spot_arm.arm_carry()
-        return response
+    handle_arm_carry = TriggerServiceDescriptor("spot_arm.arm_carry")
+    # def handle_arm_carry(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler to carry an object the robot has already grasped."""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.spot_arm.arm_carry()
+    #     return response
 
-    def handle_open_gripper(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler to open the gripper."""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.spot_arm.gripper_open()
-        return response
+    handle_open_gripper = TriggerServiceDescriptor("spot_arm.gripper_open")
+    # def handle_open_gripper(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler to open the gripper."""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.spot_arm.gripper_open()
+    #     return response
 
-    def handle_close_gripper(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler to close the gripper."""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        response.success, response.message = self.spot_wrapper.spot_arm.gripper_close()
-        return response
+    handle_close_gripper = TriggerServiceDescriptor("spot_arm.gripper_close")
+    # def handle_close_gripper(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler to close the gripper."""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     response.success, response.message = self.spot_wrapper.spot_arm.gripper_close()
+    #     return response
 
     def handle_gripper_angle(
         self, request: SetGripperAngle.Request, response: SetGripperAngle.Response
@@ -1320,16 +1342,17 @@ class SpotROS(Node):
         response.message = message
         return response
 
-    def handle_stop_dance(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """ROS service handler to stop the robot's dancing."""
-        if self.spot_wrapper is None:
-            response.success = False
-            response.message = "Spot wrapper is undefined"
-            return response
-        success, msg = self.spot_wrapper.stop_choreography()
-        response.success = success
-        response.message = msg
-        return response
+    handle_stop_dance = TriggerServiceDescriptor("stop_choreography")
+    # def handle_stop_dance(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
+    #     """ROS service handler to stop the robot's dancing."""
+    #     if self.spot_wrapper is None:
+    #         response.success = False
+    #         response.message = "Spot wrapper is undefined"
+    #         return response
+    #     success, msg = self.spot_wrapper.stop_choreography()
+    #     response.success = success
+    #     response.message = msg
+    #     return response
 
     def handle_list_all_dances(
         self, request: ListAllDances.Request, response: ListAllDances.Response


### PR DESCRIPTION
## Change Overview

Made a descriptor class for trigger services to reduce boilerplate + copy/paste code in trigger service handlers

## Testing Done

Tested all trigger services on robot. Found a bug with estop handling within `spot_wrapper` (will make a new ticket to track this but out of scope for this PR)

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
