### PR TITLE
[SW-2000] increase robot state publisher rates for faster tf lookups

### DIFF
--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -95,7 +95,9 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
             " ",
         ]
     )
-    robot_description_params = {"robot_description": robot_description}
+    # publish frequency defaults to 20 Hz, resulting in slow TF lookups.
+    # Joint state information is published at 50 Hz, so choose that instead.
+    robot_description_params = {"robot_description": robot_description, "publish_frequency": 50.0}
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",

--- a/spot_driver/launch/spot_driver.launch.py
+++ b/spot_driver/launch/spot_driver.launch.py
@@ -95,9 +95,9 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
             " ",
         ]
     )
-    # publish frequency defaults to 20 Hz, resulting in slow TF lookups.
-    # Joint state information is published at 50 Hz, so choose that instead.
-    robot_description_params = {"robot_description": robot_description, "publish_frequency": 50.0}
+    # Publish frequency of the robot state publisher defaults to 20 Hz, resulting in slow TF lookups.
+    # By ignoring the timestamp, we publish a TF update in this node every time there is a joint state update (50 Hz).
+    robot_description_params = {"robot_description": robot_description, "ignore_timestamp": True}
     robot_state_publisher = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -164,12 +164,13 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
             remappings=[(f"/{tf_prefix}joint_states", f"/{tf_prefix}low_level/joint_states")],
         )
     )
+    # Joint states get published at 333 Hz, so set the TF update rate to that.
     ld.add_action(
         Node(
             package="robot_state_publisher",
             executable="robot_state_publisher",
             output="both",
-            parameters=[robot_description],
+            parameters=[robot_description, {"publish_frequency": 333.0}],
             namespace=spot_name,
             remappings=[(f"/{tf_prefix}joint_states", f"/{tf_prefix}low_level/joint_states")],
         )

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -164,13 +164,14 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
             remappings=[(f"/{tf_prefix}joint_states", f"/{tf_prefix}low_level/joint_states")],
         )
     )
-    # Joint states get published at 333 Hz, so set the TF update rate to that.
+    # Publish frequency of the robot state publisher defaults to 20 Hz, resulting in slow TF lookups.
+    # By ignoring the timestamp, we publish a TF update in this node every time there is a joint state update (333 Hz).
     ld.add_action(
         Node(
             package="robot_state_publisher",
             executable="robot_state_publisher",
             output="both",
-            parameters=[robot_description, {"publish_frequency": 333.0}],
+            parameters=[robot_description, {"ignore_timestamp": True}],
             namespace=spot_name,
             remappings=[(f"/{tf_prefix}joint_states", f"/{tf_prefix}low_level/joint_states")],
         )


### PR DESCRIPTION
## Change Overview

The robot state publisher defaults to a TF update rate of 20 Hz, this needs to be increased to prevent slow TF lookups :) 
* spot driver publishes joint states at 50 Hz, so its TF update rate should be at least that
* spot ros2 control publishes joint states at 333 Hz, so its TF update rate should be at least that 

## Testing Done

- [x] Test spot driver and ensure publishing rates of other topics is similar to before
- [x] Test spot ros2 control and ensure publishing rates of other topics is similar to before
