### PR TITLE
[SW-2049] ability to stream joint gains through hardware interface

### DIFF
--- a/spot_hardware_interface/include/spot_hardware_interface/spot_constants.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_constants.hpp
@@ -26,24 +26,4 @@ inline constexpr int kNjointsNoArm = 12;
 /// @brief Number of joints we expect if the robot has an arm
 inline constexpr int kNjointsArm = 19;
 
-// Default gain values obtained from
-// https://github.com/boston-dynamics/spot-cpp-sdk/blob/master/cpp/examples/joint_control/constants.hpp
-
-/// @brief Default k_q_p gains for robot without an arm
-inline constexpr float kDefaultKqpNoArm[] = {624.0, 936.0, 286.0, 624.0, 936.0, 286.0,
-                                             624.0, 936.0, 286.0, 624.0, 936.0, 286.0};
-
-/// @brief Default k_qd_p gains for robot without an arm
-inline constexpr float kDefaultKqdpNoArm[] = {5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04};
-
-/// @brief Default k_q_p gains for robot with an arm (note that the first 12 elements that correspond to the leg joints
-/// are the same as `kDefaultKqpNoArm`)
-inline constexpr float kDefaultKqpArm[] = {624.0, 936.0, 286.0,  624.0, 936.0, 286.0, 624.0, 936.0, 286.0, 624.0,
-                                           936.0, 286.0, 1020.0, 255.0, 204.0, 102.0, 102.0, 102.0, 16.0};
-
-/// @brief Default k_qd_p gains for robot with an arm (note that the first 12 elements that correspond to the leg joints
-/// are the same as `kDefaultKqdpNoArm`)
-inline constexpr float kDefaultKqdpArm[] = {5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20, 5.20, 2.04, 5.20,
-                                            5.20, 2.04, 10.2, 15.3, 10.2, 2.04, 2.04, 2.04, 0.32};
-
 }  // namespace spot_hardware_interface


### PR DESCRIPTION
## Change Overview

Adds k_q_p and k_qd_p to the command interface of Spot's hardware interface.These get set to an initial value via the `initial_value` field from the URDF, so existing logic here in the hardware interface to parse this input has been removed in favor of this new method. Existing controllers will not need to change anything, as they simply don't claim the interface. 

The following PR in the stack will set up a controller to allow users to easily change this at runtime.

This PR also depends on the changes from https://github.com/bdaiinstitute/spot_description/pull/3 to expose these new command interfaces in the URDF. 

## Testing Done
The default behavior from the user interface does not change with this PR.

- [x] Tested wiggle arm example successfully on robot with default gains
- [x] Tested wiggle arm example with different initial gains, verified that robot behavior adjusts accordingly
\\