### PR TITLE
[SW-2051] expose foot contact states to state streaming handler

### DIFF
--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -210,7 +210,6 @@ class SpotHardware : public hardware_interface::SystemInterface {
   // Holds IMU data for the robot received from the BD SDK
   ImuStates imu_states_;
   // Holds foot states received from the BD SDK
-  // ::bosdyn::api::FootState::Contact foot_states_;
   std::vector<int> foot_states_;
 
   // Thread for reading the state of the robot.

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -107,11 +107,7 @@ class StateStreamingHandler {
       CONTACT_MADE	1	The foot is currently in contact with the ground.
       CONTACT_LOST	2	The foot is not in contact with the ground.
    */
-  void get_states(JointStates& joint_states, ImuStates& imu_states);
-  /**
-   * @brief Reset internal state.
-   */
-  void reset();
+  void get_foot_states(std::vector<int>& foot_states);
 
  private:
   // Stores the current position, velocity, and load of the robot's joints.
@@ -126,6 +122,7 @@ class StateStreamingHandler {
   std::vector<double> imu_odom_rot_quaternion_;
   // store the current foot contact states
   std::vector<int> current_foot_state_;
+  static constexpr size_t nfeet_ = 4;
   // responsible for ensuring read/writes of joint states do not happen at the same time.
   std::mutex mutex_;
 };
@@ -175,7 +172,7 @@ class SpotHardware : public hardware_interface::SystemInterface {
   // The 3 state interfaces are position, velocity, and effort.
   static constexpr size_t state_interfaces_per_joint_ = 3;
   size_t njoints_;
-  size_t nfeet = 4;
+  static constexpr size_t nfeet_ = 4;
 
   // Login info
   std::string hostname_;

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -98,7 +98,7 @@ class StateStreamingHandler {
    */
   void handle_state_streaming(::bosdyn::api::RobotStateStreamResponse& robot_state);
   /**
-   * @brief Get structs of the current joint states and IMU data from the robot.
+   * @brief Get structs of the current joint states, IMU data, and foot contact states from the robot.
    * @return JointStates struct containing vectors of position, velocity, and load values.
    * ImuStates struct containing info on the IMU's identifier, mounting link, position, linear acceleration,
    * angular velocity, and rotation
@@ -107,7 +107,7 @@ class StateStreamingHandler {
       CONTACT_MADE	1	The foot is currently in contact with the ground.
       CONTACT_LOST	2	The foot is not in contact with the ground.
    */
-  void get_foot_states(std::vector<int>& foot_states);
+  void get_states(JointStates& joint_states, ImuStates& imu_states, std::vector<int>& foot_states);
 
  private:
   // Stores the current position, velocity, and load of the robot's joints.

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -125,7 +125,7 @@ class StateStreamingHandler {
   std::vector<double> imu_angular_velocity_;
   std::vector<double> imu_odom_rot_quaternion_;
   // store the current foot contact states
-  ::bosdyn::api::FootState::Contact current_foot_state_;
+  std::vector<int> current_foot_state_;
   // responsible for ensuring read/writes of joint states do not happen at the same time.
   std::mutex mutex_;
 };
@@ -175,6 +175,7 @@ class SpotHardware : public hardware_interface::SystemInterface {
   // The 3 state interfaces are position, velocity, and effort.
   static constexpr size_t state_interfaces_per_joint_ = 3;
   size_t njoints_;
+  size_t nfeet = 4;
 
   // Login info
   std::string hostname_;
@@ -209,7 +210,8 @@ class SpotHardware : public hardware_interface::SystemInterface {
   // Holds IMU data for the robot received from the BD SDK
   ImuStates imu_states_;
   // Holds foot states received from the BD SDK
-  ::bosdyn::api::FootState::Contact foot_states_;
+  // ::bosdyn::api::FootState::Contact foot_states_;
+  std::vector<int> foot_states_;
 
   // Thread for reading the state of the robot.
   std::jthread state_thread_;

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -108,6 +108,10 @@ class StateStreamingHandler {
       CONTACT_LOST	2	The foot is not in contact with the ground.
    */
   void get_states(JointStates& joint_states, ImuStates& imu_states, std::vector<int>& foot_states);
+  /**
+   * @brief Reset internal state.
+   */
+  void reset();
 
  private:
   // Stores the current position, velocity, and load of the robot's joints.

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -120,6 +120,7 @@ class StateStreamingHandler {
   std::vector<double> imu_linear_acceleration_;
   std::vector<double> imu_angular_velocity_;
   std::vector<double> imu_odom_rot_quaternion_;
+  ::bosdyn::api::FootState::Contact current_foot_state_;
   // responsible for ensuring read/writes of joint states do not happen at the same time.
   std::mutex mutex_;
 };
@@ -169,6 +170,7 @@ class SpotHardware : public hardware_interface::SystemInterface {
   // The 3 state interfaces are position, velocity, and effort.
   static constexpr size_t state_interfaces_per_joint_ = 3;
   size_t njoints_;
+  size_t nfeet_;
 
   // Login info
   std::string hostname_;
@@ -202,6 +204,8 @@ class SpotHardware : public hardware_interface::SystemInterface {
 
   // Holds IMU data for the robot received from the BD SDK
   ImuStates imu_states_;
+  // Holds foot states received from the BD SDK
+  ::bosdyn::api::FootState::Contact foot_states_;
 
   // Thread for reading the state of the robot.
   std::jthread state_thread_;

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -102,6 +102,10 @@ class StateStreamingHandler {
    * @return JointStates struct containing vectors of position, velocity, and load values.
    * ImuStates struct containing info on the IMU's identifier, mounting link, position, linear acceleration,
    * angular velocity, and rotation
+   * Save the current foot states of the robot where:
+   *  CONTACT_UNKNOWN	0	Unknown contact. Do not use.
+      CONTACT_MADE	1	The foot is currently in contact with the ground.
+      CONTACT_LOST	2	The foot is not in contact with the ground.
    */
   void get_states(JointStates& joint_states, ImuStates& imu_states);
   /**
@@ -120,6 +124,7 @@ class StateStreamingHandler {
   std::vector<double> imu_linear_acceleration_;
   std::vector<double> imu_angular_velocity_;
   std::vector<double> imu_odom_rot_quaternion_;
+  // store the current foot contact states
   ::bosdyn::api::FootState::Contact current_foot_state_;
   // responsible for ensuring read/writes of joint states do not happen at the same time.
   std::mutex mutex_;
@@ -170,7 +175,6 @@ class SpotHardware : public hardware_interface::SystemInterface {
   // The 3 state interfaces are position, velocity, and effort.
   static constexpr size_t state_interfaces_per_joint_ = 3;
   size_t njoints_;
-  size_t nfeet_;
 
   // Login info
   std::string hostname_;

--- a/spot_ros2_control/config/spot_default_controllers_with_arm.yaml
+++ b/spot_ros2_control/config/spot_default_controllers_with_arm.yaml
@@ -29,10 +29,6 @@ imu_sensor_broadcaster:
     sensor_name: "imu_sensor"
     frame_id: "imu_sensor_frame"
 
-foot_sensor_broadcaster:
-  ros__parameters:
-    sensor_name: "foot_sensor"
-
 forward_position_controller:
   ros__parameters:
     joints:

--- a/spot_ros2_control/config/spot_default_controllers_with_arm.yaml
+++ b/spot_ros2_control/config/spot_default_controllers_with_arm.yaml
@@ -29,6 +29,10 @@ imu_sensor_broadcaster:
     sensor_name: "imu_sensor"
     frame_id: "imu_sensor_frame"
 
+foot_sensor_broadcaster:
+  ros__parameters:
+    sensor_name: "foot_sensor"
+
 forward_position_controller:
   ros__parameters:
     joints:

--- a/spot_ros2_control/config/spot_default_controllers_without_arm.yaml
+++ b/spot_ros2_control/config/spot_default_controllers_without_arm.yaml
@@ -29,10 +29,6 @@ imu_sensor_broadcaster:
     sensor_name: "imu_sensor"
     frame_id: "imu_sensor_frame"
 
-foot_sensor_broadcaster:
-  ros__parameters:
-    sensor_name: "foot_sensor"
-
 forward_position_controller:
   ros__parameters:
     joints:

--- a/spot_ros2_control/config/spot_default_controllers_without_arm.yaml
+++ b/spot_ros2_control/config/spot_default_controllers_without_arm.yaml
@@ -29,6 +29,10 @@ imu_sensor_broadcaster:
     sensor_name: "imu_sensor"
     frame_id: "imu_sensor_frame"
 
+foot_sensor_broadcaster:
+  ros__parameters:
+    sensor_name: "foot_sensor"
+
 forward_position_controller:
   ros__parameters:
     joints:


### PR DESCRIPTION
## Change Overview

expose foot contact states in state streaming handler

## Testing Done

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
