### PR TITLE
[N/A] hotfix: bring back set gripper camera parameters service

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -736,6 +736,17 @@ class SpotROS(Node):
                 ),
                 callback_group=self.group,
             )
+            self.create_service(
+                SetGripperCameraParameters,
+                "set_gripper_camera_parameters",
+                lambda request, response: self.service_wrapper(
+                    "set_gripper_camera_parameters",
+                    self.handle_set_gripper_camera_parameters,
+                    request,
+                    response,
+                ),
+                callback_group=self.group,
+            )
 
             self.create_service(
                 OverrideGraspOrCarry,


### PR DESCRIPTION
## Change Overview

Found out this service was accidentally removed in https://github.com/bdaiinstitute/spot_ros2/pull/578, breaking some CI tests we have internally, this adds it back so we can sync the latest hash

## Testing Done

N/A
