### PR TITLE
Add bondcpp dependency to install_spot_ros2.sh

### DIFF
--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -25,7 +25,14 @@ sudo apt-get update
 
 # Install ROS dependencies
 # TODO(jschornak-bdai): use rosdep to install these packages by parsing dependencies listed in package.xml
-sudo apt install -y ros-$ROS_DISTRO-joint-state-publisher-gui ros-$ROS_DISTRO-tf-transformations ros-$ROS_DISTRO-xacro ros-$ROS_DISTRO-depth-image-proc ros-$ROS_DISTRO-tl-expected ros-$ROS_DISTRO-ros2-control ros-$ROS_DISTRO-ros2-controllers
+sudo apt install -y ros-$ROS_DISTRO-joint-state-publisher-gui \
+                    ros-$ROS_DISTRO-tf-transformations \
+                    ros-$ROS_DISTRO-xacro \
+                    ros-$ROS_DISTRO-depth-image-proc \
+                    ros-$ROS_DISTRO-tl-expected \
+                    ros-$ROS_DISTRO-ros2-control \
+                    ros-$ROS_DISTRO-ros2-controllers \
+                    ros-$ROS_DISTRO-bondcpp
 # Install the dist-utils
 sudo apt-get install -y python3-distutils
 sudo apt-get install -y python3-apt


### PR DESCRIPTION
## Change Overview

Noticed when running code locally that my `colcon build`s were failing because I was missing the bondcpp dependency added recently. This adds it to the install script

## Testing Done

Ran script locally 
