### PR TITLE
Fixes missing bondpy dependency

### DIFF
--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -32,7 +32,8 @@ sudo apt install -y ros-$ROS_DISTRO-joint-state-publisher-gui \
                     ros-$ROS_DISTRO-tl-expected \
                     ros-$ROS_DISTRO-ros2-control \
                     ros-$ROS_DISTRO-ros2-controllers \
-                    ros-$ROS_DISTRO-bondcpp
+                    ros-$ROS_DISTRO-bondcpp \
+                    ros-$ROS_DISTRO-bondpy
 # Install the dist-utils
 sudo apt-get install -y python3-distutils
 sudo apt-get install -y python3-apt


### PR DESCRIPTION
Though `bondcpp` has been added, `bondpy` dependency is required in spot_driver to start it. 

Tested with Docker on arm. 

https://github.com/bdaiinstitute/spot_ros2/issues/612




