### PR TITLE
[SW-2229] clean up autogeneration of ros2 control config files

### DIFF
--- a/spot_ros2_control/config/spot_default_controllers_with_arm.yaml
+++ b/spot_ros2_control/config/spot_default_controllers_with_arm.yaml
@@ -1,5 +1,10 @@
-# Some built in controllers, taken from
-# https://github.com/ros-controls/roscon2022_workshop/blob/master/controlko_bringup/config/rrbot_controllers.yaml
+# Copyright (c) 2024-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+
+# This is an example that demonstrates configuration of the available controllers for a robot
+# with an arm and without a namespace.
+# It is not used!
+# By default, a configuration matching this format that IS namespaced appropriately will be
+# generated and used at launch time.
 
 controller_manager:
   ros__parameters:

--- a/spot_ros2_control/config/spot_default_controllers_without_arm.yaml
+++ b/spot_ros2_control/config/spot_default_controllers_without_arm.yaml
@@ -1,5 +1,10 @@
-# Some built in controllers, taken from
-# https://github.com/ros-controls/roscon2022_workshop/blob/master/controlko_bringup/config/rrbot_controllers.yaml
+# Copyright (c) 2024-2025 Boston Dynamics AI Institute LLC. All rights reserved.
+
+# This is an example that demonstrates configuration of the available controllers for a robot
+# without an arm and without a namespace.
+# It is not used!
+# By default, a configuration matching this format that IS namespaced appropriately will be
+# generated and used at launch time.
 
 controller_manager:
   ros__parameters:


### PR DESCRIPTION
## Change Overview

Please include a summary of the changes made and the relevant ticket or issue.

## Testing Done

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
