### PR TITLE
Use `rosdep` to install ROS 2 dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,13 +106,13 @@ jobs:
       - name: Build packages
         run: |
           source /opt/ros/$ROS_DISTRO/setup.bash
-          colcon build --symlink-install --packages-up-to spot_driver spot_description spot_msgs spot_examples spot_ros2_control --cmake-args -DCMAKE_CXX_FLAGS="--coverage"
+          colcon build --symlink-install --packages-up-to spot_driver spot_description spot_msgs spot_examples spot_ros2_control spot_common --cmake-args -DCMAKE_CXX_FLAGS="--coverage"
         working-directory: ${{ github.workspace }}/../../
 
       - name: Test non-spot-driver packages
         run: |
           source install/setup.bash
-          colcon test --event-handlers console_direct+ --packages-select spot_description spot_examples spot_msgs
+          colcon test --event-handlers console_direct+ --packages-select spot_description spot_examples spot_msgs spot_common
         working-directory: ${{ github.workspace }}/../../
       
       # Per https://github.com/colcon/colcon-ros/issues/151, `pytest-args` cannot be used in an ament_cmake package, so in order to pass arguments to pytest we have to run pytest directly

--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -1,7 +1,6 @@
 ARCH="amd64"
 SDK_VERSION="4.1.1"
 MSG_VERSION="${SDK_VERSION}"
-ROS_DISTRO=humble
 HELP=$'--arm64: Installs ARM64 version'
 REQUIREMENTS_FILE=spot_wrapper/requirements.txt
 
@@ -24,16 +23,13 @@ fi
 sudo apt-get update
 
 # Install ROS dependencies
-# TODO(jschornak-bdai): use rosdep to install these packages by parsing dependencies listed in package.xml
-sudo apt install -y ros-$ROS_DISTRO-joint-state-publisher-gui \
-                    ros-$ROS_DISTRO-tf-transformations \
-                    ros-$ROS_DISTRO-xacro \
-                    ros-$ROS_DISTRO-depth-image-proc \
-                    ros-$ROS_DISTRO-tl-expected \
-                    ros-$ROS_DISTRO-ros2-control \
-                    ros-$ROS_DISTRO-ros2-controllers \
-                    ros-$ROS_DISTRO-bondcpp \
-                    ros-$ROS_DISTRO-bondpy
+sudo apt-get install -y python3-rosdep
+#NOTE: Initialize only if a sources list definition doesn't exist yet - avoids the rosdep error message
+if ! [[ $(ls /etc/ros/rosdep/sources.list.d/*default.list 2> /dev/null) ]]; then
+  sudo rosdep init
+fi
+rosdep update && rosdep install --from-paths ./ --ignore-src -y -r
+
 # Install the dist-utils
 sudo apt-get install -y python3-distutils
 sudo apt-get install -y python3-apt

--- a/spot_ros2_control/package.xml
+++ b/spot_ros2_control/package.xml
@@ -18,6 +18,8 @@ Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
   <depend>rclcpp_lifecycle</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>ros2_control</depend>
+  <depend>ros2_controllers</depend>
   <depend>spot_hardware_interface</depend>
 
   <exec_depend>controller_manager</exec_depend>


### PR DESCRIPTION
## Change Overview

Just a small thing. I refactored the ROS dependency installation steps in `install_spot_ros2.sh` to use the `rosdep` utility instead of having to add the manual install commands. I made an assumption that `rosdep` might not be installed on the machine at all, so it will also attempt to install and initialize.

There were 3 packages that are not included in any `package.xml` definitions:
* `tf_transformations`
* `ros2_control`
* `ros2_controllers`

All spot packages are building locally on my machine and the driver launches without having these three installed, so I didn't proactively include them anywhere. However, we don't have the joint-level API license, so I don't think I'll be able to test if any of the `spot_ros2_control` nodes don't need some of those libraries at runtime.

Unrelated: I also added the new `spot_common` package to build and test steps for CI.

## Testing Done

1. Removed all ROS dependencies that were listed explicitly in old `install_spot_ros2.sh`.
2. Ran the new version and observed that all missing ROS 2 packages are being installed through `rosdep`.
3. `colcon build` all packages and verify that everything builds.
4. Launch the spot driver and verify that all works.

