### PR TITLE
[Sw-2050] expose body pose

### DIFF
--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -107,7 +107,7 @@ class StateStreamingHandler {
       CONTACT_MADE	1	The foot is currently in contact with the ground.
       CONTACT_LOST	2	The foot is not in contact with the ground.
    */
-  void get_states(JointStates& joint_states, ImuStates& imu_states, std::vector<int>& foot_states);
+  void get_states(JointStates& joint_states, ImuStates& imu_states, std::vector<int>& foot_states, std::vector<float>& odom_pose, std::vector<float>& vision_pose);
   /**
    * @brief Reset internal state.
    */
@@ -127,6 +127,11 @@ class StateStreamingHandler {
   // store the current foot contact states
   std::vector<int> current_foot_state_;
   static constexpr size_t nfeet_ = 4;
+  // store current body pose
+  std::vector<float> odom_tform_body_pos_; // (x, y, z) in m
+  std::vector<float> odom_tform_body_rot_; // (x, y, z, w) quaternion
+  std::vector<float> vision_tform_body_pos_; // (x, y, z) in m
+  std::vector<float> vision_tform_body_rot_; // (x, y, z, w) quaternion
   // responsible for ensuring read/writes of joint states do not happen at the same time.
   std::mutex mutex_;
 };
@@ -221,6 +226,11 @@ class SpotHardware : public hardware_interface::SystemInterface {
   ImuStates imu_states_;
   // Holds foot states received from the BD SDK
   std::vector<int> foot_states_;
+  // Holds body poses received from the BD SDK
+  std::vector<float> odom_tform_body_pos_;
+  std::vector<float> vision_tform_body_rot_;
+  std::vector<float> odom_tform_body_pos_;
+  std::vector<float> vision_tform_body_rot_;
 
   // Thread for reading the state of the robot.
   std::jthread state_thread_;

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -106,6 +106,7 @@ class StateStreamingHandler {
    *  CONTACT_UNKNOWN	0	Unknown contact. Do not use.
       CONTACT_MADE	1	The foot is currently in contact with the ground.
       CONTACT_LOST	2	The foot is not in contact with the ground.
+   * Save the current transforms from odom to body and vision to body frames
    */
   void get_states(JointStates& joint_states, ImuStates& imu_states, std::vector<int>& foot_states,
                   std::vector<float>& odom_pose, std::vector<float>& vision_pose);
@@ -185,14 +186,17 @@ class SpotHardware : public hardware_interface::SystemInterface {
   static constexpr size_t nfeet_ = 4;
   // Sensor configuration
   // We have 2 sensors, IMU and feet contact
-  static constexpr size_t n_sensors_ = 2;
+  static constexpr size_t n_sensors_ = 4;
   // index we expect these sensors to be at in info_.sensors
   static constexpr size_t imu_sensor_index_ = 0;
   static constexpr size_t foot_sensor_index_ = 1;
+  static constexpr size_t odom_to_body_sensor_index_ = 2;
+  static constexpr size_t vision_to_body_sensor_index_ = 3;
   // number of state interfaces we expect per sensor
   static constexpr size_t n_imu_sensor_interfaces_ = 10;
   static constexpr size_t n_foot_sensor_interfaces_ = 4;
-  static constexpr size_t n_body_sensor_interfaces_ = 14;
+  static constexpr size_t n_odom_body_sensor_interfaces_ = 7;
+  static constexpr size_t n_vision_body_sensor_interfaces_ = 7;
 
   // Login info
   std::string hostname_;

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -107,7 +107,8 @@ class StateStreamingHandler {
       CONTACT_MADE	1	The foot is currently in contact with the ground.
       CONTACT_LOST	2	The foot is not in contact with the ground.
    */
-  void get_states(JointStates& joint_states, ImuStates& imu_states, std::vector<int>& foot_states, std::vector<float>& odom_pose, std::vector<float>& vision_pose);
+  void get_states(JointStates& joint_states, ImuStates& imu_states, std::vector<int>& foot_states,
+                  std::vector<float>& odom_pose, std::vector<float>& vision_pose);
   /**
    * @brief Reset internal state.
    */
@@ -128,10 +129,10 @@ class StateStreamingHandler {
   std::vector<int> current_foot_state_;
   static constexpr size_t nfeet_ = 4;
   // store current body pose
-  std::vector<float> odom_tform_body_pos_; // (x, y, z) in m
-  std::vector<float> odom_tform_body_rot_; // (x, y, z, w) quaternion
-  std::vector<float> vision_tform_body_pos_; // (x, y, z) in m
-  std::vector<float> vision_tform_body_rot_; // (x, y, z, w) quaternion
+  std::vector<float> odom_tform_body_pos_;    // (x, y, z) in m
+  std::vector<float> odom_tform_body_rot_;    // (x, y, z, w) quaternion
+  std::vector<float> vision_tform_body_pos_;  // (x, y, z) in m
+  std::vector<float> vision_tform_body_rot_;  // (x, y, z, w) quaternion
   // responsible for ensuring read/writes of joint states do not happen at the same time.
   std::mutex mutex_;
 };
@@ -228,8 +229,8 @@ class SpotHardware : public hardware_interface::SystemInterface {
   // Holds foot states received from the BD SDK
   std::vector<int> foot_states_;
   // Holds body poses received from the BD SDK
-  std::vector<float> odom_pos_; // (x, y, z) in m
-  std::vector<float> odom_rot_; // (x, y, z, w)
+  std::vector<float> odom_pos_;  // (x, y, z) in m
+  std::vector<float> odom_rot_;  // (x, y, z, w)
   std::vector<float> vision_pos_;
   std::vector<float> vision_rot_;
 

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -109,7 +109,8 @@ class StateStreamingHandler {
    * Save the current transforms from odom to body and vision to body frames
    */
   void get_states(JointStates& joint_states, ImuStates& imu_states, std::vector<int>& foot_states,
-                  std::vector<float>& odom_pose, std::vector<float>& vision_pose);
+                  std::vector<double>& odom_pos, std::vector<double>& odom_rot, std::vector<double>& vision_pos,
+                  std::vector<double>& vision_rot);
   /**
    * @brief Reset internal state.
    */
@@ -130,10 +131,10 @@ class StateStreamingHandler {
   std::vector<int> current_foot_state_;
   static constexpr size_t nfeet_ = 4;
   // store current body pose
-  std::vector<float> odom_tform_body_pos_;    // (x, y, z) in m
-  std::vector<float> odom_tform_body_rot_;    // (x, y, z, w) quaternion
-  std::vector<float> vision_tform_body_pos_;  // (x, y, z) in m
-  std::vector<float> vision_tform_body_rot_;  // (x, y, z, w) quaternion
+  std::vector<double> odom_tform_body_pos_;    // (x, y, z) in m
+  std::vector<double> odom_tform_body_rot_;    // (x, y, z, w) quaternion
+  std::vector<double> vision_tform_body_pos_;  // (x, y, z) in m
+  std::vector<double> vision_tform_body_rot_;  // (x, y, z, w) quaternion
   // responsible for ensuring read/writes of joint states do not happen at the same time.
   std::mutex mutex_;
 };
@@ -233,10 +234,10 @@ class SpotHardware : public hardware_interface::SystemInterface {
   // Holds foot states received from the BD SDK
   std::vector<int> foot_states_;
   // Holds body poses received from the BD SDK
-  std::vector<float> odom_pos_;  // (x, y, z) in m
-  std::vector<float> odom_rot_;  // (x, y, z, w)
-  std::vector<float> vision_pos_;
-  std::vector<float> vision_rot_;
+  std::vector<double> odom_pos_;  // (x, y, z) in m
+  std::vector<double> odom_rot_;  // (x, y, z, w)
+  std::vector<double> vision_pos_;
+  std::vector<double> vision_rot_;
 
   // Thread for reading the state of the robot.
   std::jthread state_thread_;

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -326,6 +326,8 @@ class SpotHardware : public hardware_interface::SystemInterface {
 
   std::vector<double> hw_imu_sensor_states_;
   std::vector<double> hw_foot_sensor_states_;
+  std::vector<double> hw_odom_body_sensor_states_;    // Holds the odom to body transforms
+  std::vector<double> hw_vision_body_sensor_states_;  // Holds the vision to body transforms
 };
 
 }  // namespace spot_hardware_interface

--- a/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
+++ b/spot_hardware_interface/include/spot_hardware_interface/spot_hardware_interface.hpp
@@ -191,6 +191,7 @@ class SpotHardware : public hardware_interface::SystemInterface {
   // number of state interfaces we expect per sensor
   static constexpr size_t n_imu_sensor_interfaces_ = 10;
   static constexpr size_t n_foot_sensor_interfaces_ = 4;
+  static constexpr size_t n_body_sensor_interfaces_ = 14;
 
   // Login info
   std::string hostname_;
@@ -227,10 +228,10 @@ class SpotHardware : public hardware_interface::SystemInterface {
   // Holds foot states received from the BD SDK
   std::vector<int> foot_states_;
   // Holds body poses received from the BD SDK
-  std::vector<float> odom_tform_body_pos_;
-  std::vector<float> vision_tform_body_rot_;
-  std::vector<float> odom_tform_body_pos_;
-  std::vector<float> vision_tform_body_rot_;
+  std::vector<float> odom_pos_; // (x, y, z) in m
+  std::vector<float> odom_rot_; // (x, y, z, w)
+  std::vector<float> vision_pos_;
+  std::vector<float> vision_rot_;
 
   // Thread for reading the state of the robot.
   std::jthread state_thread_;

--- a/spot_hardware_interface/src/spot_hardware_interface.cpp
+++ b/spot_hardware_interface/src/spot_hardware_interface.cpp
@@ -61,10 +61,21 @@ void StateStreamingHandler::handle_state_streaming(::bosdyn::api::RobotStateStre
   imu_linear_acceleration_ = {acceleration_msg.x(), acceleration_msg.y(), acceleration_msg.z()};
   imu_angular_velocity_ = {angular_vel_msg.x(), angular_vel_msg.y(), angular_vel_msg.z()};
   imu_odom_rot_quaternion_ = {rot_msg.x(), rot_msg.y(), rot_msg.z(), rot_msg.w()};
+
+  // Get body pose data from the robot
+  const auto& odom_tform_body_pos_msg = robot_state.kinematic_state().odom_tform_body().position();
+  const auto& odom_tform_body_rot_msg = robot_state.kinematic_state().odom_tform_body().rotation();
+  const auto& vision_tform_body_pos_msg = robot_state.kinematic_state().vision_tform_body().position();
+  const auto& vision_tform_body_rot_msg = robot_state.kinematic_state().vision_tform_body().rotation();
+  // Save poses
+  odom_tform_body_pos_ = {odom_tform_body_pos_msg.x(), odom_tform_body_pos_msg.y(), odom_tform_body_pos_msg.z()};
+  odom_tform_body_rot_ = {odom_tform_body_rot_msg.x(), odom_tform_body_rot_msg.y(), odom_tform_body_rot_msg.z(), odom_tform_body_rot_msg.w()};
+  vision_tform_body_pos_ = {vision_tform_body_pos_msg.x(), vision_tform_body_pos_msg.y(), vision_tform_body_pos_msg.z()};
+  vision_tform_body_rot_ = {vision_tform_body_rot_msg.x(), vision_tform_body_rot_msg.y(), vision_tform_body_rot_msg.z(), vision_tform_body_rot_msg.w()};
 }
 
 void StateStreamingHandler::get_states(JointStates& joint_states, ImuStates& imu_states,
-                                       std::vector<int>& foot_states) {
+                                       std::vector<int>& foot_states, std::vector<float>& odom_pose, std::vector<float>& vision_pose) {
   // lock so that read/write doesn't happen at the same time
   const std::lock_guard<std::mutex> lock(mutex_);
   // Fill in members of the joint states stuct passed in by reference.
@@ -405,6 +416,8 @@ hardware_interface::return_type SpotHardware::read(const rclcpp::Time& /*time*/,
     }
     init_state_ = true;
   }
+
+  // Fill in body pose hw state
 
   // Read IMU sensor values into sensor states
   // Load rotation quaternion (x, y, z, w)

--- a/spot_hardware_interface/src/spot_hardware_interface.cpp
+++ b/spot_hardware_interface/src/spot_hardware_interface.cpp
@@ -250,8 +250,9 @@ hardware_interface::CallbackReturn SpotHardware::on_init(const hardware_interfac
   hw_states_.resize(njoints_ * state_interfaces_per_joint_, std::numeric_limits<double>::quiet_NaN());
   hw_commands_.resize(njoints_ * command_interfaces_per_joint_, std::numeric_limits<double>::quiet_NaN());
   hw_imu_sensor_states_.resize((n_imu_sensor_interfaces_), std::numeric_limits<double>::quiet_NaN());
-  hw_foot_sensor_states_.resize((n_foot_sensor_interfaces_ + n_odom_body_sensor_interfaces_ +
-                            n_odom_body_sensor_interfaces_), std::numeric_limits<double>::quiet_NaN());
+  hw_foot_sensor_states_.resize((n_foot_sensor_interfaces_), std::numeric_limits<double>::quiet_NaN());
+  hw_odom_body_sensor_states_.resize((n_odom_body_sensor_interfaces_), std::numeric_limits<double>::quiet_NaN());
+  hw_vision_body_sensor_states_.resize((n_vision_body_sensor_interfaces_), std::numeric_limits<double>::quiet_NaN());
 
   return hardware_interface::CallbackReturn::SUCCESS;
 }
@@ -345,6 +346,20 @@ std::vector<hardware_interface::StateInterface> SpotHardware::export_state_inter
   for (size_t i = 0; i < n_foot_sensor_interfaces_; i++) {
     state_interfaces.emplace_back(hardware_interface::StateInterface(
         foot_sensor.name, foot_sensor.state_interfaces[i].name, &hw_foot_sensor_states_[i]));
+  }
+
+  // export odom to body transform sensor states
+  const auto& odom_to_body_sensor = info_.sensors[odom_to_body_sensor_index_];
+  for (size_t i = 0; i < n_odom_body_sensor_interfaces_; i++) {
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+        odom_to_body_sensor.name, odom_to_body_sensor.state_interfaces[i].name, &hw_odom_body_sensor_states_[i]));
+  }
+
+  // export vision to body transform sensor states
+  const auto& vision_to_body_sensor = info_.sensors[vision_to_body_sensor_index_];
+  for (size_t i = 0; i < n_vision_body_sensor_interfaces_; i++) {
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+        vision_to_body_sensor.name, vision_to_body_sensor.state_interfaces[i].name, &hw_vision_body_sensor_states_[i]));
   }
 
   return state_interfaces;
@@ -457,28 +472,25 @@ hardware_interface::return_type SpotHardware::read(const rclcpp::Time& /*time*/,
   hw_imu_sensor_states_.at(9) = imu_states_.linear_acceleration.at(2);
 
   // Load foot contact states
-  hw_foot_sensor_states_.at(0) = foot_states_.at(0);
-  hw_foot_sensor_states_.at(1) = foot_states_.at(1);
-  hw_foot_sensor_states_.at(2) = foot_states_.at(2);
-  hw_foot_sensor_states_.at(3) = foot_states_.at(3);
+  hw_foot_sensor_states_.assign(foot_states_.begin(), foot_states_.end());
 
   // Load odom to body transform
-  hw_sensor_states_.at(14) = odom_pos_.at(0);
-  hw_sensor_states_.at(15) = odom_pos_.at(1);
-  hw_sensor_states_.at(16) = odom_pos_.at(2);
-  hw_sensor_states_.at(17) = odom_rot_.at(0);
-  hw_sensor_states_.at(18) = odom_rot_.at(1);
-  hw_sensor_states_.at(19) = odom_rot_.at(2);
-  hw_sensor_states_.at(20) = odom_rot_.at(3);
+  hw_odom_body_sensor_states_.at(0) = odom_pos_.at(0);
+  hw_odom_body_sensor_states_.at(1) = odom_pos_.at(1);
+  hw_odom_body_sensor_states_.at(2) = odom_pos_.at(2);
+  hw_odom_body_sensor_states_.at(3) = odom_rot_.at(0);
+  hw_odom_body_sensor_states_.at(4) = odom_rot_.at(1);
+  hw_odom_body_sensor_states_.at(5) = odom_rot_.at(2);
+  hw_odom_body_sensor_states_.at(6) = odom_rot_.at(3);
 
   // Load vision to body transform
-  hw_sensor_states_.at(21) = vision_pos_.at(0);
-  hw_sensor_states_.at(22) = vision_pos_.at(1);
-  hw_sensor_states_.at(23) = vision_pos_.at(2);
-  hw_sensor_states_.at(24) = vision_rot_.at(0);
-  hw_sensor_states_.at(25) = vision_rot_.at(1);
-  hw_sensor_states_.at(26) = vision_rot_.at(2);
-  hw_sensor_states_.at(27) = vision_rot_.at(3);
+  hw_vision_body_sensor_states_.at(0) = vision_pos_.at(0);
+  hw_vision_body_sensor_states_.at(1) = vision_pos_.at(1);
+  hw_vision_body_sensor_states_.at(2) = vision_pos_.at(2);
+  hw_vision_body_sensor_states_.at(3) = vision_rot_.at(0);
+  hw_vision_body_sensor_states_.at(4) = vision_rot_.at(1);
+  hw_vision_body_sensor_states_.at(5) = vision_rot_.at(2);
+  hw_vision_body_sensor_states_.at(6) = vision_rot_.at(3);
 
   return hardware_interface::return_type::OK;
 }

--- a/spot_hardware_interface/src/spot_hardware_interface.cpp
+++ b/spot_hardware_interface/src/spot_hardware_interface.cpp
@@ -69,15 +69,17 @@ void StateStreamingHandler::handle_state_streaming(::bosdyn::api::RobotStateStre
   const auto& vision_tform_body_rot_msg = robot_state.kinematic_state().vision_tform_body().rotation();
   // Save poses
   odom_tform_body_pos_ = {odom_tform_body_pos_msg.x(), odom_tform_body_pos_msg.y(), odom_tform_body_pos_msg.z()};
-  odom_tform_body_rot_ = {odom_tform_body_rot_msg.x(), odom_tform_body_rot_msg.y(), odom_tform_body_rot_msg.z(), odom_tform_body_rot_msg.w()};
-  vision_tform_body_pos_ = {vision_tform_body_pos_msg.x(), vision_tform_body_pos_msg.y(), vision_tform_body_pos_msg.z()};
-  vision_tform_body_rot_ = {vision_tform_body_rot_msg.x(), vision_tform_body_rot_msg.y(), vision_tform_body_rot_msg.z(), vision_tform_body_rot_msg.w()};
+  odom_tform_body_rot_ = {odom_tform_body_rot_msg.x(), odom_tform_body_rot_msg.y(), odom_tform_body_rot_msg.z(),
+                          odom_tform_body_rot_msg.w()};
+  vision_tform_body_pos_ = {vision_tform_body_pos_msg.x(), vision_tform_body_pos_msg.y(),
+                            vision_tform_body_pos_msg.z()};
+  vision_tform_body_rot_ = {vision_tform_body_rot_msg.x(), vision_tform_body_rot_msg.y(), vision_tform_body_rot_msg.z(),
+                            vision_tform_body_rot_msg.w()};
 }
 
-void StateStreamingHandler::get_states(JointStates& joint_states, ImuStates& imu_states,
-                                       std::vector<int>& foot_states, std::vector<float>& odom_pos, 
-                                       std::vector<float>& odom_rot, std::vector<float>& vision_pos,
-                                       std::vector<float>& vision_rot) {
+void StateStreamingHandler::get_states(JointStates& joint_states, ImuStates& imu_states, std::vector<int>& foot_states,
+                                       std::vector<float>& odom_pos, std::vector<float>& odom_rot,
+                                       std::vector<float>& vision_pos, std::vector<float>& vision_rot) {
   // lock so that read/write doesn't happen at the same time
   const std::lock_guard<std::mutex> lock(mutex_);
   // Fill in members of the joint states stuct passed in by reference.
@@ -385,7 +387,8 @@ hardware_interface::CallbackReturn SpotHardware::on_cleanup(const rclcpp_lifecyc
 }
 
 hardware_interface::return_type SpotHardware::read(const rclcpp::Time& /*time*/, const rclcpp::Duration& /*period*/) {
-  state_streaming_handler_.get_states(joint_states_, imu_states_, foot_states_, odom_pos_, odom_rot_, vision_pos_, vision_rot_);
+  state_streaming_handler_.get_states(joint_states_, imu_states_, foot_states_, odom_pos_, odom_rot_, vision_pos_,
+                                      vision_rot_);
   const auto& joint_pos = joint_states_.position;
   const auto& joint_vel = joint_states_.velocity;
   const auto& joint_load = joint_states_.load;

--- a/spot_hardware_interface/src/spot_hardware_interface.cpp
+++ b/spot_hardware_interface/src/spot_hardware_interface.cpp
@@ -78,8 +78,8 @@ void StateStreamingHandler::handle_state_streaming(::bosdyn::api::RobotStateStre
 }
 
 void StateStreamingHandler::get_states(JointStates& joint_states, ImuStates& imu_states, std::vector<int>& foot_states,
-                                       std::vector<float>& odom_pos, std::vector<float>& odom_rot,
-                                       std::vector<float>& vision_pos, std::vector<float>& vision_rot) {
+                                       std::vector<double>& odom_pos, std::vector<double>& odom_rot,
+                                       std::vector<double>& vision_pos, std::vector<double>& vision_rot) {
   // lock so that read/write doesn't happen at the same time
   const std::lock_guard<std::mutex> lock(mutex_);
   // Fill in members of the joint states stuct passed in by reference.
@@ -238,10 +238,10 @@ hardware_interface::CallbackReturn SpotHardware::on_init(const hardware_interfac
                  info_.sensors[odom_to_body_sensor_index_].state_interfaces.size(), n_odom_body_sensor_interfaces_);
     return hardware_interface::CallbackReturn::ERROR;
   }
-  if (info_.sensors[vision_to_body_sensor_index_].state_interfaces.size() != n_vision_body_sensor_interfaces_ {
+  if (info_.sensors[vision_to_body_sensor_index_].state_interfaces.size() != n_vision_body_sensor_interfaces_) {
     RCLCPP_FATAL(rclcpp::get_logger("SpotHardware"),
                  "Vision to body frame state interface has %ld state interfaces found. '%ld' expected.",
-                 info_.sensors[vision_to_body_sensor_index_].state_interfaces.size(), n_vision_body_sensor_interfaces_;
+                 info_.sensors[vision_to_body_sensor_index_].state_interfaces.size(), n_vision_body_sensor_interfaces_);
     return hardware_interface::CallbackReturn::ERROR;
   }
 
@@ -250,7 +250,8 @@ hardware_interface::CallbackReturn SpotHardware::on_init(const hardware_interfac
   hw_states_.resize(njoints_ * state_interfaces_per_joint_, std::numeric_limits<double>::quiet_NaN());
   hw_commands_.resize(njoints_ * command_interfaces_per_joint_, std::numeric_limits<double>::quiet_NaN());
   hw_imu_sensor_states_.resize((n_imu_sensor_interfaces_), std::numeric_limits<double>::quiet_NaN());
-  hw_foot_sensor_states_.resize((n_foot_sensor_interfaces_ + n_body_sensor_interfaces_), std::numeric_limits<double>::quiet_NaN());
+  hw_foot_sensor_states_.resize((n_foot_sensor_interfaces_ + n_odom_body_sensor_interfaces_ +
+                            n_odom_body_sensor_interfaces_), std::numeric_limits<double>::quiet_NaN());
 
   return hardware_interface::CallbackReturn::SUCCESS;
 }

--- a/spot_hardware_interface/src/spot_hardware_interface.cpp
+++ b/spot_hardware_interface/src/spot_hardware_interface.cpp
@@ -232,6 +232,18 @@ hardware_interface::CallbackReturn SpotHardware::on_init(const hardware_interfac
                  info_.sensors[foot_sensor_index_].state_interfaces.size(), n_foot_sensor_interfaces_);
     return hardware_interface::CallbackReturn::ERROR;
   }
+  if (info_.sensors[odom_to_body_sensor_index_].state_interfaces.size() != n_odom_body_sensor_interfaces_) {
+    RCLCPP_FATAL(rclcpp::get_logger("SpotHardware"),
+                 "Odom to body frame sensor state interface has %ld state interfaces found. '%ld' expected.",
+                 info_.sensors[odom_to_body_sensor_index_].state_interfaces.size(), n_odom_body_sensor_interfaces_);
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+  if (info_.sensors[vision_to_body_sensor_index_].state_interfaces.size() != n_vision_body_sensor_interfaces_ {
+    RCLCPP_FATAL(rclcpp::get_logger("SpotHardware"),
+                 "Vision to body frame state interface has %ld state interfaces found. '%ld' expected.",
+                 info_.sensors[vision_to_body_sensor_index_].state_interfaces.size(), n_vision_body_sensor_interfaces_;
+    return hardware_interface::CallbackReturn::ERROR;
+  }
 
   // resize to fit the expected number of interfaces
   njoints_ = info_.joints.size();


### PR DESCRIPTION
## Change Overview

Exposes the odom to body and vision to body transforms in the ros2_control hardware interface.
Needs https://github.com/bdaiinstitute/spot_description/pull/10

## Testing Done

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
