### PR TITLE
[SW-2321] Simple CI test for spot ros2 control

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
 # Global owners
 *           @METEORITENMAX @jbarry-bdai @amessing-bdai @mpickett-bdai @bhung-bdai @tcappellari-bdai @khughes-bdai
-
-# Directory owners
-.github     @jiuguangw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,10 @@ jobs:
           colcon test --event-handlers console_direct+ --packages-select spot_driver
         working-directory: ${{ github.workspace }}/../../
 
-      # Per https://github.com/colcon/colcon-ros/issues/151, `pytest-args` cannot be used in an ament_cmake package, so in order to pass arguments to pytest we have to run pytest directly
       - name: Test spot_ros2_control
         run: |
           source install/setup.bash
-          pytest -n auto $GITHUB_WORKSPACE/spot_ros2_control/test/pytests/
+          colcon test --event-handlers console_direct+ --packages-select spot_ros2_control
         working-directory: ${{ github.workspace }}/../../
 
       - name: Generate coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,13 @@ jobs:
           colcon test --event-handlers console_direct+ --packages-select spot_driver
         working-directory: ${{ github.workspace }}/../../
 
+      # Per https://github.com/colcon/colcon-ros/issues/151, `pytest-args` cannot be used in an ament_cmake package, so in order to pass arguments to pytest we have to run pytest directly
+      - name: Test spot_ros2_control
+        run: |
+          source install/setup.bash
+          pytest -n auto $GITHUB_WORKSPACE/spot_ros2_control/test/pytests/
+        working-directory: ${{ github.workspace }}/../../
+
       - name: Generate coverage report
         run: lcov -c -d build/spot_driver/ -o coverage_spot_driver.info --include "*/spot_driver/*" --exclude "*/test/*"
         working-directory: ${{ github.workspace }}/../../

--- a/spot_controllers/CMakeLists.txt
+++ b/spot_controllers/CMakeLists.txt
@@ -25,14 +25,6 @@ foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # comment the line when a copyright and license is added to all source files
-  set(ament_cmake_copyright_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-endif()
-
 generate_parameter_library(
   forward_state_controller_parameters
   include/spot_controllers/forward_state_controller_parameters.yaml

--- a/spot_controllers/package.xml
+++ b/spot_controllers/package.xml
@@ -9,9 +9,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
-
   <depend>controller_interface</depend>
   <depend>forward_command_controller</depend>
   <depend>pluginlib</depend>

--- a/spot_hardware_interface/CMakeLists.txt
+++ b/spot_hardware_interface/CMakeLists.txt
@@ -28,14 +28,6 @@ foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
 endforeach()
 find_package(bosdyn REQUIRED)
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # comment the line when a copyright and license is added to all source files
-  set(ament_cmake_copyright_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-endif()
-
 # Add the hardware interface
 add_library(
   spot_hardware_interface

--- a/spot_hardware_interface/package.xml
+++ b/spot_hardware_interface/package.xml
@@ -26,9 +26,6 @@ Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
   <exec_depend>spot_description</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/spot_ros2_control/CMakeLists.txt
+++ b/spot_ros2_control/CMakeLists.txt
@@ -88,4 +88,8 @@ install(TARGETS spot_ros2_control
 
 ament_export_targets(export_spot_ros2_control HAS_LIBRARY_TARGET)
 
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
+
 ament_package()

--- a/spot_ros2_control/CMakeLists.txt
+++ b/spot_ros2_control/CMakeLists.txt
@@ -24,14 +24,6 @@ foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # comment the line when a copyright and license is added to all source files
-  set(ament_cmake_copyright_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-endif()
-
 # Add the hardware interface
 add_library(
   spot_ros2_control

--- a/spot_ros2_control/package.xml
+++ b/spot_ros2_control/package.xml
@@ -28,8 +28,12 @@ Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
   <exec_depend>spot_controllers</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>python3-pytest-cov</test_depend>
+  <test_depend>python3-yaml</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_pytest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/spot_ros2_control/test/CMakeLists.txt
+++ b/spot_ros2_control/test/CMakeLists.txt
@@ -2,6 +2,4 @@
 ########################### C++ #################################
 find_package(ament_cmake_pytest REQUIRED)
 
-ament_add_pytest_test(
-    spot_ros2_control_pytest ${CMAKE_CURRENT_SOURCE_DIR} TIMEOUT 1800
-)
+ament_add_pytest_test(spot_ros2_control_pytest ${CMAKE_CURRENT_SOURCE_DIR} TIMEOUT 60)

--- a/spot_ros2_control/test/CMakeLists.txt
+++ b/spot_ros2_control/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
-########################### C++ #################################
+
 find_package(ament_cmake_pytest REQUIRED)
 
 ament_add_pytest_test(spot_ros2_control_pytest ${CMAKE_CURRENT_SOURCE_DIR} TIMEOUT 60)

--- a/spot_ros2_control/test/CMakeLists.txt
+++ b/spot_ros2_control/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+########################### C++ #################################
+find_package(ament_cmake_pytest REQUIRED)
+
+ament_add_pytest_test(
+    spot_ros2_control_pytest ${CMAKE_CURRENT_SOURCE_DIR} TIMEOUT 1800
+)

--- a/spot_ros2_control/test/pytests/conftest.py
+++ b/spot_ros2_control/test/pytests/conftest.py
@@ -20,11 +20,13 @@ from spot_wrapper.testing.fixtures import SpotFixture
 from spot_wrapper.testing.mocks import MockSpot
 
 
-# there is probably a better way to do this
+# this mocks a spot with an arm
 @spot_wrapper.testing.fixture
 class simple_spot(MockSpot):
     def __init__(self):
         super().__init__()
+        manipulator_state = self.robot_state.manipulator_state
+        manipulator_state.is_gripper_holding_item = False
 
 
 @pytest.fixture

--- a/spot_ros2_control/test/pytests/conftest.py
+++ b/spot_ros2_control/test/pytests/conftest.py
@@ -44,7 +44,31 @@ def ros(simple_spot: SpotFixture, domain_id: int) -> Iterator[ROSAwareScope]:
 
 
 @launch_pytest.fixture
-def spot_ros2_control_graph_description(simple_spot: SpotFixture, domain_id: int) -> Iterator[LaunchDescription]:
+def mock_spot_ros2_control(domain_id: int, spot_name: str = "", mock_arm: bool = True) -> Iterator[LaunchDescription]:
+    ld = LaunchDescription(
+        [
+            SetEnvironmentVariable("ROS_DOMAIN_ID", str(domain_id)),
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(
+                    PathJoinSubstitution(
+                        [
+                            FindPackageShare("spot_ros2_control"),
+                            "launch",
+                            "spot_ros2_control.launch.py",
+                        ]
+                    )
+                ),
+                launch_arguments=[("spot_name", spot_name), ("mock_arm", str(mock_arm)), ("launch_rviz", "False")],
+            ),
+            ReadyToTest(),
+        ],
+    )
+    update_sigterm_sigkill_timeout(ld, sigterm_timeout_s=0.0, sigkill_timeout_s=0.0)
+    yield ld
+
+
+@launch_pytest.fixture
+def robot_spot_ros2_control(simple_spot: SpotFixture, domain_id: int) -> Iterator[LaunchDescription]:
     with tempfile.NamedTemporaryFile(mode="w", suffix="config.yaml") as temp:
         data = {
             "username": "user",
@@ -70,7 +94,14 @@ def spot_ros2_control_graph_description(simple_spot: SpotFixture, domain_id: int
                             ]
                         )
                     ),
-                    launch_arguments=[("config_file", temp.file.name), ("spot_name", simple_spot.api.name)],
+                    launch_arguments=[
+                        ("config_file", temp.file.name),
+                        ("hardware_interface", "robot"),
+                        ("launch_image_publishers", "false"),
+                        ("control_only", "true"),
+                        ("spot_name", simple_spot.api.name),
+                        ("launch_rviz", "False"),
+                    ],
                 ),
                 ReadyToTest(),
             ],
@@ -81,4 +112,5 @@ def spot_ros2_control_graph_description(simple_spot: SpotFixture, domain_id: int
 
 
 def pytest_configure() -> None:
-    pytest.spot_ros2_control_graph_description = spot_ros2_control_graph_description
+    pytest.mock_spot_ros2_control = mock_spot_ros2_control
+    pytest.robot_spot_ros2_control = robot_spot_ros2_control

--- a/spot_ros2_control/test/pytests/conftest.py
+++ b/spot_ros2_control/test/pytests/conftest.py
@@ -47,30 +47,6 @@ def ros(simple_spot: SpotFixture, domain_id: int) -> Iterator[ROSAwareScope]:
 
 
 @launch_pytest.fixture
-def mock_spot_ros2_control(domain_id: int, spot_name: str = "", mock_arm: bool = True) -> Iterator[LaunchDescription]:
-    ld = LaunchDescription(
-        [
-            SetEnvironmentVariable("ROS_DOMAIN_ID", str(domain_id)),
-            IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(
-                    PathJoinSubstitution(
-                        [
-                            FindPackageShare("spot_ros2_control"),
-                            "launch",
-                            "spot_ros2_control.launch.py",
-                        ]
-                    )
-                ),
-                launch_arguments=[("spot_name", spot_name), ("mock_arm", str(mock_arm)), ("launch_rviz", "False")],
-            ),
-            ReadyToTest(),
-        ],
-    )
-    update_sigterm_sigkill_timeout(ld, sigterm_timeout_s=0.0, sigkill_timeout_s=0.0)
-    yield ld
-
-
-@launch_pytest.fixture
 def robot_spot_ros2_control(simple_spot: SpotFixture, domain_id: int) -> Iterator[LaunchDescription]:
     with tempfile.NamedTemporaryFile(mode="w", suffix="config.yaml") as temp:
         data = {
@@ -115,5 +91,4 @@ def robot_spot_ros2_control(simple_spot: SpotFixture, domain_id: int) -> Iterato
 
 
 def pytest_configure() -> None:
-    pytest.mock_spot_ros2_control = mock_spot_ros2_control
     pytest.robot_spot_ros2_control = robot_spot_ros2_control

--- a/spot_ros2_control/test/pytests/conftest.py
+++ b/spot_ros2_control/test/pytests/conftest.py
@@ -1,0 +1,84 @@
+import tempfile
+from typing import Iterator
+
+import domain_coordinator
+import launch_pytest
+import pytest
+import synchros2.scope as ros_scope
+import yaml
+from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
+from launch.launch_description import LaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution
+from launch_pytest.actions import ReadyToTest
+from launch_ros.substitutions import FindPackageShare
+from synchros2.launch.actions import update_sigterm_sigkill_timeout
+from synchros2.scope import ROSAwareScope
+
+import spot_wrapper.testing
+from spot_wrapper.testing.fixtures import SpotFixture
+from spot_wrapper.testing.mocks import MockSpot
+
+
+# there is probably a better way to do this
+@spot_wrapper.testing.fixture
+class simple_spot(MockSpot):
+    def __init__(self):
+        super().__init__()
+
+
+@pytest.fixture
+def domain_id() -> Iterator[int]:
+    with domain_coordinator.domain_id() as domain_id:  # to ensure node isolation
+        yield domain_id
+
+
+@pytest.fixture
+def ros(simple_spot: SpotFixture, domain_id: int) -> Iterator[ROSAwareScope]:
+    """
+    This method is a generator function that returns a different ROS2 scope
+    each time it is invoked, to handle a ROS2 context lifecycle.
+    """
+    with ros_scope.top(global_=True, namespace=simple_spot.api.name, domain_id=domain_id) as top:
+        yield top
+
+
+@launch_pytest.fixture
+def spot_ros2_control_graph_description(simple_spot: SpotFixture, domain_id: int) -> Iterator[LaunchDescription]:
+    with tempfile.NamedTemporaryFile(mode="w", suffix="config.yaml") as temp:
+        data = {
+            "username": "user",
+            "password": "pass",
+            "hostname": simple_spot.address,
+            "port": simple_spot.port,
+            "certificate": str(simple_spot.certificate_path),
+            "spot_name": simple_spot.api.name,
+        }
+        yaml.dump({"/**": {"ros__parameters": data}}, temp.file)
+        temp.file.close()
+
+        ld = LaunchDescription(
+            [
+                SetEnvironmentVariable("ROS_DOMAIN_ID", str(domain_id)),
+                IncludeLaunchDescription(
+                    PythonLaunchDescriptionSource(
+                        PathJoinSubstitution(
+                            [
+                                FindPackageShare("spot_ros2_control"),
+                                "launch",
+                                "spot_ros2_control.launch.py",
+                            ]
+                        )
+                    ),
+                    launch_arguments=[("config_file", temp.file.name), ("spot_name", simple_spot.api.name)],
+                ),
+                ReadyToTest(),
+            ],
+        )
+        update_sigterm_sigkill_timeout(ld, sigterm_timeout_s=0.0, sigkill_timeout_s=0.0)
+
+        yield ld
+
+
+def pytest_configure() -> None:
+    pytest.spot_ros2_control_graph_description = spot_ros2_control_graph_description

--- a/spot_ros2_control/test/pytests/conftest.py
+++ b/spot_ros2_control/test/pytests/conftest.py
@@ -25,6 +25,7 @@ from spot_wrapper.testing.mocks import MockSpot
 class simple_spot(MockSpot):
     def __init__(self):
         super().__init__()
+        # force an entry in manipulator state to indicate robot has arm
         manipulator_state = self.robot_state.manipulator_state
         manipulator_state.is_gripper_holding_item = False
 
@@ -108,7 +109,7 @@ def robot_spot_ros2_control(simple_spot: SpotFixture, domain_id: int) -> Iterato
                 ReadyToTest(),
             ],
         )
-        update_sigterm_sigkill_timeout(ld, sigterm_timeout_s=0.0, sigkill_timeout_s=0.0)
+        update_sigterm_sigkill_timeout(ld, sigterm_timeout_s=10.0, sigkill_timeout_s=10.0)
 
         yield ld
 

--- a/spot_ros2_control/test/pytests/test_spot_ros2_control.py
+++ b/spot_ros2_control/test/pytests/test_spot_ros2_control.py
@@ -4,7 +4,7 @@ import pytest
 from bosdyn.api.robot_command_pb2 import RobotCommandResponse
 from bosdyn.api.robot_state_pb2 import RobotStateStreamResponse
 from sensor_msgs.msg import JointState
-from synchros2.futures import wait_for_future
+from synchros2.futures import unwrap_future
 from synchros2.scope import ROSAwareScope
 from synchros2.subscription import Subscription
 
@@ -41,25 +41,26 @@ def state_stream_response(position: list[float], velocity: list[float], load: li
 
 @pytest.mark.launch(fixture=pytest.robot_spot_ros2_control)
 def test_joint_states(simple_spot: SpotFixture, ros: ROSAwareScope) -> None:
-    # Mock a joint state stream response
+    # Create a state stream response containing unique joint state values for each joint
     position = list(range(0, NUM_JOINTS_ARM))
     velocity = list(range(NUM_JOINTS_ARM, 2 * NUM_JOINTS_ARM))
     load = list(range(2 * NUM_JOINTS_ARM, 3 * NUM_JOINTS_ARM))
     stream_response = state_stream_response(position=position, velocity=velocity, load=load)
+    # send this response to the mock robot
     simple_spot.api.GetRobotStateStream.future.returns(itertools.repeat(stream_response))
     response = RobotCommandResponse()
     response.status = RobotCommandResponse.Status.STATUS_OK
     simple_spot.api.RobotCommand.future.returns(response)
+    # start the mock joint control stream
     call = simple_spot.api.JointControlStream.serve(timeout=2.0)
     assert call is not None
+
+    # Grab the latest joint states message from the joint state broadcaster
     spot_name = simple_spot.api.name
-    # Grab the latest joint states topic
     joint_states = Subscription(JointState, f"/{spot_name}/low_level/joint_states", node=ros.node)
-    assert wait_for_future(joint_states.update, timeout_sec=10.0)
-    joint_state_message = joint_states.latest
-    assert joint_state_message is not None
+    joint_state_message = unwrap_future(joint_states.update, timeout_sec=10.0)
     expected_joints = [f"{spot_name}/{joint}" for joint in LEG_JOINTS + ARM_JOINTS]
-    # ensure that the joint state message contains the values from our state stream response.
+    # ensure that the joint state message contains the values from our state stream response
     for i, joint in enumerate(expected_joints):
         assert joint in joint_state_message.name
         joint_index = joint_state_message.name.index(joint)
@@ -67,7 +68,7 @@ def test_joint_states(simple_spot: SpotFixture, ros: ROSAwareScope) -> None:
         assert joint_state_message.velocity[joint_index] == velocity[i]
         assert joint_state_message.effort[joint_index] == load[i]
 
-    # Here for the SafePowerOff command when the hardware interface deactivates
+    # mock the response for the SafePowerOff command used when the hardware interface deactivates
     response = RobotCommandResponse()
     response.status = RobotCommandResponse.Status.STATUS_OK
     simple_spot.api.RobotCommand.future.returns(response)

--- a/spot_ros2_control/test/pytests/test_spot_ros2_control.py
+++ b/spot_ros2_control/test/pytests/test_spot_ros2_control.py
@@ -4,7 +4,6 @@ import pytest
 from bosdyn.api.robot_command_pb2 import RobotCommandResponse
 from bosdyn.api.robot_state_pb2 import RobotStateStreamResponse
 from sensor_msgs.msg import JointState
-from std_msgs.msg import Float64MultiArray
 from synchros2.futures import wait_for_future
 from synchros2.scope import ROSAwareScope
 from synchros2.subscription import Subscription
@@ -27,74 +26,45 @@ LEG_JOINTS = [
 ]
 ARM_JOINTS = ["arm_sh0", "arm_sh1", "arm_el0", "arm_el1", "arm_wr0", "arm_wr1", "arm_f1x"]
 
-
-@pytest.mark.launch(fixture=pytest.mock_spot_ros2_control)
-def test_mock_forward_position(ros: ROSAwareScope) -> None:
-    print("Hello")
-    # TODO update this, we should be able to programatically wait until everything is active...
-    # time.sleep(5)
-    joint_states_sub = Subscription(JointState, "/low_level/joint_states", node=ros.node)
-    command_pub = ros.node.create_publisher(Float64MultiArray, "/forward_position_controller/commands", 10)
-    assert wait_for_future(joint_states_sub.update, timeout_sec=10.0)
-    # get a joint angles message before sending any command.
-    initial_joint_states = joint_states_sub.latest
-
-    expected_joints = LEG_JOINTS + ARM_JOINTS
-    njoints = len(expected_joints)
-    # check that the size matches the joints we expect.
-    assert len(initial_joint_states.name) == njoints
-    assert len(initial_joint_states.position) == njoints
-    assert len(initial_joint_states.velocity) == njoints
-    assert len(initial_joint_states.effort) == njoints
-    for joint in expected_joints:
-        assert joint in initial_joint_states.name
-
-    # try publishing commands to forward position controller.
-    # this sends a dummy command of 1 to front_left_hip_x, 2 to front_left_hip_y, ...
-    command = Float64MultiArray(data=list(range(1, njoints + 1)))
-    command_pub.publish(command)
-    assert wait_for_future(joint_states_sub.update, timeout_sec=10.0)
-    # get the joint state message after sending the command, and check that the update is reflected
-    updated_joint_states = joint_states_sub.latest
-    print("\n\n\n\n\n\n\n\n")
-    print(initial_joint_states.position)
-    print(updated_joint_states.position)
-    for i, joint in enumerate(expected_joints):
-        assert joint in updated_joint_states.name
-        joint_index = updated_joint_states.name.index(joint)
-        # position value should be updated with the command
-        assert updated_joint_states.position[joint_index] == command.data[i]
-        # velocity and effort should be unchanged
-        assert updated_joint_states.velocity[joint_index] == initial_joint_states.velocity[joint_index]
-        assert updated_joint_states.effort[joint_index] == initial_joint_states.effort[joint_index]
+NUM_JOINTS_ARM = 19
 
 
-NUM_JOINTS = 19
-
-
-def zero_robot_state_stream_response() -> RobotStateStreamResponse:
-    zero_response = RobotStateStreamResponse()
-    zero_response.joint_states.position.extend([0.0] * NUM_JOINTS)
-    zero_response.joint_states.velocity.extend([0.0] * NUM_JOINTS)
-    zero_response.joint_states.load.extend([0.0] * NUM_JOINTS)
-    zero_response.inertial_state.packets.add()  # hardware interface expects at least a packet
-    zero_response.contact_states.extend([0] * 4)  # hardware interface expects all 4 feet to have a contact state
-    return zero_response
+def state_stream_response(position: list[float], velocity: list[float], load: list[float]) -> RobotStateStreamResponse:
+    response = RobotStateStreamResponse()
+    response.joint_states.position.extend(position)
+    response.joint_states.velocity.extend(velocity)
+    response.joint_states.load.extend(load)
+    response.inertial_state.packets.add()  # hardware interface expects at least a packet
+    response.contact_states.extend([0] * 4)  # hardware interface expects all 4 feet to have a contact state
+    return response
 
 
 @pytest.mark.launch(fixture=pytest.robot_spot_ros2_control)
-def test_spot_ros2_control(simple_spot: SpotFixture, ros: ROSAwareScope) -> None:
-    simple_spot.api.GetRobotStateStream.future.returns(itertools.repeat(zero_robot_state_stream_response()))
+def test_joint_states(simple_spot: SpotFixture, ros: ROSAwareScope) -> None:
+    # Mock a joint state stream response
+    position = list(range(0, NUM_JOINTS_ARM))
+    velocity = list(range(NUM_JOINTS_ARM, 2 * NUM_JOINTS_ARM))
+    load = list(range(2 * NUM_JOINTS_ARM, 3 * NUM_JOINTS_ARM))
+    stream_response = state_stream_response(position=position, velocity=velocity, load=load)
+    simple_spot.api.GetRobotStateStream.future.returns(itertools.repeat(stream_response))
     response = RobotCommandResponse()
     response.status = RobotCommandResponse.Status.STATUS_OK
     simple_spot.api.RobotCommand.future.returns(response)
     call = simple_spot.api.JointControlStream.serve(timeout=2.0)
     assert call is not None
     spot_name = simple_spot.api.name
+    # Grab the latest joint states topic
     joint_states = Subscription(JointState, f"/{spot_name}/low_level/joint_states", node=ros.node)
-    assert wait_for_future(joint_states.update, timeout_sec=20.0)
-    message = joint_states.latest
-    print(message)
+    assert wait_for_future(joint_states.update, timeout_sec=10.0)
+    joint_state_message = joint_states.latest
+    expected_joints = [f"{spot_name}/{joint}" for joint in LEG_JOINTS + ARM_JOINTS]
+    # ensure that the joint state message contains the values from our state stream response.
+    for i, joint in enumerate(expected_joints):
+        assert joint in joint_state_message.name
+        joint_index = joint_state_message.name.index(joint)
+        assert joint_state_message.position[joint_index] == position[i]
+        assert joint_state_message.velocity[joint_index] == velocity[i]
+        assert joint_state_message.effort[joint_index] == load[i]
 
     # Here for the SafePowerOff command when the hardware interface deactivates
     response = RobotCommandResponse()

--- a/spot_ros2_control/test/pytests/test_spot_ros2_control.py
+++ b/spot_ros2_control/test/pytests/test_spot_ros2_control.py
@@ -1,10 +1,43 @@
+import itertools
+
 import pytest
+from bosdyn.api.robot_state_pb2 import RobotStateStreamResponse
+from sensor_msgs.msg import JointState
+from synchros2.futures import wait_for_future
 from synchros2.scope import ROSAwareScope
+from synchros2.subscription import Subscription
 
 from spot_wrapper.testing.fixtures import SpotFixture
 
 
-@pytest.mark.launch(fixture=pytest.spot_ros2_control_graph_description)
+@pytest.mark.launch(fixture=pytest.mock_spot_ros2_control)
+def test_mock(ros: ROSAwareScope) -> None:
+    print("Hello")
+    joint_states = Subscription(JointState, "/low_level/joint_states", node=ros.node)
+    assert wait_for_future(joint_states.update, timeout_sec=10.0)
+    message = joint_states.latest
+    print(message)
+
+
+NUM_JOINTS = 19
+
+
+def zero_robot_state_stream_response() -> RobotStateStreamResponse:
+    zero_response = RobotStateStreamResponse()
+    zero_response.joint_states.position.extend([0.0] * NUM_JOINTS)
+    zero_response.joint_states.velocity.extend([0.0] * NUM_JOINTS)
+    zero_response.joint_states.load.extend([0.0] * NUM_JOINTS)
+    zero_response.inertial_state.packets.add()  # hardware interface expects at least a packet
+    zero_response.contact_states.extend([0] * 4)  # hardware interface expects all 4 feet to have a contact state
+    return zero_response
+
+
+@pytest.mark.launch(fixture=pytest.robot_spot_ros2_control)
 def test_spot_ros2_control(simple_spot: SpotFixture, ros: ROSAwareScope) -> None:
+    simple_spot.api.GetRobotStateStream.future.returns(itertools.repeat(zero_robot_state_stream_response()))
     spot_name = simple_spot.api.name
     print("spot name ", spot_name)
+    joint_states = Subscription(JointState, f"/{spot_name}/low_level/joint_states", node=ros.node)
+    assert wait_for_future(joint_states.update, timeout_sec=20.0)
+    message = joint_states.latest
+    print(message)

--- a/spot_ros2_control/test/pytests/test_spot_ros2_control.py
+++ b/spot_ros2_control/test/pytests/test_spot_ros2_control.py
@@ -95,3 +95,8 @@ def test_spot_ros2_control(simple_spot: SpotFixture, ros: ROSAwareScope) -> None
     assert wait_for_future(joint_states.update, timeout_sec=20.0)
     message = joint_states.latest
     print(message)
+
+    # Here for the SafePowerOff command when the hardware interface deactivates
+    response = RobotCommandResponse()
+    response.status = RobotCommandResponse.Status.STATUS_OK
+    simple_spot.api.RobotCommand.future.returns(response)

--- a/spot_ros2_control/test/pytests/test_spot_ros2_control.py
+++ b/spot_ros2_control/test/pytests/test_spot_ros2_control.py
@@ -1,0 +1,10 @@
+import pytest
+from synchros2.scope import ROSAwareScope
+
+from spot_wrapper.testing.fixtures import SpotFixture
+
+
+@pytest.mark.launch(fixture=pytest.spot_ros2_control_graph_description)
+def test_spot_ros2_control(simple_spot: SpotFixture, ros: ROSAwareScope) -> None:
+    spot_name = simple_spot.api.name
+    print("spot name ", spot_name)

--- a/spot_ros2_control/test/pytests/test_spot_ros2_control.py
+++ b/spot_ros2_control/test/pytests/test_spot_ros2_control.py
@@ -1,22 +1,72 @@
 import itertools
 
 import pytest
+from bosdyn.api.robot_command_pb2 import RobotCommandResponse
 from bosdyn.api.robot_state_pb2 import RobotStateStreamResponse
 from sensor_msgs.msg import JointState
+from std_msgs.msg import Float64MultiArray
 from synchros2.futures import wait_for_future
 from synchros2.scope import ROSAwareScope
 from synchros2.subscription import Subscription
 
 from spot_wrapper.testing.fixtures import SpotFixture
 
+LEG_JOINTS = [
+    "front_left_hip_x",
+    "front_left_hip_y",
+    "front_left_knee",
+    "front_right_hip_x",
+    "front_right_hip_y",
+    "front_right_knee",
+    "rear_left_hip_x",
+    "rear_left_hip_y",
+    "rear_left_knee",
+    "rear_right_hip_x",
+    "rear_right_hip_y",
+    "rear_right_knee",
+]
+ARM_JOINTS = ["arm_sh0", "arm_sh1", "arm_el0", "arm_el1", "arm_wr0", "arm_wr1", "arm_f1x"]
+
 
 @pytest.mark.launch(fixture=pytest.mock_spot_ros2_control)
-def test_mock(ros: ROSAwareScope) -> None:
+def test_mock_forward_position(ros: ROSAwareScope) -> None:
     print("Hello")
-    joint_states = Subscription(JointState, "/low_level/joint_states", node=ros.node)
-    assert wait_for_future(joint_states.update, timeout_sec=10.0)
-    message = joint_states.latest
-    print(message)
+    # TODO update this, we should be able to programatically wait until everything is active...
+    # time.sleep(5)
+    joint_states_sub = Subscription(JointState, "/low_level/joint_states", node=ros.node)
+    command_pub = ros.node.create_publisher(Float64MultiArray, "/forward_position_controller/commands", 10)
+    assert wait_for_future(joint_states_sub.update, timeout_sec=10.0)
+    # get a joint angles message before sending any command.
+    initial_joint_states = joint_states_sub.latest
+
+    expected_joints = LEG_JOINTS + ARM_JOINTS
+    njoints = len(expected_joints)
+    # check that the size matches the joints we expect.
+    assert len(initial_joint_states.name) == njoints
+    assert len(initial_joint_states.position) == njoints
+    assert len(initial_joint_states.velocity) == njoints
+    assert len(initial_joint_states.effort) == njoints
+    for joint in expected_joints:
+        assert joint in initial_joint_states.name
+
+    # try publishing commands to forward position controller.
+    # this sends a dummy command of 1 to front_left_hip_x, 2 to front_left_hip_y, ...
+    command = Float64MultiArray(data=list(range(1, njoints + 1)))
+    command_pub.publish(command)
+    assert wait_for_future(joint_states_sub.update, timeout_sec=10.0)
+    # get the joint state message after sending the command, and check that the update is reflected
+    updated_joint_states = joint_states_sub.latest
+    print("\n\n\n\n\n\n\n\n")
+    print(initial_joint_states.position)
+    print(updated_joint_states.position)
+    for i, joint in enumerate(expected_joints):
+        assert joint in updated_joint_states.name
+        joint_index = updated_joint_states.name.index(joint)
+        # position value should be updated with the command
+        assert updated_joint_states.position[joint_index] == command.data[i]
+        # velocity and effort should be unchanged
+        assert updated_joint_states.velocity[joint_index] == initial_joint_states.velocity[joint_index]
+        assert updated_joint_states.effort[joint_index] == initial_joint_states.effort[joint_index]
 
 
 NUM_JOINTS = 19
@@ -35,8 +85,12 @@ def zero_robot_state_stream_response() -> RobotStateStreamResponse:
 @pytest.mark.launch(fixture=pytest.robot_spot_ros2_control)
 def test_spot_ros2_control(simple_spot: SpotFixture, ros: ROSAwareScope) -> None:
     simple_spot.api.GetRobotStateStream.future.returns(itertools.repeat(zero_robot_state_stream_response()))
+    response = RobotCommandResponse()
+    response.status = RobotCommandResponse.Status.STATUS_OK
+    simple_spot.api.RobotCommand.future.returns(response)
+    call = simple_spot.api.JointControlStream.serve(timeout=2.0)
+    assert call is not None
     spot_name = simple_spot.api.name
-    print("spot name ", spot_name)
     joint_states = Subscription(JointState, f"/{spot_name}/low_level/joint_states", node=ros.node)
     assert wait_for_future(joint_states.update, timeout_sec=20.0)
     message = joint_states.latest

--- a/spot_ros2_control/test/pytests/test_spot_ros2_control.py
+++ b/spot_ros2_control/test/pytests/test_spot_ros2_control.py
@@ -57,6 +57,7 @@ def test_joint_states(simple_spot: SpotFixture, ros: ROSAwareScope) -> None:
     joint_states = Subscription(JointState, f"/{spot_name}/low_level/joint_states", node=ros.node)
     assert wait_for_future(joint_states.update, timeout_sec=10.0)
     joint_state_message = joint_states.latest
+    assert joint_state_message is not None
     expected_joints = [f"{spot_name}/{joint}" for joint in LEG_JOINTS + ARM_JOINTS]
     # ensure that the joint state message contains the values from our state stream response.
     for i, joint in enumerate(expected_joints):

--- a/spot_ros2_control/test/pytests/test_spot_ros2_control.py
+++ b/spot_ros2_control/test/pytests/test_spot_ros2_control.py
@@ -1,7 +1,7 @@
 import itertools
 
 import pytest
-from bosdyn.api.robot_command_pb2 import JointControlStreamResponse, RobotCommandResponse
+from bosdyn.api.robot_command_pb2 import RobotCommandResponse
 from bosdyn.api.robot_state_pb2 import RobotStateStreamResponse
 from sensor_msgs.msg import JointState
 from std_msgs.msg import Float64MultiArray
@@ -100,8 +100,3 @@ def test_spot_ros2_control(simple_spot: SpotFixture, ros: ROSAwareScope) -> None
     response = RobotCommandResponse()
     response.status = RobotCommandResponse.Status.STATUS_OK
     simple_spot.api.RobotCommand.future.returns(response)
-
-    # explicitly close the joint control stream
-    response = JointControlStreamResponse()
-    response.status = JointControlStreamResponse.Status.STATUS_OK
-    call.returns(response)

--- a/spot_ros2_control/test/pytests/test_spot_ros2_control.py
+++ b/spot_ros2_control/test/pytests/test_spot_ros2_control.py
@@ -1,7 +1,7 @@
 import itertools
 
 import pytest
-from bosdyn.api.robot_command_pb2 import RobotCommandResponse
+from bosdyn.api.robot_command_pb2 import JointControlStreamResponse, RobotCommandResponse
 from bosdyn.api.robot_state_pb2 import RobotStateStreamResponse
 from sensor_msgs.msg import JointState
 from std_msgs.msg import Float64MultiArray
@@ -100,3 +100,8 @@ def test_spot_ros2_control(simple_spot: SpotFixture, ros: ROSAwareScope) -> None
     response = RobotCommandResponse()
     response.status = RobotCommandResponse.Status.STATUS_OK
     simple_spot.api.RobotCommand.future.returns(response)
+
+    # explicitly close the joint control stream
+    response = JointControlStreamResponse()
+    response.status = JointControlStreamResponse.Status.STATUS_OK
+    call.returns(response)


### PR DESCRIPTION
## Change Overview

Adds a simple CI test for `spot_ros2_control`. The main goal of having this test is to ensure that the `spot_ros2_control` launchfile can launch without error. For example, updates to `spot_description` have broken this in the past, but we had no way of seeing this through CI. This test also verifies that joint states from the Spot SDK are passed to the joint state broadcaster correctly using the `MockSpot` testing fixture. In the future we can add more tests to verify our Spot specific controllers/broadcasters in CI.

Additionally, i removed the `ament_lint_auto` and `ament_lint_common` test dependencies from `spot_hardware_interface` and `spot_controllers` as we are not running these linters in our other core packages (i.e. `spot_driver`) -- this makes the entire repo pass `colcon test` :) 

## Testing Done

- [x] ran test locally via `pytest` and `colcon test --packages-select spot_ros2_control`
- [x] ran `colcon test` locally on whole repo, no failures
- [x] This new test now also runs in CI