### PR TITLE
[SW-2328] ROS 2 control pose broadcaster

### DIFF
--- a/spot_controllers/CMakeLists.txt
+++ b/spot_controllers/CMakeLists.txt
@@ -20,6 +20,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp
   rclcpp_lifecycle
   spot_msgs
+  tf2_msgs
 )
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
@@ -40,6 +41,11 @@ generate_parameter_library(
   include/spot_controllers/foot_state_broadcaster_parameters.yaml
 )
 
+generate_parameter_library(
+  spot_pose_broadcaster_parameters
+  include/spot_controllers/spot_pose_broadcaster_parameters.yaml
+)
+
 # Add the hardware interface
 add_library(
   spot_controllers
@@ -47,6 +53,7 @@ add_library(
   src/forward_state_controller.cpp
   src/spot_joint_controller.cpp
   src/foot_state_broadcaster.cpp
+  src/spot_pose_broadcaster.cpp
 )
 target_compile_features(spot_controllers PUBLIC cxx_std_20)
 target_include_directories(spot_controllers PUBLIC
@@ -58,6 +65,7 @@ target_link_libraries(
   forward_state_controller_parameters
   spot_joint_controller_parameters
   foot_state_broadcaster_parameters
+  spot_pose_broadcaster_parameters
   forward_command_controller::forward_command_controller
 )
 ament_target_dependencies(
@@ -77,7 +85,7 @@ install(
   DESTINATION include/${PROJECT_NAME}
 )
 
-install(TARGETS spot_controllers forward_state_controller_parameters spot_joint_controller_parameters foot_state_broadcaster_parameters
+install(TARGETS spot_controllers forward_state_controller_parameters spot_joint_controller_parameters foot_state_broadcaster_parameters spot_pose_broadcaster_parameters
   EXPORT export_spot_controllers
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib

--- a/spot_controllers/CMakeLists.txt
+++ b/spot_controllers/CMakeLists.txt
@@ -20,8 +20,10 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp
   rclcpp_lifecycle
   spot_msgs
+  tf2_geometry_msgs
   tf2_msgs
   tf2
+  geometry_msgs
 )
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/spot_controllers/CMakeLists.txt
+++ b/spot_controllers/CMakeLists.txt
@@ -21,6 +21,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp_lifecycle
   spot_msgs
   tf2_msgs
+  tf2
 )
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/spot_controllers/README.md
+++ b/spot_controllers/README.md
@@ -45,3 +45,11 @@ Each message contains four `FootState` messages filled in with the appropriate `
 0 corresponds to an unknown contact, 1 corresponds to the foot being in contact in the floor, and 2 corresponds to the foot not being in contact with the floor.
 Note that in contrast to the `FootState` published by the high level driver, Spot's streaming interface for foot contacts does NOT contain an estimate for the foot's position with respect to the body.
 Therefore, the `foot_position_rt_body` field of the `FootState` message is not filled in and should be disregarded.
+
+## `SpotPoseBroadcaster`
+This is a broadcaster that will publish the estimates of the `odom` and `vision` frame transforms to `body` as both a TF frame and a ROS pose message.
+This broadcaster reads from the state interfaces `vision_t_body` and `odom_t_body`.
+It broadcasts these to TF frames `low_level/vision_t_body` and `low_level/odom_t_body` (named this way as to not conflict with the existing `odom` and `vision` frames published from the high level driver estimates).
+Note that these frames are broadcasted to the TF tree as the children of the `body` frame to ensure that `body` does not contain more than one parent.
+The same data as a `Pose` message is also available on the topics `vision_t_body` and `odom_t_body`. 
+These directly publish the transform of the body frame with respect to `vision`/`odom`.

--- a/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
+++ b/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
@@ -57,8 +57,11 @@ class SpotPoseBroadcaster : public controller_interface::ControllerInterface {
   std::unique_ptr<semantic_components::PoseSensor> vision_pose_sensor_;
   std::unique_ptr<semantic_components::PoseSensor> odom_pose_sensor_;
 
-  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_publisher_;
-  std::unique_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>> realtime_publisher_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr vision_pose_publisher_;
+  std::unique_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>> vision_realtime_publisher_;
+
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr odom_pose_publisher_;
+  std::unique_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>> odom_realtime_publisher_;
 
   std::optional<rclcpp::Duration> tf_publish_period_;
   rclcpp::Time tf_last_publish_time_{0, 0, RCL_CLOCK_UNINITIALIZED};

--- a/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
+++ b/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
@@ -18,13 +18,14 @@
 #include <optional>
 #include <string>
 
-#include <tf2/LinearMath/Transform.hpp>
 #include "controller_interface/controller_interface.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/transform.hpp"
 #include "rclcpp/publisher.hpp"
 #include "rclcpp_lifecycle/state.hpp"
 #include "realtime_tools/realtime_publisher.hpp"
 #include "semantic_components/pose_sensor.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
 
 #include "spot_controllers/spot_pose_broadcaster_parameters.hpp"

--- a/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
+++ b/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
@@ -49,6 +49,9 @@ class SpotPoseBroadcaster : public controller_interface::ControllerInterface {
   controller_interface::return_type update(const rclcpp::Time& time, const rclcpp::Duration& period) override;
 
  private:
+  // Logs a ROS pose message to console
+  void log_pose(const geometry_msgs::msg::Pose& pose);
+
   using Params = spot_pose_broadcaster::Params;
   using ParamListener = spot_pose_broadcaster::ParamListener;
   std::shared_ptr<ParamListener> param_listener_;

--- a/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
+++ b/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
@@ -52,7 +52,8 @@ class SpotPoseBroadcaster : public controller_interface::ControllerInterface {
   std::shared_ptr<ParamListener> param_listener_;
   Params params_;
 
-  std::unique_ptr<semantic_components::PoseSensor> pose_sensor_;
+  std::unique_ptr<semantic_components::PoseSensor> vision_pose_sensor_;
+  std::unique_ptr<semantic_components::PoseSensor> odom_pose_sensor_;
 
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_publisher_;
   std::unique_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>> realtime_publisher_;

--- a/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
+++ b/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
@@ -1,3 +1,7 @@
+// File modified. Modifications Copyright (c) 2025 Boston Dynamics AI Institute LLC.
+// All rights reserved.
+
+// --------------------------------------------------------------
 // Copyright 2024 FZI Forschungszentrum Informatik
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
+++ b/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
@@ -1,0 +1,66 @@
+// Copyright 2024 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <array>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "controller_interface/controller_interface.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "rclcpp/publisher.hpp"
+#include "rclcpp_lifecycle/state.hpp"
+#include "realtime_tools/realtime_publisher.hpp"
+#include "semantic_components/pose_sensor.hpp"
+#include "tf2_msgs/msg/tf_message.hpp"
+
+#include "spot_controllers/spot_pose_broadcaster_parameters.hpp"
+
+namespace spot_controllers {
+
+class SpotPoseBroadcaster : public controller_interface::ControllerInterface {
+ public:
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+
+  controller_interface::CallbackReturn on_init() override;
+
+  controller_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State& previous_state) override;
+
+  controller_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) override;
+
+  controller_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
+
+  controller_interface::return_type update(const rclcpp::Time& time, const rclcpp::Duration& period) override;
+
+ private:
+  using Params = spot_pose_broadcaster::Params;
+  using ParamListener = spot_pose_broadcaster::ParamListener;
+  std::shared_ptr<ParamListener> param_listener_;
+  Params params_;
+
+  std::unique_ptr<semantic_components::PoseSensor> pose_sensor_;
+
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_publisher_;
+  std::unique_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>> realtime_publisher_;
+
+  std::optional<rclcpp::Duration> tf_publish_period_;
+  rclcpp::Time tf_last_publish_time_{0, 0, RCL_CLOCK_UNINITIALIZED};
+  rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr tf_publisher_;
+  std::unique_ptr<realtime_tools::RealtimePublisher<tf2_msgs::msg::TFMessage>> realtime_tf_publisher_;
+};
+
+}  // namespace spot_controllers

--- a/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
+++ b/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
@@ -54,6 +54,8 @@ class SpotPoseBroadcaster : public controller_interface::ControllerInterface {
   std::shared_ptr<ParamListener> param_listener_;
   Params params_;
 
+  std::string frame_prefix_;
+
   std::unique_ptr<semantic_components::PoseSensor> vision_pose_sensor_;
   std::unique_ptr<semantic_components::PoseSensor> odom_pose_sensor_;
 

--- a/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
+++ b/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
@@ -18,6 +18,7 @@
 #include <optional>
 #include <string>
 
+#include <tf2/LinearMath/Transform.hpp>
 #include "controller_interface/controller_interface.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "rclcpp/publisher.hpp"

--- a/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
+++ b/spot_controllers/include/spot_controllers/spot_pose_broadcaster.hpp
@@ -68,8 +68,6 @@ class SpotPoseBroadcaster : public controller_interface::ControllerInterface {
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr odom_pose_publisher_;
   std::unique_ptr<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>> odom_realtime_publisher_;
 
-  std::optional<rclcpp::Duration> tf_publish_period_;
-  rclcpp::Time tf_last_publish_time_{0, 0, RCL_CLOCK_UNINITIALIZED};
   rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr tf_publisher_;
   std::unique_ptr<realtime_tools::RealtimePublisher<tf2_msgs::msg::TFMessage>> realtime_tf_publisher_;
 };

--- a/spot_controllers/include/spot_controllers/spot_pose_broadcaster_parameters.yaml
+++ b/spot_controllers/include/spot_controllers/spot_pose_broadcaster_parameters.yaml
@@ -11,6 +11,8 @@ spot_pose_broadcaster:
     description: "Sensor name containing the transform from the low level vision estimate to body.
                   The state interface names are: ``<vision_t_body_sensor>/position.x, ..., <vision_t_body_sensor>/position.z,
                   <vision_t_body_sensor>/orientation.x, ..., <vision_t_body_sensor>/orientation.w``"
+    validation:
+      not_empty<>: null
 
   odom_t_body_sensor:
     type: string
@@ -18,18 +20,26 @@ spot_pose_broadcaster:
     description: "Sensor name containing the transform from the low level odom estimate to body.
                   The state interface names are: ``<odom_t_body_sensor>/position.x, ..., <odom_t_body_sensor>/position.z,
                   <odom_t_body_sensor>/orientation.x, ..., <odom_t_body_sensor>/orientation.w``"
+    validation:
+        not_empty<>: null
 
   body_frame_name:
     type: string
     default_value: "body"
     description: "TF frame name for the body"
+    validation:
+      not_empty<>: null
 
   vision_frame_name:
     type: string
     default_value: "low_level/vision"
     description: "TF frame name for the low level estimate of the vision frame"
+    validation:
+      not_empty<>: null
 
   odom_frame_name:
     type: string
     default_value: "low_level/odom"
     description: "TF frame name for the low level estimate of the odom frame"
+    validation:
+      not_empty<>: null

--- a/spot_controllers/include/spot_controllers/spot_pose_broadcaster_parameters.yaml
+++ b/spot_controllers/include/spot_controllers/spot_pose_broadcaster_parameters.yaml
@@ -4,24 +4,11 @@ spot_pose_broadcaster:
     default_value: true
     description: "Flag to determine if the prefix of the sensor name should be picked up
                   from the namespace of the controller."
-  frame_id:
-    type: string
-    default_value: ""
-    description: "frame_id in which values are published"
-    validation:
-      not_empty<>: null
-  pose_name:
-    type: string
-    default_value: ""
-    description: "Base name used as prefix for controller interfaces. The state interface names are: ``<pose_name>/position.x, ..., <pose_name>/position.z, <pose_name>/orientation.x, ..., <pose_name>/orientation.w``"
-    validation:
-      not_empty<>: null
 
   tf_enable:
     type: bool
     default_value: true
     description: "Publish poses as TF transforms"
-
 
   vision_t_body:
     sensor_name:
@@ -54,23 +41,7 @@ spot_pose_broadcaster:
       type: string
       default_value: "body"
       description: "Name of the parent frame"
-    invert:
+    invert_tf:
       type: bool
       default_value: true
       description: "whether to invert the transform, and publish body_t_odom (needed for a valid TF tree)"
-
-  tf:
-    enable:
-      type: bool
-      default_value: true
-      description: "Whether to publish the pose as a tf transform"
-    child_frame_id:
-      type: string
-      default_value: ""
-      description: "Child frame id of published tf transforms. Defaults to ``pose_name`` if left empty."
-    publish_rate:
-      type: double
-      default_value: 0.0
-      description: "Rate to limit publishing of tf transforms to (Hz). If set to 0, no limiting is performed."
-      validation:
-        gt_eq<>: 0.0

--- a/spot_controllers/include/spot_controllers/spot_pose_broadcaster_parameters.yaml
+++ b/spot_controllers/include/spot_controllers/spot_pose_broadcaster_parameters.yaml
@@ -5,43 +5,30 @@ spot_pose_broadcaster:
     description: "Flag to determine if the prefix of the sensor name should be picked up
                   from the namespace of the controller."
 
-  tf_enable:
-    type: bool
-    default_value: true
-    description: "Publish poses as TF transforms"
-
   vision_t_body:
     sensor_name:
       type: string
       default_value: "vision_t_body"
       description: "The state interface names are: ``<pose_name>/position.x, ..., <pose_name>/position.z, <pose_name>/orientation.x, ..., <pose_name>/orientation.w``"
-    frame_name:
+    vision_frame_name:
       type: string
       default_value: "low_level/vision"
       description: "Name for the pose"
-    parent_frame_name:
+    body_frame_name:
       type: string
       default_value: "body"
-      description: "Name of the parent frame"
-    invert_tf:
-      type: bool
-      default_value: true
-      description: "whether to invert the transform, and publish body_t_vision (needed for a valid TF tree)"
+      description: "Name of the child frame"
 
   odom_t_body:
     sensor_name:
       type: string
       default_value: "odom_t_body"
       description: "The state interface names are: ``<pose_name>/position.x, ..., <pose_name>/position.z, <pose_name>/orientation.x, ..., <pose_name>/orientation.w``"
-    frame_name:
+    odom_frame_name:
       type: string
       default_value: "low_level/odom"
       description: "Name for the pose"
-    parent_frame_name:
+    body_frame_name:
       type: string
       default_value: "body"
-      description: "Name of the parent frame"
-    invert_tf:
-      type: bool
-      default_value: true
-      description: "whether to invert the transform, and publish body_t_odom (needed for a valid TF tree)"
+      description: "Name of the child frame"

--- a/spot_controllers/include/spot_controllers/spot_pose_broadcaster_parameters.yaml
+++ b/spot_controllers/include/spot_controllers/spot_pose_broadcaster_parameters.yaml
@@ -1,0 +1,28 @@
+spot_pose_broadcaster:
+  frame_id:
+    type: string
+    default_value: ""
+    description: "frame_id in which values are published"
+    validation:
+      not_empty<>: null
+  pose_name:
+    type: string
+    default_value: ""
+    description: "Base name used as prefix for controller interfaces. The state interface names are: ``<pose_name>/position.x, ..., <pose_name>/position.z, <pose_name>/orientation.x, ..., <pose_name>/orientation.w``"
+    validation:
+      not_empty<>: null
+  tf:
+    enable:
+      type: bool
+      default_value: true
+      description: "Whether to publish the pose as a tf transform"
+    child_frame_id:
+      type: string
+      default_value: ""
+      description: "Child frame id of published tf transforms. Defaults to ``pose_name`` if left empty."
+    publish_rate:
+      type: double
+      default_value: 0.0
+      description: "Rate to limit publishing of tf transforms to (Hz). If set to 0, no limiting is performed."
+      validation:
+        gt_eq<>: 0.0

--- a/spot_controllers/include/spot_controllers/spot_pose_broadcaster_parameters.yaml
+++ b/spot_controllers/include/spot_controllers/spot_pose_broadcaster_parameters.yaml
@@ -1,4 +1,9 @@
 spot_pose_broadcaster:
+  use_namespace_as_prefix:
+    type: bool
+    default_value: true
+    description: "Flag to determine if the prefix of the sensor name should be picked up
+                  from the namespace of the controller."
   frame_id:
     type: string
     default_value: ""
@@ -11,6 +16,49 @@ spot_pose_broadcaster:
     description: "Base name used as prefix for controller interfaces. The state interface names are: ``<pose_name>/position.x, ..., <pose_name>/position.z, <pose_name>/orientation.x, ..., <pose_name>/orientation.w``"
     validation:
       not_empty<>: null
+
+  tf_enable:
+    type: bool
+    default_value: true
+    description: "Publish poses as TF transforms"
+
+
+  vision_t_body:
+    sensor_name:
+      type: string
+      default_value: "vision_t_body"
+      description: "The state interface names are: ``<pose_name>/position.x, ..., <pose_name>/position.z, <pose_name>/orientation.x, ..., <pose_name>/orientation.w``"
+    frame_name:
+      type: string
+      default_value: "low_level/vision"
+      description: "Name for the pose"
+    parent_frame_name:
+      type: string
+      default_value: "body"
+      description: "Name of the parent frame"
+    invert_tf:
+      type: bool
+      default_value: true
+      description: "whether to invert the transform, and publish body_t_vision (needed for a valid TF tree)"
+
+  odom_t_body:
+    sensor_name:
+      type: string
+      default_value: "odom_t_body"
+      description: "The state interface names are: ``<pose_name>/position.x, ..., <pose_name>/position.z, <pose_name>/orientation.x, ..., <pose_name>/orientation.w``"
+    frame_name:
+      type: string
+      default_value: "low_level/odom"
+      description: "Name for the pose"
+    parent_frame_name:
+      type: string
+      default_value: "body"
+      description: "Name of the parent frame"
+    invert:
+      type: bool
+      default_value: true
+      description: "whether to invert the transform, and publish body_t_odom (needed for a valid TF tree)"
+
   tf:
     enable:
       type: bool

--- a/spot_controllers/include/spot_controllers/spot_pose_broadcaster_parameters.yaml
+++ b/spot_controllers/include/spot_controllers/spot_pose_broadcaster_parameters.yaml
@@ -2,33 +2,34 @@ spot_pose_broadcaster:
   use_namespace_as_prefix:
     type: bool
     default_value: true
-    description: "Flag to determine if the prefix of the sensor name should be picked up
+    description: "Flag to determine if the prefix of the sensor name and TF frames should be picked up
                   from the namespace of the controller."
 
-  vision_t_body:
-    sensor_name:
-      type: string
-      default_value: "vision_t_body"
-      description: "The state interface names are: ``<pose_name>/position.x, ..., <pose_name>/position.z, <pose_name>/orientation.x, ..., <pose_name>/orientation.w``"
-    vision_frame_name:
-      type: string
-      default_value: "low_level/vision"
-      description: "Name for the pose"
-    body_frame_name:
-      type: string
-      default_value: "body"
-      description: "Name of the child frame"
+  vision_t_body_sensor:
+    type: string
+    default_value: "vision_t_body"
+    description: "Sensor name containing the transform from the low level vision estimate to body.
+                  The state interface names are: ``<vision_t_body_sensor>/position.x, ..., <vision_t_body_sensor>/position.z,
+                  <vision_t_body_sensor>/orientation.x, ..., <vision_t_body_sensor>/orientation.w``"
 
-  odom_t_body:
-    sensor_name:
-      type: string
-      default_value: "odom_t_body"
-      description: "The state interface names are: ``<pose_name>/position.x, ..., <pose_name>/position.z, <pose_name>/orientation.x, ..., <pose_name>/orientation.w``"
-    odom_frame_name:
-      type: string
-      default_value: "low_level/odom"
-      description: "Name for the pose"
-    body_frame_name:
-      type: string
-      default_value: "body"
-      description: "Name of the child frame"
+  odom_t_body_sensor:
+    type: string
+    default_value: "odom_t_body"
+    description: "Sensor name containing the transform from the low level odom estimate to body.
+                  The state interface names are: ``<odom_t_body_sensor>/position.x, ..., <odom_t_body_sensor>/position.z,
+                  <odom_t_body_sensor>/orientation.x, ..., <odom_t_body_sensor>/orientation.w``"
+
+  body_frame_name:
+    type: string
+    default_value: "body"
+    description: "TF frame name for the body"
+
+  vision_frame_name:
+    type: string
+    default_value: "low_level/vision"
+    description: "TF frame name for the low level estimate of the vision frame"
+
+  odom_frame_name:
+    type: string
+    default_value: "low_level/odom"
+    description: "TF frame name for the low level estimate of the odom frame"

--- a/spot_controllers/spot_controllers.xml
+++ b/spot_controllers/spot_controllers.xml
@@ -13,5 +13,9 @@
   <description>
     Broadcaster for exposing Spot's feet contact states.
   </description>
+  <class name="spot_controllers/SpotPoseBroadcaster" type="spot_controllers::SpotPoseBroadcaster" base_class_type="controller_interface::ControllerInterface">
+  <description>
+    Broadcaster for publishing poses and/or TF from joint state stream.
+  </description>
   </class>
 </library>

--- a/spot_controllers/spot_controllers.xml
+++ b/spot_controllers/spot_controllers.xml
@@ -13,6 +13,7 @@
   <description>
     Broadcaster for exposing Spot's feet contact states.
   </description>
+  </class>
   <class name="spot_controllers/SpotPoseBroadcaster" type="spot_controllers::SpotPoseBroadcaster" base_class_type="controller_interface::ControllerInterface">
   <description>
     Broadcaster for publishing poses and/or TF from joint state stream.

--- a/spot_controllers/src/spot_pose_broadcaster.cpp
+++ b/spot_controllers/src/spot_pose_broadcaster.cpp
@@ -155,6 +155,12 @@ controller_interface::CallbackReturn SpotPoseBroadcaster::on_deactivate(
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
+void SpotPoseBroadcaster::log_pose(const geometry_msgs::msg::Pose& pose) {
+  RCLCPP_INFO_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 1000, "Pose: [%f, %f, %f], [%f, %f, %f, %f]",
+                       pose.position.x, pose.position.y, pose.position.z, pose.orientation.x, pose.orientation.y,
+                       pose.orientation.z, pose.orientation.w);
+}
+
 controller_interface::return_type SpotPoseBroadcaster::update(const rclcpp::Time& time,
                                                               const rclcpp::Duration& /*period*/) {
   geometry_msgs::msg::Pose vision_t_body, odom_t_body;
@@ -173,10 +179,8 @@ controller_interface::return_type SpotPoseBroadcaster::update(const rclcpp::Time
   }
   if (!is_pose_valid(vision_t_body)) {
     // invalid poses should not get published to TF
-    RCLCPP_ERROR_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 1000,
-                          "Invalid pose [%f, %f, %f], [%f, %f, %f, %f]", vision_t_body.position.x,
-                          vision_t_body.position.y, vision_t_body.position.z, vision_t_body.orientation.x,
-                          vision_t_body.orientation.y, vision_t_body.orientation.z, vision_t_body.orientation.w);
+    RCLCPP_ERROR_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 1000, "Invalid vision_t_body");
+    log_pose(vision_t_body);
   } else if (realtime_tf_publisher_ && realtime_tf_publisher_->trylock()) {
     // Pose is valid, publish it to TF
     const std::vector<geometry_msgs::msg::Pose> poses = {vision_t_body, odom_t_body};

--- a/spot_controllers/src/spot_pose_broadcaster.cpp
+++ b/spot_controllers/src/spot_pose_broadcaster.cpp
@@ -1,3 +1,7 @@
+// File modified. Modifications Copyright (c) 2025 Boston Dynamics AI Institute LLC.
+// All rights reserved.
+
+// --------------------------------------------------------------
 // Copyright 2024 FZI Forschungszentrum Informatik
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/spot_controllers/src/spot_pose_broadcaster.cpp
+++ b/spot_controllers/src/spot_pose_broadcaster.cpp
@@ -169,17 +169,30 @@ controller_interface::return_type SpotPoseBroadcaster::update(const rclcpp::Time
     for (size_t i = 0; i < poses.size(); i++) {
       const auto& current_pose = poses.at(i);
 
+      tf2::Transform tf;
+
+      tf2::fromMsg(current_pose, tf);
+
+      // invert the tf
+      const auto inverse_tf = tf.inverse();
+
+      // convert this to a tf2 transform?
+      geometry_msgs::msg::Transform tf_msg;
+      tf2::toMsg(inverse_tf, tf_msg);
+
       auto& tf_transform = realtime_tf_publisher_->msg_.transforms.at(i);
       tf_transform.header.stamp = time;
 
-      tf_transform.transform.translation.x = current_pose.position.x;
-      tf_transform.transform.translation.y = current_pose.position.y;
-      tf_transform.transform.translation.z = current_pose.position.z;
+      tf_transform.transform = tf_msg;
 
-      tf_transform.transform.rotation.x = current_pose.orientation.x;
-      tf_transform.transform.rotation.y = current_pose.orientation.y;
-      tf_transform.transform.rotation.z = current_pose.orientation.z;
-      tf_transform.transform.rotation.w = current_pose.orientation.w;
+      // tf_transform.transform.translation.x = current_pose.position.x;
+      // tf_transform.transform.translation.y = current_pose.position.y;
+      // tf_transform.transform.translation.z = current_pose.position.z;
+
+      // tf_transform.transform.rotation.x = current_pose.orientation.x;
+      // tf_transform.transform.rotation.y = current_pose.orientation.y;
+      // tf_transform.transform.rotation.z = current_pose.orientation.z;
+      // tf_transform.transform.rotation.w = current_pose.orientation.w;
 
       RCLCPP_ERROR_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 1000,
                             "Transform %ld, [%f, %f, %f], [%f, %f, %f, %f]", i, tf_transform.transform.translation.x,

--- a/spot_controllers/src/spot_pose_broadcaster.cpp
+++ b/spot_controllers/src/spot_pose_broadcaster.cpp
@@ -42,7 +42,12 @@ controller_interface::InterfaceConfiguration SpotPoseBroadcaster::command_interf
 controller_interface::InterfaceConfiguration SpotPoseBroadcaster::state_interface_configuration() const {
   controller_interface::InterfaceConfiguration state_interfaces_config;
   state_interfaces_config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
-  state_interfaces_config.names = pose_sensor_->get_state_interface_names();
+  for (const auto& interface : vision_pose_sensor_->get_state_interface_names()) {
+    state_interfaces_config.names.emplace_back(interface);
+  }
+  for (const auto& interface : odom_pose_sensor_->get_state_interface_names()) {
+    state_interfaces_config.names.emplace_back(interface);
+  }
 
   return state_interfaces_config;
 }
@@ -63,7 +68,25 @@ controller_interface::CallbackReturn SpotPoseBroadcaster::on_configure(
     const rclcpp_lifecycle::State& /*previous_state*/) {
   params_ = param_listener_->get_params();
 
-  pose_sensor_ = std::make_unique<semantic_components::PoseSensor>(params_.pose_name);
+  RCLCPP_ERROR(get_node()->get_logger(), "vision tform body %s", params_.vision_t_body.sensor_name.c_str());
+  RCLCPP_ERROR(get_node()->get_logger(), "odom tform body %s", params_.odom_t_body.sensor_name.c_str());
+
+  const bool use_namespace_as_prefix = params_.use_namespace_as_prefix;
+  std::string frame_prefix = "";
+  if (use_namespace_as_prefix) {
+    // Grab the namespace from the node.
+    const std::string node_namespace = get_node()->get_namespace();
+    // namespace is "/" if there is none, else it's "/<namespace>". Erase the first char ("/") for easier parsing.
+    const std::string trimmed_namespace = node_namespace.substr(1);
+    // Now trimmed_namespace is either the empty string or "<namespace>"
+    frame_prefix = trimmed_namespace.empty() ? "" : trimmed_namespace + "/";
+    // And now sensor prefix is either "" or "<namespace>/"
+  }
+  RCLCPP_ERROR(get_node()->get_logger(), "frame prefix %s", frame_prefix.c_str());
+
+  vision_pose_sensor_ =
+      std::make_unique<semantic_components::PoseSensor>(frame_prefix + params_.vision_t_body.sensor_name);
+  odom_pose_sensor_ = std::make_unique<semantic_components::PoseSensor>(frame_prefix + params_.odom_t_body.sensor_name);
   tf_publish_period_ = params_.tf.publish_rate == 0.0
                            ? std::nullopt
                            : std::optional{rclcpp::Duration::from_seconds(1.0 / params_.tf.publish_rate)};
@@ -94,14 +117,14 @@ controller_interface::CallbackReturn SpotPoseBroadcaster::on_configure(
   if (realtime_tf_publisher_) {
     realtime_tf_publisher_->lock();
 
-    realtime_tf_publisher_->msg_.transforms.resize(1);
-    auto& tf_transform = realtime_tf_publisher_->msg_.transforms.front();
-    tf_transform.header.frame_id = params_.frame_id;
-    if (params_.tf.child_frame_id.empty()) {
-      tf_transform.child_frame_id = params_.pose_name;
-    } else {
-      tf_transform.child_frame_id = params_.tf.child_frame_id;
-    }
+    realtime_tf_publisher_->msg_.transforms.resize(2);
+    auto& vision_tf_transform = realtime_tf_publisher_->msg_.transforms.at(0);
+    vision_tf_transform.header.frame_id = frame_prefix + params_.vision_t_body.parent_frame_name;
+    vision_tf_transform.child_frame_id = frame_prefix + params_.vision_t_body.frame_name;
+
+    auto& odom_tf_transform = realtime_tf_publisher_->msg_.transforms.at(1);
+    odom_tf_transform.header.frame_id = frame_prefix + params_.odom_t_body.parent_frame_name;
+    odom_tf_transform.child_frame_id = frame_prefix + params_.odom_t_body.frame_name;
 
     realtime_tf_publisher_->unlock();
   }
@@ -111,31 +134,34 @@ controller_interface::CallbackReturn SpotPoseBroadcaster::on_configure(
 
 controller_interface::CallbackReturn SpotPoseBroadcaster::on_activate(
     const rclcpp_lifecycle::State& /*previous_state*/) {
-  pose_sensor_->assign_loaned_state_interfaces(state_interfaces_);
+  vision_pose_sensor_->assign_loaned_state_interfaces(state_interfaces_);
+  // FIXME this seems wrong, each sensor has a different set of state interfaces
+  odom_pose_sensor_->assign_loaned_state_interfaces(state_interfaces_);
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
 controller_interface::CallbackReturn SpotPoseBroadcaster::on_deactivate(
     const rclcpp_lifecycle::State& /*previous_state*/) {
-  pose_sensor_->release_interfaces();
+  vision_pose_sensor_->release_interfaces();
+  odom_pose_sensor_->release_interfaces();
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
 controller_interface::return_type SpotPoseBroadcaster::update(const rclcpp::Time& time,
                                                               const rclcpp::Duration& /*period*/) {
-  geometry_msgs::msg::Pose pose;
-  pose_sensor_->get_values_as_message(pose);
+  geometry_msgs::msg::Pose vision_t_body;
+  vision_pose_sensor_->get_values_as_message(vision_t_body);
 
   if (realtime_publisher_ && realtime_publisher_->trylock()) {
     realtime_publisher_->msg_.header.stamp = time;
-    realtime_publisher_->msg_.pose = pose;
+    realtime_publisher_->msg_.pose = vision_t_body;
     realtime_publisher_->unlockAndPublish();
   }
-  if (!is_pose_valid(pose)) {
+  if (!is_pose_valid(vision_t_body)) {
     RCLCPP_ERROR_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 1000,
-                          "Invalid pose [%f, %f, %f], [%f, %f, %f, %f]", pose.position.x, pose.position.y,
-                          pose.position.z, pose.orientation.x, pose.orientation.y, pose.orientation.z,
-                          pose.orientation.w);
+                          "Invalid pose [%f, %f, %f], [%f, %f, %f, %f]", vision_t_body.position.x,
+                          vision_t_body.position.y, vision_t_body.position.z, vision_t_body.orientation.x,
+                          vision_t_body.orientation.y, vision_t_body.orientation.z, vision_t_body.orientation.w);
   } else if (realtime_tf_publisher_ && realtime_tf_publisher_->trylock()) {
     bool do_publish = false;
     // rlcpp::Time comparisons throw if clock types are not the same
@@ -146,17 +172,29 @@ controller_interface::return_type SpotPoseBroadcaster::update(const rclcpp::Time
     }
 
     if (do_publish) {
-      auto& tf_transform = realtime_tf_publisher_->msg_.transforms[0];
-      tf_transform.header.stamp = time;
+      auto& vision_tf_transform = realtime_tf_publisher_->msg_.transforms[0];
+      vision_tf_transform.header.stamp = time;
 
-      tf_transform.transform.translation.x = pose.position.x;
-      tf_transform.transform.translation.y = pose.position.y;
-      tf_transform.transform.translation.z = pose.position.z;
+      vision_tf_transform.transform.translation.x = vision_t_body.position.x;
+      vision_tf_transform.transform.translation.y = vision_t_body.position.y;
+      vision_tf_transform.transform.translation.z = vision_t_body.position.z;
 
-      tf_transform.transform.rotation.x = pose.orientation.x;
-      tf_transform.transform.rotation.y = pose.orientation.y;
-      tf_transform.transform.rotation.z = pose.orientation.z;
-      tf_transform.transform.rotation.w = pose.orientation.w;
+      vision_tf_transform.transform.rotation.x = vision_t_body.orientation.x;
+      vision_tf_transform.transform.rotation.y = vision_t_body.orientation.y;
+      vision_tf_transform.transform.rotation.z = vision_t_body.orientation.z;
+      vision_tf_transform.transform.rotation.w = vision_t_body.orientation.w;
+
+      auto& odom_tf_transform = realtime_tf_publisher_->msg_.transforms[1];
+      odom_tf_transform.header.stamp = time;
+
+      odom_tf_transform.transform.translation.x = vision_t_body.position.x;
+      odom_tf_transform.transform.translation.y = vision_t_body.position.y;
+      odom_tf_transform.transform.translation.z = vision_t_body.position.z;
+
+      odom_tf_transform.transform.rotation.x = vision_t_body.orientation.x;
+      odom_tf_transform.transform.rotation.y = vision_t_body.orientation.y;
+      odom_tf_transform.transform.rotation.z = vision_t_body.orientation.z;
+      odom_tf_transform.transform.rotation.w = vision_t_body.orientation.w;
 
       realtime_tf_publisher_->unlockAndPublish();
 

--- a/spot_controllers/src/spot_pose_broadcaster.cpp
+++ b/spot_controllers/src/spot_pose_broadcaster.cpp
@@ -1,0 +1,176 @@
+// Copyright 2024 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "spot_controllers/spot_pose_broadcaster.hpp"
+#include <cmath>
+#include <rclcpp/logging.hpp>
+
+namespace {
+
+constexpr auto DEFAULT_POSE_TOPIC = "~/pose";
+constexpr auto DEFAULT_TF_TOPIC = "/tf";
+
+}  // namespace
+
+namespace spot_controllers {
+
+bool is_pose_valid(const geometry_msgs::msg::Pose& pose) {
+  return std::isfinite(pose.position.x) && std::isfinite(pose.position.y) && std::isfinite(pose.position.z) &&
+         std::isfinite(pose.orientation.x) && std::isfinite(pose.orientation.y) && std::isfinite(pose.orientation.z) &&
+         std::isfinite(pose.orientation.w) &&
+
+         std::abs(pose.orientation.x * pose.orientation.x + pose.orientation.y * pose.orientation.y +
+                  pose.orientation.z * pose.orientation.z + pose.orientation.w * pose.orientation.w - 1.0) <= 10e-3;
+}
+
+controller_interface::InterfaceConfiguration SpotPoseBroadcaster::command_interface_configuration() const {
+  controller_interface::InterfaceConfiguration command_interfaces_config;
+  command_interfaces_config.type = controller_interface::interface_configuration_type::NONE;
+  return command_interfaces_config;
+}
+
+controller_interface::InterfaceConfiguration SpotPoseBroadcaster::state_interface_configuration() const {
+  controller_interface::InterfaceConfiguration state_interfaces_config;
+  state_interfaces_config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+  state_interfaces_config.names = pose_sensor_->get_state_interface_names();
+
+  return state_interfaces_config;
+}
+
+controller_interface::CallbackReturn SpotPoseBroadcaster::on_init() {
+  try {
+    param_listener_ = std::make_shared<ParamListener>(get_node());
+    params_ = param_listener_->get_params();
+  } catch (const std::exception& ex) {
+    fprintf(stderr, "Exception thrown during init stage with message: %s\n", ex.what());
+    return controller_interface::CallbackReturn::ERROR;
+  }
+
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn SpotPoseBroadcaster::on_configure(
+    const rclcpp_lifecycle::State& /*previous_state*/) {
+  params_ = param_listener_->get_params();
+
+  pose_sensor_ = std::make_unique<semantic_components::PoseSensor>(params_.pose_name);
+  tf_publish_period_ = params_.tf.publish_rate == 0.0
+                           ? std::nullopt
+                           : std::optional{rclcpp::Duration::from_seconds(1.0 / params_.tf.publish_rate)};
+
+  try {
+    pose_publisher_ =
+        get_node()->create_publisher<geometry_msgs::msg::PoseStamped>(DEFAULT_POSE_TOPIC, rclcpp::SystemDefaultsQoS());
+    realtime_publisher_ =
+        std::make_unique<realtime_tools::RealtimePublisher<geometry_msgs::msg::PoseStamped>>(pose_publisher_);
+
+    if (params_.tf.enable) {
+      tf_publisher_ =
+          get_node()->create_publisher<tf2_msgs::msg::TFMessage>(DEFAULT_TF_TOPIC, rclcpp::SystemDefaultsQoS());
+      realtime_tf_publisher_ =
+          std::make_unique<realtime_tools::RealtimePublisher<tf2_msgs::msg::TFMessage>>(tf_publisher_);
+    }
+  } catch (const std::exception& ex) {
+    fprintf(stderr, "Exception thrown during publisher creation at configure stage with message: %s\n", ex.what());
+    return controller_interface::CallbackReturn::ERROR;
+  }
+
+  // Initialize pose message
+  realtime_publisher_->lock();
+  realtime_publisher_->msg_.header.frame_id = params_.frame_id;
+  realtime_publisher_->unlock();
+
+  // Initialize tf message if tf publishing is enabled
+  if (realtime_tf_publisher_) {
+    realtime_tf_publisher_->lock();
+
+    realtime_tf_publisher_->msg_.transforms.resize(1);
+    auto& tf_transform = realtime_tf_publisher_->msg_.transforms.front();
+    tf_transform.header.frame_id = params_.frame_id;
+    if (params_.tf.child_frame_id.empty()) {
+      tf_transform.child_frame_id = params_.pose_name;
+    } else {
+      tf_transform.child_frame_id = params_.tf.child_frame_id;
+    }
+
+    realtime_tf_publisher_->unlock();
+  }
+
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn SpotPoseBroadcaster::on_activate(
+    const rclcpp_lifecycle::State& /*previous_state*/) {
+  pose_sensor_->assign_loaned_state_interfaces(state_interfaces_);
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn SpotPoseBroadcaster::on_deactivate(
+    const rclcpp_lifecycle::State& /*previous_state*/) {
+  pose_sensor_->release_interfaces();
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::return_type SpotPoseBroadcaster::update(const rclcpp::Time& time,
+                                                              const rclcpp::Duration& /*period*/) {
+  geometry_msgs::msg::Pose pose;
+  pose_sensor_->get_values_as_message(pose);
+
+  if (realtime_publisher_ && realtime_publisher_->trylock()) {
+    realtime_publisher_->msg_.header.stamp = time;
+    realtime_publisher_->msg_.pose = pose;
+    realtime_publisher_->unlockAndPublish();
+  }
+  if (!is_pose_valid(pose)) {
+    RCLCPP_ERROR_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 1000,
+                          "Invalid pose [%f, %f, %f], [%f, %f, %f, %f]", pose.position.x, pose.position.y,
+                          pose.position.z, pose.orientation.x, pose.orientation.y, pose.orientation.z,
+                          pose.orientation.w);
+  } else if (realtime_tf_publisher_ && realtime_tf_publisher_->trylock()) {
+    bool do_publish = false;
+    // rlcpp::Time comparisons throw if clock types are not the same
+    if (tf_last_publish_time_.get_clock_type() != time.get_clock_type()) {
+      do_publish = true;
+    } else if (!tf_publish_period_ || (tf_last_publish_time_ + *tf_publish_period_ <= time)) {
+      do_publish = true;
+    }
+
+    if (do_publish) {
+      auto& tf_transform = realtime_tf_publisher_->msg_.transforms[0];
+      tf_transform.header.stamp = time;
+
+      tf_transform.transform.translation.x = pose.position.x;
+      tf_transform.transform.translation.y = pose.position.y;
+      tf_transform.transform.translation.z = pose.position.z;
+
+      tf_transform.transform.rotation.x = pose.orientation.x;
+      tf_transform.transform.rotation.y = pose.orientation.y;
+      tf_transform.transform.rotation.z = pose.orientation.z;
+      tf_transform.transform.rotation.w = pose.orientation.w;
+
+      realtime_tf_publisher_->unlockAndPublish();
+
+      tf_last_publish_time_ = time;
+    } else {
+      realtime_tf_publisher_->unlock();
+    }
+  }
+
+  return controller_interface::return_type::OK;
+}
+
+}  // namespace spot_controllers
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(spot_controllers::SpotPoseBroadcaster, controller_interface::ControllerInterface)

--- a/spot_ros2_control/README.md
+++ b/spot_ros2_control/README.md
@@ -60,7 +60,9 @@ IMU data from the robot state stream is exposed on the topic `/<Robot Name>/imu_
 
 Feet contact data from the robot state stream is exposed on the topic `/<Robot Name>/foot_state_broadcaster/feet`.
 
-Additionally, the state publisher node, object synchronization node, and image publisher nodes from [`spot_driver`](../spot_driver/) will get launched by default when running on the robot to provide extra information such as TF, odometry, and camera feeds.
+Estimates of the robot's `body` pose with respect to `vision` and `odom` frames can be found via the TF frames `<Robot Name>/low_level/vision` and `<Robot Name>/low_level/odom`, or alternatively on the topics `/<Robot Name>/spot_pose_broadcaster/vision_t_body` and `/<Robot Name>/spot_pose_broadcaster/odom_t_body`.
+
+Additionally, the state publisher node, object synchronization node, and image publisher nodes from [`spot_driver`](../spot_driver/) will get launched by default when running on the robot to provide extra information such as additional TF frames, odometry, and camera feeds.
 To turn off the image publishers (which can cause problems with bandwidth), add the launch argument `launch_image_publishers:=false`.
 
 ### Setting Gains

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -101,13 +101,6 @@ def create_controllers_config(spot_name: str, has_arm: bool) -> str:
                 "frame_id": f"{prefix}imu_sensor_frame",
             }
         },
-        f"{prefix}spot_pose_broadcaster": {
-            "ros__parameters": {
-                "pose_name": f"{prefix}low_level/vision",
-                "frame_id": f"{prefix}body",
-                "child_frame_id": f"{prefix}/low_level/vision",
-            }
-        },
     }
     with NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as out_file:
         yaml.dump(config, out_file)

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -74,6 +74,7 @@ def create_controllers_config(spot_name: str, has_arm: bool) -> str:
                 "forward_state_controller": {"type": "spot_controllers/ForwardStateController"},
                 "spot_joint_controller": {"type": "spot_controllers/SpotJointController"},
                 "foot_state_broadcaster": {"type": "spot_controllers/FootStateBroadcaster"},
+                "spot_pose_broadcaster": {"type": "spot_controllers/SpotPoseBroadcaster"},
                 "hardware_components_initial_state": {"unconfigured": ["SpotSystem"]},
             }
         },
@@ -98,6 +99,13 @@ def create_controllers_config(spot_name: str, has_arm: bool) -> str:
             "ros__parameters": {
                 "sensor_name": f"{prefix}imu_sensor",
                 "frame_id": f"{prefix}imu_sensor_frame",
+            }
+        },
+        f"{prefix}spot_pose_broadcaster": {
+            "ros__parameters": {
+                "pose_name": f"{prefix}vision_tform_body",
+                "frame_id": f"{prefix}body",
+                "child_frame_id": f"{prefix}/low_level/vision",
             }
         },
     }

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -103,7 +103,7 @@ def create_controllers_config(spot_name: str, has_arm: bool) -> str:
         },
         f"{prefix}spot_pose_broadcaster": {
             "ros__parameters": {
-                "pose_name": f"{prefix}vision_tform_body",
+                "pose_name": f"{prefix}low_level/vision",
                 "frame_id": f"{prefix}body",
                 "child_frame_id": f"{prefix}/low_level/vision",
             }
@@ -243,6 +243,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
                         "joint_state_broadcaster",
                         "imu_sensor_broadcaster",
                         "foot_state_broadcaster",
+                        "spot_pose_broadcaster",
                         LaunchConfiguration("robot_controller"),
                     ],
                     namespace=spot_name,


### PR DESCRIPTION
## Change Overview

Adds a `spot_pose_broadcaster` controller plugin that exposes the low level `odom_t_body` and `vision_t_body` poses.

New TF frames: they are the same as `<spot name>/odom` and `<spot name>/vision`, respectively, but obtained through the joint level API and are broadcasted at 333 Hz
* `<spot_name>/low_level/odom`
*  `<spot_name>/low_level/vision`

New published topics, which contain the same transforms but in ROS Pose msg form:
* `/<spot name>/spot_pose_broadcaster/odom_t_body`
* `/<spot name>/spot_pose_broadcaster/vision_t_body`

largely based off of https://github.com/ros-controls/ros2_controllers/tree/humble/pose_broadcaster

## Testing Done

- [x] Tested in mock mode, which sets both of these to identity transforms
- [x] Tested on robot, verified that the location matches the high level robot state equivlaent
- [x] Tested with and without namespace set
- [x] Existing unit test still passes

![low_level_frames.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Xynj6CBpA3NqqBFfE8Q9/a0fed399-a15e-4aa4-afdc-ff821aef293d.png)

[Screencast from 05-01-2025 12:59:18 PM.webm <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Xynj6CBpA3NqqBFfE8Q9/dacfdf79-45a8-43f9-b994-7331028137fc.webm" />](https://app.graphite.dev/media/video/Xynj6CBpA3NqqBFfE8Q9/dacfdf79-45a8-43f9-b994-7331028137fc.webm)

