### PR TITLE
added missing tl_expected dependency

### DIFF
--- a/spot_hardware_interface/CMakeLists.txt
+++ b/spot_hardware_interface/CMakeLists.txt
@@ -22,6 +22,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp
   rclcpp_lifecycle
   spot_msgs
+	tl_expected
 )
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)


### PR DESCRIPTION
## Change Overview

spot_hardware_interface fails to build due to missing tl_expected header.
Adding `tl_expected` to list of package include dependencies fixes the build error.


## Testing Done

Tested on ubuntu 22.04, outside of docker, with all dependencies installed as specified by readme. Built with 
`colcon build --packages-up-to spot_ros2_control`
