### PR TITLE
Update to 5.0.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,7 +29,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
 
 RUN source "/opt/ros/${ROS_DISTRO}/setup.bash"
 
-ARG SPOT_SDK_VERSION="4.1.1"
+ARG SPOT_SDK_VERSION="5.0.0"
 ARG SPOT_MSG_VERSION="${SPOT_SDK_VERSION}"
 
 # Install bosdyn_msgs package

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 # Overview
 `spot_ros2` is a set of ROS 2 packages for interacting with Boston Dynamics' Spot, based off the [the ROS 1 equivalent](https://github.com/heuristicus/spot_ros).
 Its [`spot_driver`](spot_driver) package is designed to bridge the core functionality of the Spot SDK to ROS 2, and exposes topics, services, and actions necessary to control Spot and receive state information (such as images). 
-Currently, this repository corresponds to version 4.1.1 of the [spot-sdk](https://github.com/boston-dynamics/spot-sdk/releases/tag/v4.1.1).
+Currently, this repository corresponds to version 5.0.0 of the [spot-sdk](https://github.com/boston-dynamics/spot-sdk/releases/tag/v5.0.0).
 
 ## Requirements
 This repository is supported for use with Ubuntu 22.04 and [ROS 2 Humble](https://docs.ros.org/en/humble/index.html) on both ARM64 and AMD64 platforms.
@@ -114,32 +114,32 @@ It can be installed from source as a normal ROS package [here](https://github.co
 If you encounter problems when using this repository, feel free to ask a question in the [discussions](https://github.com/bdaiinstitute/spot_ros2/discussions), or open an [issue](https://github.com/bdaiinstitute/spot_ros2/issues) describing the problem in context.
 
 ## Verify Package Versions
-If you encounter `ModuleNotFoundErrors` with `bosdyn` packages upon running the driver, it is likely that the necessary Boston Dynamics API packages did not get installed with `install_spot_ros2.sh`. To check this, you can run the following command. Note that all versions should be `4.1.1`.
+If you encounter `ModuleNotFoundErrors` with `bosdyn` packages upon running the driver, it is likely that the necessary Boston Dynamics API packages did not get installed with `install_spot_ros2.sh`. To check this, you can run the following command. Note that all versions should be `5.0.0`.
 ```bash
 $ pip list | grep bosdyn
-bosdyn-api                               4.1.1
-bosdyn-api-msgs                          4.1.1
-bosdyn-auto-return-api-msgs              4.1.1
-bosdyn-autowalk-api-msgs                 4.1.1
-bosdyn-choreography-client               4.1.1
-bosdyn-client                            4.1.1
-bosdyn-core                              4.1.1
-bosdyn-graph-nav-api-msgs                4.1.1
-bosdyn-keepalive-api-msgs                4.1.1
-bosdyn-log-status-api-msgs               4.1.1
-bosdyn-metrics-logging-api-msgs          4.1.1
-bosdyn-mission                           4.1.1
-bosdyn-mission-api-msgs                  4.1.1
-bosdyn-msgs                              4.1.1
-bosdyn-spot-api-msgs                     4.1.1
-bosdyn-spot-cam-api-msgs                 4.1.1
+bosdyn-api                               5.0.0
+bosdyn-api-msgs                          5.0.0
+bosdyn-auto-return-api-msgs              5.0.0
+bosdyn-autowalk-api-msgs                 5.0.0
+bosdyn-choreography-client               5.0.0
+bosdyn-client                            5.0.0
+bosdyn-core                              5.0.0
+bosdyn-graph-nav-api-msgs                5.0.0
+bosdyn-keepalive-api-msgs                5.0.0
+bosdyn-log-status-api-msgs               5.0.0
+bosdyn-metrics-logging-api-msgs          5.0.0
+bosdyn-mission                           5.0.0
+bosdyn-mission-api-msgs                  5.0.0
+bosdyn-msgs                              5.0.0
+bosdyn-spot-api-msgs                     5.0.0
+bosdyn-spot-cam-api-msgs                 5.0.0
 ```
 If these packages were not installed correctly on your system, you can try manually installing them following [Boston Dynamics' guide](https://dev.bostondynamics.com/docs/python/quickstart#install-spot-python-packages).
 
 The above command verifies the installation of the `bosdyn` packages from Boston Dynamics and the generated protobuf to ROS messages in the `bosdyn_msgs` package (these have `msgs` in the name). You can also verify the `bosdyn_msgs` installation was correct with the following command:
 ```bash
 $ ros2 pkg xml bosdyn_msgs -t version
-4.1.1
+5.0.0
 ```
 
 Finally, you can verify the installation of the `spot-cpp-sdk` with the following command:
@@ -147,7 +147,7 @@ Finally, you can verify the installation of the `spot-cpp-sdk` with the followin
 $ dpkg -l spot-cpp-sdk
 ||/ Name           Version      Architecture Description
 +++-==============-============-============-=================================
-ii  spot-cpp-sdk   4.1.1        amd64        Boston Dynamics Spot C++ SDK
+ii  spot-cpp-sdk   5.0.0        amd64        Boston Dynamics Spot C++ SDK
 ```
 
 # License

--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -1,5 +1,5 @@
 ARCH="amd64"
-SDK_VERSION="4.1.1"
+SDK_VERSION="5.0.0"
 MSG_VERSION="${SDK_VERSION}"
 HELP=$'--arm64: Installs ARM64 version'
 REQUIREMENTS_FILE=spot_wrapper/requirements.txt

--- a/spot_driver/src/conversions/robot_state.cpp
+++ b/spot_driver/src/conversions/robot_state.cpp
@@ -277,7 +277,7 @@ std::optional<spot_msgs::msg::SystemFaultState> getSystemFaultState(const ::bosd
                              .sec(fault.duration().seconds())
                              .nanosec(fault.duration().nanos());
     fault_msg.code = fault.code();
-    fault_msg.uid = fault.uid();
+    fault_msg.uuid = fault.uuid();
     fault_msg.error_message = fault.error_message();
     for (const auto& attr : fault.attributes()) {
       fault_msg.attributes.push_back(attr);

--- a/spot_driver/test/include/spot_driver/matchers.hpp
+++ b/spot_driver/test/include/spot_driver/matchers.hpp
@@ -112,13 +112,13 @@ MATCHER_P(DurationEq, duration, "") {
       arg, result_listener);
 }
 
-MATCHER_P8(SystemFaultEq, timestamp, clock_skew, duration, name, uid, code, error_msg, attributes, "") {
+MATCHER_P8(SystemFaultEq, timestamp, clock_skew, duration, name, uuid, code, error_msg, attributes, "") {
   using SystemFault = spot_msgs::msg::SystemFault;
   return testing::ExplainMatchResult(
       testing::AllOf(testing::Field("header", &SystemFault::header, ClockSkewIsAppliedToHeader(timestamp, clock_skew)),
                      testing::Field("duration", &SystemFault::duration, DurationEq(duration)),
                      testing::Field("name", &SystemFault::name, testing::StrEq(name)),
-                     testing::Field("code", &SystemFault::code, code), testing::Field("uid", &SystemFault::uid, uid),
+                     testing::Field("code", &SystemFault::code, code), testing::Field("uuid", &SystemFault::uuid, uuid),
                      testing::Field("error_message", &SystemFault::error_message, testing::StrEq(error_msg)),
                      testing::Field("attributes", &SystemFault::attributes, testing::ContainerEq(attributes))),
       arg, result_listener);

--- a/spot_driver/test/include/spot_driver/robot_state_test_tools.hpp
+++ b/spot_driver/test/include/spot_driver/robot_state_test_tools.hpp
@@ -49,7 +49,7 @@ inline ::bosdyn::api::WiFiState createWifiState(::bosdyn::api::WiFiState_Mode mo
 inline void appendSystemFault(::bosdyn::api::SystemFaultState* mutable_fault_state,
                               const google::protobuf::Timestamp& onset_timestamp,
                               const google::protobuf::Duration& duration, const std::string& name, const int32_t code,
-                              const uint64_t uid, const std::string& error_message,
+                              const std::string& uuid, const std::string& error_message,
                               const std::vector<std::string>& attributes,
                               const ::bosdyn::api::SystemFault_Severity& severity) {
   auto* fault = mutable_fault_state->add_faults();
@@ -57,7 +57,7 @@ inline void appendSystemFault(::bosdyn::api::SystemFaultState* mutable_fault_sta
   fault->mutable_duration()->CopyFrom(duration);
   fault->set_name(name);
   fault->set_code(code);
-  fault->set_uid(uid);
+  fault->set_uuid(uuid);
   fault->set_error_message(error_message);
   *fault->mutable_attributes() = {attributes.cbegin(), attributes.cend()};
   fault->set_severity(severity);

--- a/spot_driver/test/src/conversions/test_robot_state.cpp
+++ b/spot_driver/test/src/conversions/test_robot_state.cpp
@@ -608,15 +608,16 @@ TEST(RobotStateConversions, TestGetSystemFaultState) {
   google::protobuf::Duration duration1;
   duration1.set_seconds(15);
   duration1.set_nanos(0);
-  appendSystemFault(robot_state.mutable_system_fault_state(), timestamp1, duration1, "fault1", 19, 3, "battery is low",
-                    {"robot", "battery"}, ::bosdyn::api::SystemFault_Severity::SystemFault_Severity_SEVERITY_WARN);
+  appendSystemFault(robot_state.mutable_system_fault_state(), timestamp1, duration1, "fault1", 19, "3",
+                    "battery is low", {"robot", "battery"},
+                    ::bosdyn::api::SystemFault_Severity::SystemFault_Severity_SEVERITY_WARN);
 
   google::protobuf::Timestamp timestamp2;
   timestamp2.set_seconds(75);
   google::protobuf::Duration duration2;
   duration2.set_seconds(0);
   duration2.set_nanos(0);
-  appendSystemFault(robot_state.mutable_system_fault_state(), timestamp2, duration2, "fault2", 55, 9,
+  appendSystemFault(robot_state.mutable_system_fault_state(), timestamp2, duration2, "fault2", 55, "9",
                     "robot has departed from this plane of reality", {"robot"},
                     ::bosdyn::api::SystemFault_Severity::SystemFault_Severity_SEVERITY_CRITICAL);
 
@@ -631,9 +632,9 @@ TEST(RobotStateConversions, TestGetSystemFaultState) {
   // THEN the clock skew is correctly applied
   EXPECT_THAT(out->faults,
               UnorderedElementsAre(
-                  SystemFaultEq(timestamp1, clock_skew, duration1, "fault1", 3UL, 19, "battery is low",
+                  SystemFaultEq(timestamp1, clock_skew, duration1, "fault1", "3", 19, "battery is low",
                                 std::vector<std::string>{"robot", "battery"}),
-                  SystemFaultEq(timestamp2, clock_skew, duration2, "fault2", 9UL, 55,
+                  SystemFaultEq(timestamp2, clock_skew, duration2, "fault2", "9", 55,
                                 "robot has departed from this plane of reality", std::vector<std::string>{"robot"})));
 }
 

--- a/spot_msgs/msg/SystemFault.msg
+++ b/spot_msgs/msg/SystemFault.msg
@@ -8,7 +8,7 @@ std_msgs/Header header
 string name
 builtin_interfaces/Duration duration
 int32 code
-uint64 uid
+string uuid
 string error_message
 string[] attributes
 uint8 severity


### PR DESCRIPTION
## Change Overview

Updates from spot sdk 4.1.1 to 5.0.0.

* Needs: https://github.com/bdaiinstitute/spot_wrapper/pull/167

* Uses release of spot-cpp-sdk here: https://github.com/bdaiinstitute/spot-cpp-sdk/releases/tag/v5.0.0

* Uses release of bosdyn_msgs here: https://github.com/bdaiinstitute/bosdyn_msgs/releases/tag/5.0.0

There were two deprecation warnings that came up during testing. First, `uid` in the System Fault proto was deprecated in favor of `uuid` [here](https://github.com/bdaiinstitute/spot-cpp-sdk/blob/6d8255c3165741ba0b398e6c72010fb3251b2f6b/protos/bosdyn/api/robot_state.proto#L265). This has been updated in this PR as this is a minor change.
Second, `end_effector_force_in_hand` has been deprecated in favor of `end_effector_wrench_in_hand` in the Manipulator State proto [here](https://github.com/bdaiinstitute/spot-cpp-sdk/blob/6d8255c3165741ba0b398e6c72010fb3251b2f6b/protos/bosdyn/api/robot_state.proto#L629). This will be addressed in a future ticket as this is a larger change that will cause more downstream changes in our internal code, but it is worth noting there will be a build time warning about this deprecation until this is updated. 

## Testing Done

- [x] CI
- [x] Run `install_spot_ros2.sh` script locally without error. verified that all my installations are on 5.0.0
- [x] Run driver and run examples on hardware
- [x] Run ros2 control stack and example on hardware
