### PR TITLE
Allow spawning of multiple robot controllers via launch arg

### DIFF
--- a/spot_ros2_control/README.md
+++ b/spot_ros2_control/README.md
@@ -41,12 +41,12 @@ This will forward position commands directly to the joint control API through th
 The controller expects the command array to contain the list of positions to forward for each joint on the robot (12 elements for robots without an arm, and 19 for robots with an arm).
 
 An alternative feed-forward controller provided by the [`spot_controllers`](../spot_controllers/) package can be used to specify the position, velocity, and effort of all joints at the same time.
-To bring up this controller, add the launch argument `robot_controller:=forward_state_controller`.
+To bring up this controller, add the launch argument `robot_controllers:=forward_state_controller`.
 Commands can then be sent on the topic `/<Robot Name>/forward_state_controller/commands`.
 This controller expects the ordering of the command array to be `[<positions for each joint>, <velocities for each joint>, <efforts for each joint>]` (36 elements for robots without an arm, and 57 for robots with an arm).
 
 Finally, the custom controller `spot_joint_controller` is also provided for the ability to stream position, velocity, effort, k_q_p, and k_qd_p for any subset of joints.
-To enable this controller, add the launch argument `robot_controller:=spot_joint_controller`.
+To enable this controller, add the launch argument `robot_controllers:=spot_joint_controller`.
 This controller accepts commands on the topic `/<Robot Name>/spot_joint_controller/joint_commands`.
 Unlike the previous controllers, you do not need to set a value for every single joint, but instead can select the joints by name you wish to control in the `joint_commands` message -- all other joints that are not specified will be left unchanged.
 More details on this controller can be found on the [`spot_controllers` README](../spot_controllers/README.md).
@@ -104,7 +104,7 @@ ros2 launch spot_ros2_control wiggle_arm.launch.py
 Add the launch argument `spot_name:=<namespace>` if the ros2 control stack was launched in a namespace.
 
 An alternate example using the `spot_joint_controller` is provided to demonstrate how to stream position and gains at the same time.
-First launch `spot_ros2_control.launch.py` with the launch argument `robot_controller:=spot_joint_controller`.
+First launch `spot_ros2_control.launch.py` with the launch argument `robot_controllers:=spot_joint_controller`.
 Next, run
 ```bash
 ros2 run spot_ros2_control set_grippper_gains
@@ -114,7 +114,7 @@ This demo will repeatedly open and close the gripper, and after each motion, wil
 
 ## Additional Arguments
 * `controllers_config`: If this argument is unset, a general purpose controller configuration will be loaded containing a forward position controller and a joint state publisher, that is filled appropriately based on whether or not the robot used (mock or real) has an arm. The forward state controller and spot joint controller are also specified here. If you wish to load different controllers, this can be set here.
-* `robot_controller`: This is the name of the robot controller that will be started when the launchfile is called. The default is the simple forward position controller. The name must match a controller in the `controllers_config` file.
+* `robot_controllers`: These are the names of the robot controllers that will be started when the launchfile is called. The default is the simple forward position controller. Each name must match a controller in the `controllers_config` file.
 * `launch_rviz`: If you do not want rviz to be launched, add the argument `launch_rviz:=False`.
 * `auto_start`: If you do not want hardware interfaces and controllers to be activated on launch, add the argument `auto_start:=False`.
 

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -163,7 +163,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
                         "imu_sensor_broadcaster",
                         "foot_state_broadcaster",
                         "spot_pose_broadcaster",
-                        *robot_controllers.split(","),
+                        *robot_controllers.split(" "),
                     ],
                     namespace=spot_name,
                 )
@@ -265,7 +265,7 @@ def generate_launch_description():
                 "robot_controllers",
                 default_value="forward_position_controller",
                 description=(
-                    "Comma-separated list of robot controller(s) to start. Each controller match an entry in"
+                    "List of robot controller(s) to start (space-separated). Each controller match an entry in"
                     " controllers_config. For the default configuration file, options are forward_position_controller,"
                     " forward_state_controller, or spot_joint_controller."
                 ),

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -65,6 +65,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     mock_arm: bool = IfCondition(LaunchConfiguration("mock_arm")).evaluate(context)
     spot_name: str = LaunchConfiguration("spot_name").perform(context)
     config_file: str = LaunchConfiguration("config_file").perform(context)
+    robot_controllers: str = LaunchConfiguration("robot_controllers").perform(context)
 
     # Default parameters used in the URDF if not connected to a robot
     arm = mock_arm
@@ -162,7 +163,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
                         "imu_sensor_broadcaster",
                         "foot_state_broadcaster",
                         "spot_pose_broadcaster",
-                        LaunchConfiguration("robot_controller"),
+                        *robot_controllers.split(","),
                     ],
                     namespace=spot_name,
                 )
@@ -261,12 +262,12 @@ def generate_launch_description():
                 ),
             ),
             DeclareLaunchArgument(
-                "robot_controller",
+                "robot_controllers",
                 default_value="forward_position_controller",
                 description=(
-                    "Robot controller to start. Must match an entry in controllers_config. For the default"
-                    " configuration file, options are forward_position_controller, forward_state_controller, or"
-                    " spot_joint_controller."
+                    "Comma-separated list of robot controller(s) to start. Each controller match an entry in"
+                    " controllers_config. For the default configuration file, options are forward_position_controller,"
+                    " forward_state_controller, or spot_joint_controller."
                 ),
             ),
             DeclareBooleanLaunchArgument(


### PR DESCRIPTION

## Change Overview

We can now specify multiple ros2_control controllers to spawn at launch by listing them, comma-separated, in the `robot_controllers` arg. Previously this arg only accepted a single controller name, allowing only a single user-specified controller from the `*_controller_config.yaml` file to be launched.

## Testing Done

This was tested by spawning two different custom controllers with different parameters using the `robot_controllers` launch arg, tested on both Mock and real Spot.
