### PR TITLE
Fix CI

### DIFF
--- a/spot_common/test/pytests/test_launch_helpers.py
+++ b/spot_common/test/pytests/test_launch_helpers.py
@@ -145,7 +145,7 @@ class LaunchHelpersTest(unittest.TestCase):
             "Launch argument: explicit prefix.",
         )
 
-        name_path_join_substitution = PathJoinSubstitution(self.name_value)
+        name_path_join_substitution = PathJoinSubstitution([self.name_value])
         prefix_path_join_substitution = PathJoinSubstitution([self.prefix_value, ""])
 
         name, prefix = get_name_and_prefix({self.name_key: name_path_join_substitution})


### PR DESCRIPTION
## Change Overview

The newest humble sync has changed the behavior of `PathJoinSubstitution`. Passing a single string to a `PathJoinSubstitution` will now create a list of `TextSubstitutions` between each character. The fix to this is to pass this single string wrapped in a list.

## Testing Done

- [x] CI passes 
- [x] Double checked that there are no other instances of passing in a string directly to PathJoinSubstitution in this repo 