### PR TITLE
[SW-NA] add set_spot_env.sh script, remove references to config file

### DIFF
--- a/spot_driver/BUILD.bazel
+++ b/spot_driver/BUILD.bazel
@@ -444,13 +444,10 @@ cc_library(
 
 ros.cmd(
     name = "launch_spot_driver",
-    cmd = "ros2 launch spot_driver spot_driver.launch.py config_file:=spot_driver/config/spot_ros_config_DO_NOT_COMMIT.yaml",
-    # cmd = "ros2 launch spot_driver spot_driver.launch.py config_file:=spot_driver/config/spot_ros_example.yaml",
+    cmd = "ros2 launch spot_driver spot_driver.launch.py,
     data = [
         ":spot_driver_launch",
         "test/profile.xml",
-        "config/spot_ros_config_DO_NOT_COMMIT.yaml",
-        # "config/spot_ros_config_example.yaml",
     ],
     deps = [
         "//spot_common:pkg_py",

--- a/utilities/set_spot_env.sh
+++ b/utilities/set_spot_env.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Usage: source set_spot_env.sh config.yaml
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: source $0 <config.yaml>"
+  return 1 2>/dev/null || exit 1
+fi
+
+YAML_FILE="$1"
+
+# Get the first uncommented hostname line
+HOSTNAME_LINE=$(grep -E '^[[:space:]]*hostname:[[:space:]]*".*"' "$YAML_FILE" | head -n 1)
+
+if [[ -z "$HOSTNAME_LINE" ]]; then
+  echo "Error: No uncommented hostname entry found in $YAML_FILE"
+  return 1 2>/dev/null || exit 1
+fi
+
+# Extract IP from the line
+SPOT_IP=$(echo "$HOSTNAME_LINE" | sed -E 's/.*hostname:[[:space:]]*"([^"]*)".*/\1/')
+
+# Extract label if present in comment
+LABEL=$(echo "$HOSTNAME_LINE" | grep -oE '#[[:space:]]*[^#]*$' | sed 's/#\s*//')
+
+# Extract other credentials
+USERNAME=$(grep -E '^[[:space:]]*username:[[:space:]]*".*"' "$YAML_FILE" | sed -E 's/.*username:[[:space:]]*"([^"]*)".*/\1/')
+PASSWORD=$(grep -E '^[[:space:]]*password:[[:space:]]*".*"' "$YAML_FILE" | sed -E 's/.*password:[[:space:]]*"([^"]*)".*/\1/')
+
+# Set environment variables
+export BOSDYN_CLIENT_USERNAME="$USERNAME"
+export BOSDYN_CLIENT_PASSWORD="$PASSWORD"
+export SPOT_IP="$SPOT_IP"
+
+# Output
+if [[ -n "$LABEL" ]]; then
+  echo "Set SPOT_IP=$SPOT_IP  # $LABEL"
+else
+  echo "Set SPOT_IP=$SPOT_IP"
+fi


### PR DESCRIPTION
## Change Overview

adds a utilities/set_spot_env.sh script that parses the spot_driver/config/spot_ros_example.yaml (or similar) to set the BOSDYN_CLIENT_USERNAME, BOSDYN_CLIENT_PASSWORD, and SPOT_IP environment variables. Removes references to config files from BUILD.bazel file.

## Testing Done

ran script on my config/spot_ros_config_DO_NOT_COMMIT.yaml, confirmed env vars set.