### PR TITLE
clang build error: removed constexpr from non-literal value (pre-C++ 20)

### DIFF
--- a/spot_driver/CMakeLists.txt
+++ b/spot_driver/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 project(spot_driver)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/spot_driver/CMakeLists.txt
+++ b/spot_driver/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.22)
 
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 project(spot_driver)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -155,7 +155,8 @@ std::string getEnvironmentVariableParameterFallback(const std::shared_ptr<rclcpp
  * parameter is not a valid option, std::nullopt is returned instead.
  */
 template <typename OptionsT>
-static constexpr std::optional<std::string> validateFrameParameter(const std::string& frame, const OptionsT& base_names) {
+static constexpr std::optional<std::string> validateFrameParameter(const std::string& frame,
+                                                                   const OptionsT& base_names) {
   static_assert(type_traits::is_iterable<OptionsT>,
                 "Trait bound not satisfied for argument 'base_names', type not iterable.");
   static_assert(std::is_convertible_v<typename OptionsT::value_type, std::string>,

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -155,7 +155,7 @@ std::string getEnvironmentVariableParameterFallback(const std::shared_ptr<rclcpp
  * parameter is not a valid option, std::nullopt is returned instead.
  */
 template <typename OptionsT>
-static std::optional<std::string> validateFrameParameter(const std::string& frame, const OptionsT& base_names) {
+static constexpr std::optional<std::string> validateFrameParameter(const std::string& frame, const OptionsT& base_names) {
   static_assert(type_traits::is_iterable<OptionsT>,
                 "Trait bound not satisfied for argument 'base_names', type not iterable.");
   static_assert(std::is_convertible_v<typename OptionsT::value_type, std::string>,

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -155,7 +155,7 @@ std::string getEnvironmentVariableParameterFallback(const std::shared_ptr<rclcpp
  * parameter is not a valid option, std::nullopt is returned instead.
  */
 template <typename OptionsT>
-static constexpr std::optional<std::string> validateFrameParameter(const std::string& frame, const OptionsT& base_names) {
+static std::optional<std::string> validateFrameParameter(const std::string& frame, const OptionsT& base_names) {
   static_assert(type_traits::is_iterable<OptionsT>,
                 "Trait bound not satisfied for argument 'base_names', type not iterable.");
   static_assert(std::is_convertible_v<typename OptionsT::value_type, std::string>,

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -155,8 +155,7 @@ std::string getEnvironmentVariableParameterFallback(const std::shared_ptr<rclcpp
  * parameter is not a valid option, std::nullopt is returned instead.
  */
 template <typename OptionsT>
-static std::optional<std::string> validateFrameParameter(const std::string& frame,
-                                                                   const OptionsT& base_names) {
+static std::optional<std::string> validateFrameParameter(const std::string& frame, const OptionsT& base_names) {
   static_assert(type_traits::is_iterable<OptionsT>,
                 "Trait bound not satisfied for argument 'base_names', type not iterable.");
   static_assert(std::is_convertible_v<typename OptionsT::value_type, std::string>,

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -155,7 +155,7 @@ std::string getEnvironmentVariableParameterFallback(const std::shared_ptr<rclcpp
  * parameter is not a valid option, std::nullopt is returned instead.
  */
 template <typename OptionsT>
-static constexpr std::optional<std::string> validateFrameParameter(const std::string& frame,
+static std::optional<std::string> validateFrameParameter(const std::string& frame,
                                                                    const OptionsT& base_names) {
   static_assert(type_traits::is_iterable<OptionsT>,
                 "Trait bound not satisfied for argument 'base_names', type not iterable.");

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -155,8 +155,7 @@ std::string getEnvironmentVariableParameterFallback(const std::shared_ptr<rclcpp
  * parameter is not a valid option, std::nullopt is returned instead.
  */
 template <typename OptionsT>
-static constexpr std::optional<std::string> validateFrameParameter(const std::string& frame,
-                                                                   const OptionsT& base_names) {
+static constexpr std::optional<std::string> validateFrameParameter(const std::string& frame, const OptionsT& base_names) {
   static_assert(type_traits::is_iterable<OptionsT>,
                 "Trait bound not satisfied for argument 'base_names', type not iterable.");
   static_assert(std::is_convertible_v<typename OptionsT::value_type, std::string>,


### PR DESCRIPTION
## Change Overview

When building latest main (3aa69ec) with clang-14, `spot_driver` fails to build due to `validateFrameParameter()` being marked `constexpr` but returning a non-literal value (std::optional<std::string> pre-C++20).

By removing `constexpr` from the return type of the function resolves this issue.

Here is the full build error prior to fix: 
`/home/gaddison/sporc_ws3/src/spot_ros2/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp:158:45: error: constexpr function's return type 'std::optional<std::string>' (aka 'optional<basic_string<char>>') is not a literal type
static constexpr std::optional<std::string> validateFrameParameter(const std::string& frame,
                                            ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/optional:663:7: note: 'optional<std::basic_string<char>>' is not literal because it has base class '_Optional_base<std::basic_string<char>>' of non-literal type
    : private _Optional_base<_Tp>,
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/gaddison/sporc_ws3/src/spot_ros2/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp:230:7: error: no matching function for call to 'validateFrameParameter'
      validateFrameParameter(preferred_odom_frame, kValidOdomFrameNames);
      ^~~~~~~~~~~~~~~~~~~~~~
/home/gaddison/sporc_ws3/src/spot_ros2/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp:158:45: note: candidate template ignored: substitution failure [with OptionsT = std::array<const char *const, 2>]
static constexpr std::optional<std::string> validateFrameParameter(const std::string& frame,
                                            ^
/home/gaddison/sporc_ws3/src/spot_ros2/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp:239:52: error: no matching function for call to 'validateFrameParameter'
  const std::optional<std::string> valid_tf_root = validateFrameParameter(tf_root, kValidTFRootFrameNames);
                                                   ^~~~~~~~~~~~~~~~~~~~~~
/home/gaddison/sporc_ws3/src/spot_ros2/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp:158:45: note: candidate template ignored: substitution failure [with OptionsT = std::array<const char *const, 3>]
static constexpr std::optional<std::string> validateFrameParameter(const std::string& frame,
                                            ^
3 errors generated.
`


## Testing Done

Build with colcon on ubuntu 22.04 with clang-14. 
