### PR TITLE
Added a parameter for arm control

### DIFF
--- a/spot_driver/config/spot_ros_example.yaml
+++ b/spot_driver/config/spot_ros_example.yaml
@@ -29,6 +29,7 @@
     # frame_prefix: "" # Set an explicit prefix for all frames in your TF tree (an empty string is a valid prefix option).
 
     cmd_duration: 0.25 # The duration of cmd_vel commands. Increase this if spot stutters when publishing cmd_vel.
+    arm_cmd_duration: 1.0 # The duration of arm_vel commands. Decrease this if the arm has a delay. Publish it at more than 4 Hz
     rgb_cameras: True  # Set to False if your robot has greyscale cameras -- otherwise you won't receive data.
     initialize_spot_cam: False # Set to True if you are connecting to a SpotCam payload module.
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -357,6 +357,7 @@ class SpotROS(Node):
 
         self.declare_parameter("estop_timeout", 9.0)
         self.declare_parameter("cmd_duration", 0.125)
+        self.declare_parameter("arm_cmd_duration", 1.0)
         self.declare_parameter("start_estop", False)
         self.declare_parameter("rgb_cameras", True)
 
@@ -459,6 +460,7 @@ class SpotROS(Node):
             )
 
         self.cmd_duration: float = self.get_parameter("cmd_duration").value
+        self.arm_cmd_duration: float = self.get_parameter("arm_cmd_duration").value
 
         self.username: str = get_from_env_and_fall_back_to_param("BOSDYN_CLIENT_USERNAME", self, "username", "user")
         self.password: str = get_from_env_and_fall_back_to_param("BOSDYN_CLIENT_PASSWORD", self, "password", "password")
@@ -2609,8 +2611,9 @@ class SpotROS(Node):
         try:
             proto_command = arm_command_pb2.ArmVelocityCommand.Request()
             convert(arm_velocity_command, proto_command)
+            self.get_logger().info(f"Arm command duration: {self.arm_cmd_duration}")
             result, message = self.spot_wrapper.spot_arm.handle_arm_velocity(
-                arm_velocity_command=proto_command, cmd_duration=self.cmd_duration
+                arm_velocity_command=proto_command, cmd_duration=self.arm_cmd_duration
             )
             if not result:
                 self.get_logger().error(f"Failed to execute arm velocity command: {message}")

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -599,7 +599,11 @@ class SpotROS(Node):
                 PoseStamped, "arm_pose_commands", self.arm_pose_cmd_callback, 100, callback_group=self.group
             )
             self.create_subscription(
-                ArmVelocityCommandRequest, "arm_velocity_commands", self.arm_velocity_cmd_callback, 100, callback_group=self.group,
+                ArmVelocityCommandRequest,
+                "arm_velocity_commands",
+                self.arm_velocity_cmd_callback,
+                100,
+                callback_group=self.group,
             )
 
             if not self.gripperless:

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2613,6 +2613,7 @@ class SpotROS(Node):
             convert(arm_velocity_command, proto_command)
             result, message = self.spot_wrapper.spot_arm.handle_arm_velocity(
                 arm_velocity_command=proto_command, cmd_duration=self.arm_cmd_duration
+            )
             if not result:
                 self.get_logger().error(f"Failed to execute arm velocity command: {message}")
         except Exception as e:

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -44,8 +44,8 @@ from bosdyn.client.lease import Lease, LeaseWallet
 from bosdyn_api_msgs.math_helpers import bosdyn_localization_to_pose_msg, bosdyn_pose_to_tf
 from bosdyn_msgs.conversions import convert
 from bosdyn_msgs.msg import (
-    ArmVelocityCommandRequest,
     ArmCommandFeedback,
+    ArmVelocityCommandRequest,
     Camera,
     FullBodyCommand,
     FullBodyCommandFeedback,
@@ -599,9 +599,9 @@ class SpotROS(Node):
                 PoseStamped, "arm_pose_commands", self.arm_pose_cmd_callback, 100, callback_group=self.group
             )
             self.create_subscription(
-                ArmVelocityCommandRequest, "arm_velocity_commands", self.arm_velocity_cmd_callback, 100, callback_group=self.group
+                ArmVelocityCommandRequest, "arm_velocity_commands", self.arm_velocity_cmd_callback, 100, callback_group=self.group,
             )
-            
+
             if not self.gripperless:
                 self.create_service(
                     SetGripperAngle,
@@ -2596,20 +2596,20 @@ class SpotROS(Node):
             self.get_logger().warning(f"Failed to go to arm pose: {result[1]}")
         else:
             self.get_logger().info("Successfully went to arm pose")
-    
+
     def arm_velocity_cmd_callback(self, arm_velocity_command: ArmVelocityCommandRequest) -> None:
         if not self.spot_wrapper:
-            self.get_logger().info(f"Mock mode, received arm velocity command")
+            self.get_logger().info("Mock mode, received arm velocity command")
             return
 
         try:
             proto_command = arm_command_pb2.ArmVelocityCommand.Request()
             convert(arm_velocity_command, proto_command)
-            result, message = self.spot_wrapper.spot_arm.handle_arm_velocity(arm_velocity_command=proto_command,
-                                                                            cmd_duration=self.cmd_duration)
+            result, message = self.spot_wrapper.spot_arm.handle_arm_velocity(
+                arm_velocity_command=proto_command, cmd_duration=self.cmd_duration
+            )
             if not result:
-                self.get_logger().error(f"Failed to execute arm velocity command: {message}")   
-            return result
+                self.get_logger().error(f"Failed to execute arm velocity command: {message}")
         except Exception as e:
             self.get_logger().error(f"Failed to convert arm velocity command: {e}")
 

--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2601,52 +2601,17 @@ class SpotROS(Node):
         if not self.spot_wrapper:
             self.get_logger().info(f"Mock mode, received arm velocity command")
             return
-        cylindrical_velocity = arm_command_pb2.ArmVelocityCommand.CylindricalVelocity()
-        cylindrical_velocity.linear_velocity.r = arm_velocity_command.command.cylindrical_velocity.linear_velocity.r
-        cylindrical_velocity.linear_velocity.theta = arm_velocity_command.command.cylindrical_velocity.linear_velocity.theta
-        cylindrical_velocity.linear_velocity.z = arm_velocity_command.command.cylindrical_velocity.linear_velocity.z
-
-        # Create angular velocity vector
-        angular_velocity = geometry_pb2.Vec3(
-            x=arm_velocity_command.angular_velocity_of_hand_rt_odom_in_hand.x,
-            y=arm_velocity_command.angular_velocity_of_hand_rt_odom_in_hand.y,
-            z=arm_velocity_command.angular_velocity_of_hand_rt_odom_in_hand.z,
-        )
-
-        # Create cartesian velocity command
-        cartesian_velocity = arm_command_pb2.ArmVelocityCommand.CartesianVelocity()
-        cartesian_velocity.velocity_in_frame_name.x = arm_velocity_command.command.cartesian_velocity.velocity_in_frame_name.x
-        cartesian_velocity.velocity_in_frame_name.y = arm_velocity_command.command.cartesian_velocity.velocity_in_frame_name.y
-        cartesian_velocity.velocity_in_frame_name.z = arm_velocity_command.command.cartesian_velocity.velocity_in_frame_name.z
-        cartesian_velocity.frame_name = arm_velocity_command.command.cartesian_velocity.frame_name
-
-        # self.get_logger().info(
-        #     f"Received arm velocity command:" 
-        #     f"Cylindrical_velocity={cylindrical_velocity},"
-        #     f"Angular_velocity={angular_velocity}," 
-        #     f"Cartesian_velocity={cartesian_velocity}"
-        # )
-
-        self.get_logger().info("HERERE")
 
         try:
             proto_command = arm_command_pb2.ArmVelocityCommand.Request()
             convert(arm_velocity_command, proto_command)
-            self.get_logger().info(f"Arm velocity command: {proto_command}")
+            result, message = self.spot_wrapper.spot_arm.handle_arm_velocity(arm_velocity_command=proto_command,
+                                                                            cmd_duration=self.cmd_duration)
+            if not result:
+                self.get_logger().error(f"Failed to execute arm velocity command: {message}")   
+            return result
         except Exception as e:
             self.get_logger().error(f"Failed to convert arm velocity command: {e}")
-
-        result, message = self.spot_wrapper.spot_arm.handle_arm_velocity(cylindrical_velocity_command=cylindrical_velocity, 
-                                                                         angular_velocity_of_hand_rt_odom_in_hand=angular_velocity, 
-                                                                         seconds=arm_velocity_command.end_time.sec,
-                                                                         nanoseconds=arm_velocity_command.end_time.nanosec,
-                                                                         cmd_duration=self.cmd_duration)
-        if not result:
-            self.get_logger().warning(f"Failed to execute arm velocity command: {message}")
-        else:
-            self.get_logger().info("Successfully executed arm velocity command")
-            self.get_logger().info(f"Command ID: {message}")   
-        return result
 
     def handle_graph_nav_get_localization_pose(
         self,


### PR DESCRIPTION

## Change Overview

This builds on the work from #704 by adding a new parameter: `arm_cmd_duration`, similar to `cmd_duration` for base control.

Previously, arm and base commands were sent at the same rate with the same timeout, but this caused issues. Adding a separate parameter for the arm allows better control.

## Testing Done

* Tested on the real robot
* Arm commands now work as expected with the new timeout