### PR TITLE
[SW-3138] bosdyn_msgs additional_debs generation script; add arm64

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -110,120 +110,120 @@ ros.additional_deb(
     ],
     cc_includes = ["opt/spot-cpp-sdk/include"],
 )
+
 ros.additional_deb(
-    hub_name = "humble",
-    name = "bosdyn-api-msgs",
-    # TODO(astout) add arm64
-    urls_by_arch = {"amd64": ["https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-api-msgs_5.0.0-0jammy_amd64.deb"]},
-    sha256_by_arch = {"amd64": "97a7d5300083a9a510fd462146cdb31df20dbd2412b6dba2a381dd5f9d8fefa7"},
+    hub_name = 'humble',
+    name = 'bosdyn-api-msgs',
+    urls_by_arch = {'amd64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-api-msgs_5.0.0-0jammy_amd64.deb'], 'arm64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-api-msgs_5.0.0-0jammy_arm64.deb']},
+    sha256_by_arch = {'amd64': '97a7d5300083a9a510fd462146cdb31df20dbd2412b6dba2a381dd5f9d8fefa7', 'arm64': '826740307d118476efcb51e334ce3f6a18d79b6f7835ef2e451339a80e41f561'},
     dependencies = [],
     cc_includes = [],
 )
+
 ros.additional_deb(
-    hub_name = "humble",
-    name = "bosdyn-auto-return-api-msgs",
-    # TODO(astout) add arm64
-    urls_by_arch = {"amd64": ["https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-auto-return-api-msgs_5.0.0-0jammy_amd64.deb"]},
-    sha256_by_arch = {"amd64": "866cecf22464ac622cd822d99f0aa1daef3dacc0b01ffd68c350b94d3a309fe0"},
+    hub_name = 'humble',
+    name = 'bosdyn-auto-return-api-msgs',
+    urls_by_arch = {'amd64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-auto-return-api-msgs_5.0.0-0jammy_amd64.deb'], 'arm64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-auto-return-api-msgs_5.0.0-0jammy_arm64.deb']},
+    sha256_by_arch = {'amd64': '866cecf22464ac622cd822d99f0aa1daef3dacc0b01ffd68c350b94d3a309fe0', 'arm64': '75254f1cb86f95a934fdaea430ffbbd4a09c37cf70b12501fc872fad37eb35b7'},
     dependencies = [],
     cc_includes = [],
 )
+
 ros.additional_deb(
-    hub_name = "humble",
-    name = "bosdyn-autowalk-api-msgs",
-    # TODO(astout) add arm64
-    urls_by_arch = {"amd64": ["https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-autowalk-api-msgs_5.0.0-0jammy_amd64.deb"]},
-    sha256_by_arch = {"amd64": "43eee1ca83ed825cdc9fb648d209faffb12558a87c1c643108497ef1207e2818"},
+    hub_name = 'humble',
+    name = 'bosdyn-autowalk-api-msgs',
+    urls_by_arch = {'amd64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-autowalk-api-msgs_5.0.0-0jammy_amd64.deb'], 'arm64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-autowalk-api-msgs_5.0.0-0jammy_arm64.deb']},
+    sha256_by_arch = {'amd64': '43eee1ca83ed825cdc9fb648d209faffb12558a87c1c643108497ef1207e2818', 'arm64': 'c873c002af02b4b22135cb028f023adf281b5f9da102f0803618aad83d3fa54d'},
     dependencies = [],
     cc_includes = [],
 )
+
 ros.additional_deb(
-    hub_name = "humble",
-    name = "bosdyn-cmake-module",
-    # TODO(astout) add arm64
-    urls_by_arch = {"amd64": ["https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-cmake-module_5.0.0-0jammy_amd64.deb"]},
-    sha256_by_arch = {"amd64": "94fe18b0dc1e452c54821d5dd03f983c1f3e10d2854e3aaf2d5f3fadf1eb4c7a"},
+    hub_name = 'humble',
+    name = 'bosdyn-cmake-module',
+    urls_by_arch = {'amd64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-cmake-module_5.0.0-0jammy_amd64.deb'], 'arm64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-cmake-module_5.0.0-0jammy_arm64.deb']},
+    sha256_by_arch = {'amd64': '94fe18b0dc1e452c54821d5dd03f983c1f3e10d2854e3aaf2d5f3fadf1eb4c7a', 'arm64': '629dcecb64d2ddc8e1850dd3ddf3e66b292b826545970c5e91a0416f326262fe'},
     dependencies = [],
     cc_includes = [],
 )
+
 ros.additional_deb(
-    hub_name = "humble",
-    name = "bosdyn-graph-nav-api-msgs",
-    # TODO(astout) add arm64
-    urls_by_arch = {"amd64": ["https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-graph-nav-api-msgs_5.0.0-0jammy_amd64.deb"]},
-    sha256_by_arch = {"amd64": "24f3fcbc5eda2521a3e2f00b94ea51521a956c1f3b9a36ba348e367f907315f9"},
+    hub_name = 'humble',
+    name = 'bosdyn-graph-nav-api-msgs',
+    urls_by_arch = {'amd64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-graph-nav-api-msgs_5.0.0-0jammy_amd64.deb'], 'arm64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-graph-nav-api-msgs_5.0.0-0jammy_arm64.deb']},
+    sha256_by_arch = {'amd64': '24f3fcbc5eda2521a3e2f00b94ea51521a956c1f3b9a36ba348e367f907315f9', 'arm64': 'c67b315dcd9618bc3e02dde9e7ec30a34df5e71e9d89b2c276b923779a33e0a3'},
     dependencies = [],
     cc_includes = [],
 )
+
 ros.additional_deb(
-    hub_name = "humble",
-    name = "bosdyn-keepalive-api-msgs",
-    # TODO(astout) add arm64
-    urls_by_arch = {"amd64": ["https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-keepalive-api-msgs_5.0.0-0jammy_amd64.deb"]},
-    sha256_by_arch = {"amd64": "a72e2861d973716f894c2753048177c2050492f2262a226ebe5d31795c8c1d1f"},
+    hub_name = 'humble',
+    name = 'bosdyn-keepalive-api-msgs',
+    urls_by_arch = {'amd64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-keepalive-api-msgs_5.0.0-0jammy_amd64.deb'], 'arm64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-keepalive-api-msgs_5.0.0-0jammy_arm64.deb']},
+    sha256_by_arch = {'amd64': 'a72e2861d973716f894c2753048177c2050492f2262a226ebe5d31795c8c1d1f', 'arm64': '4c1cd167ec011b67fb500ee471fedcafea8f5aa6c6f4eefb8cc2623586603ba5'},
     dependencies = [],
     cc_includes = [],
 )
+
 ros.additional_deb(
-    hub_name = "humble",
-    name = "bosdyn-log-status-api-msgs",
-    # TODO(astout) add arm64
-    urls_by_arch = {"amd64": ["https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-log-status-api-msgs_5.0.0-0jammy_amd64.deb"]},
-    sha256_by_arch = {"amd64": "69a69076432b49a4eb763219da5a007193bdac5bc127aab84cc59a7c7e20f2c3"},
+    hub_name = 'humble',
+    name = 'bosdyn-log-status-api-msgs',
+    urls_by_arch = {'amd64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-log-status-api-msgs_5.0.0-0jammy_amd64.deb'], 'arm64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-log-status-api-msgs_5.0.0-0jammy_arm64.deb']},
+    sha256_by_arch = {'amd64': '69a69076432b49a4eb763219da5a007193bdac5bc127aab84cc59a7c7e20f2c3', 'arm64': '58a08bf6778176342f14c278a5abbf4465804f935c2a772c2cd100f960522708'},
     dependencies = [],
     cc_includes = [],
 )
+
 ros.additional_deb(
-    hub_name = "humble",
-    name = "bosdyn-metrics-logging-api-msgs",
-    # TODO(astout) add arm64
-    urls_by_arch = {"amd64": ["https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-metrics-logging-api-msgs_5.0.0-0jammy_amd64.deb"]},
-    sha256_by_arch = {"amd64": "70e200e4b3bac00d3dc58c1c152efe2e9a446505e16cef5a30325cef0d59e473"},
+    hub_name = 'humble',
+    name = 'bosdyn-metrics-logging-api-msgs',
+    urls_by_arch = {'amd64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-metrics-logging-api-msgs_5.0.0-0jammy_amd64.deb'], 'arm64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-metrics-logging-api-msgs_5.0.0-0jammy_arm64.deb']},
+    sha256_by_arch = {'amd64': '70e200e4b3bac00d3dc58c1c152efe2e9a446505e16cef5a30325cef0d59e473', 'arm64': 'b255964bf68859637a124ff2e4ff3e92f5f88032f02d0f24657fd2a9232c77ce'},
     dependencies = [],
     cc_includes = [],
 )
+
 ros.additional_deb(
-    hub_name = "humble",
-    name = "bosdyn-mission-api-msgs",
-    # TODO(astout) add arm64
-    urls_by_arch = {"amd64": ["https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-mission-api-msgs_5.0.0-0jammy_amd64.deb"]},
-    sha256_by_arch = {"amd64": "585239d37b64d746a625336a04a6cd7bb35a7a861279fc1d59a98e1bbf0990ef"},
+    hub_name = 'humble',
+    name = 'bosdyn-mission-api-msgs',
+    urls_by_arch = {'amd64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-mission-api-msgs_5.0.0-0jammy_amd64.deb'], 'arm64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-mission-api-msgs_5.0.0-0jammy_arm64.deb']},
+    sha256_by_arch = {'amd64': '585239d37b64d746a625336a04a6cd7bb35a7a861279fc1d59a98e1bbf0990ef', 'arm64': 'b4b1a06c1bc4d82870be63506dec15f97d27233a44b1986bea89a6f385090d40'},
     dependencies = [],
     cc_includes = [],
 )
+
 ros.additional_deb(
-    hub_name = "humble",
-    name = "bosdyn-msgs",
-    # TODO(astout) add arm64
-    urls_by_arch = {"amd64": ["https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-msgs_5.0.0-0jammy_amd64.deb"]},
-    sha256_by_arch = {"amd64": "d7b53a8d19eabd680f4b35fba7846b32f278f03fd6560b226abcebddb8c0bee2"},
+    hub_name = 'humble',
+    name = 'bosdyn-msgs',
+    urls_by_arch = {'amd64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-msgs_5.0.0-0jammy_amd64.deb'], 'arm64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-msgs_5.0.0-0jammy_arm64.deb']},
+    sha256_by_arch = {'amd64': 'd7b53a8d19eabd680f4b35fba7846b32f278f03fd6560b226abcebddb8c0bee2', 'arm64': 'dc2f125b05f766a8491f522437af812b92ed5cda9b5560ce08cc70dd865c68d1'},
     dependencies = [],
     cc_includes = [],
 )
+
 ros.additional_deb(
-    hub_name = "humble",
-    name = "bosdyn-spot-api-msgs",
-    # TODO(astout) add arm64
-    urls_by_arch = {"amd64": ["https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-spot-api-msgs_5.0.0-0jammy_amd64.deb"]},
-    sha256_by_arch = {"amd64": "d1ef79c663a671230d8faa3fbf3ce6c4f77cffa2d0cfa970a12efcf6490a9610"},
+    hub_name = 'humble',
+    name = 'bosdyn-spot-api-msgs',
+    urls_by_arch = {'amd64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-spot-api-msgs_5.0.0-0jammy_amd64.deb'], 'arm64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-spot-api-msgs_5.0.0-0jammy_arm64.deb']},
+    sha256_by_arch = {'amd64': 'd1ef79c663a671230d8faa3fbf3ce6c4f77cffa2d0cfa970a12efcf6490a9610', 'arm64': 'a05a0effc5db9737fd9525cb6eb6f12bc8551d2b263ef38bb114d2b069dd881d'},
     dependencies = [],
     cc_includes = [],
 )
+
 ros.additional_deb(
-    hub_name = "humble",
-    name = "bosdyn-spot-cam-api-msgs",
-    # TODO(astout) add arm64
-    urls_by_arch = {"amd64": ["https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-spot-cam-api-msgs_5.0.0-0jammy_amd64.deb"]},
-    sha256_by_arch = {"amd64": "fad965383ccbae634daaeb12fcf982de6dbabe39773bd48be22f55164ee9be7f"},
+    hub_name = 'humble',
+    name = 'bosdyn-spot-cam-api-msgs',
+    urls_by_arch = {'amd64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-spot-cam-api-msgs_5.0.0-0jammy_amd64.deb'], 'arm64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-bosdyn-spot-cam-api-msgs_5.0.0-0jammy_arm64.deb']},
+    sha256_by_arch = {'amd64': 'fad965383ccbae634daaeb12fcf982de6dbabe39773bd48be22f55164ee9be7f', 'arm64': '9ce568198b129e61945b9a27d0cfcf7df6116cfce2a682d634510d6e0f55b7fc'},
     dependencies = [],
     cc_includes = [],
 )
+
 ros.additional_deb(
-    hub_name = "humble",
-    name = "proto2ros",
-    # TODO(astout) add arm64
-    urls_by_arch = {"amd64": ["https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-proto2ros_1.0.0-0jammy_amd64.deb"]},
-    sha256_by_arch = {"amd64": "6d2858d4e2014fa4ac1b207a2d95a62956afb2b51944ccfa3128ee7ec8c57456"},
+    hub_name = 'humble',
+    name = 'proto2ros',
+    urls_by_arch = {'amd64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-proto2ros_1.0.0-0jammy_amd64.deb'], 'arm64': ['https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/5.0.0/ros-humble-proto2ros_1.0.0-0jammy_arm64.deb']},
+    sha256_by_arch = {'amd64': '6d2858d4e2014fa4ac1b207a2d95a62956afb2b51944ccfa3128ee7ec8c57456', 'arm64': '716068ab1065804b1f5ec19b5106e8b1ab9d334613c27bb0de71506f69184509'},
     dependencies = [],
     cc_includes = [],
 )

--- a/generate_additional_debs.py
+++ b/generate_additional_debs.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+"""
+A code generator to generate the additional_deb entries for bosdyn_msgs (and possibly other things).
+"""
+
+import hashlib
+import requests
+
+def sha256_of_url(url):
+    sha256 = hashlib.sha256()
+    with requests.get(url, stream=True) as r:
+        r.raise_for_status()
+        for chunk in r.iter_content(chunk_size=8192):
+            if chunk:  # filter out keep-alive chunks
+                sha256.update(chunk)
+    return sha256.hexdigest()
+
+
+VERSION = "5.0.0"
+INCREMENT = "-0"
+BASE_URL = f"https://github.com/bdaiinstitute/bosdyn_msgs/releases/download/{VERSION}/"
+DEBIAN_NAME = "jammy"
+PACKAGES = [
+    "bosdyn-api-msgs",
+    "bosdyn-auto-return-api-msgs",
+    "bosdyn-autowalk-api-msgs",
+    "bosdyn-cmake-module",
+    "bosdyn-graph-nav-api-msgs",
+    "bosdyn-keepalive-api-msgs",
+    "bosdyn-log-status-api-msgs",
+    "bosdyn-metrics-logging-api-msgs",
+    "bosdyn-mission-api-msgs",
+    "bosdyn-msgs",
+    "bosdyn-spot-api-msgs",
+    "bosdyn-spot-cam-api-msgs",
+]
+ARCHS = ["amd64", "arm64"]
+
+HUB_NAME = "humble"
+
+ENTRY_TEMPLATE = """\
+ros.additional_deb(
+    hub_name = '{hub_name}',
+    name = '{name}',
+    urls_by_arch = {urls_by_arch},
+    sha256_by_arch = {sha256_by_arch},
+    dependencies = [],
+    cc_includes = [],
+)
+"""
+
+print("Generating. Downloading debians to compute their sha hashes, be a little patient.\n")
+
+output = []
+# for each entry
+for pkg in PACKAGES:
+    # for each architecture
+    urls_by_arch = {}
+    sha256_by_arch = {}
+    for arch in ARCHS:
+        # construct the url
+        url = BASE_URL+"ros-humble-"+pkg+"_"+VERSION+INCREMENT+DEBIAN_NAME+"_"+arch+".deb"
+        print(f"downloading and computing hash for {url}...")
+        urls_by_arch[arch] = [url]
+        # get the sha
+        try:
+            sha = sha256_of_url(url)
+        except requests.exceptions.HTTPError as e:
+            print(f"WARNING: HTTPError on url {url}:\n{e}\n")
+            continue
+        sha256_by_arch[arch] = sha
+    # construct entry
+    entry = ENTRY_TEMPLATE.format(
+        hub_name = HUB_NAME, 
+        name = pkg, 
+        urls_by_arch = str(urls_by_arch),
+        sha256_by_arch = str(sha256_by_arch)
+    )
+    output.append(entry)
+
+# proto2ros has a different version
+# I'm sure there's a way to not repeat myself, but it's not worth refactoring to do so (yet)
+
+PACKAGES = ["proto2ros",]
+VERSION = "1.0.0"
+
+for pkg in PACKAGES:
+    # for each architecture
+    urls_by_arch = {}
+    sha256_by_arch = {}
+    for arch in ARCHS:
+        # construct the url
+        url = BASE_URL+"ros-humble-"+pkg+"_"+VERSION+INCREMENT+DEBIAN_NAME+"_"+arch+".deb"
+        print(f"downloading and computing hash for {url}...")
+        urls_by_arch[arch] = [url]
+        # get the sha
+        try:
+            sha = sha256_of_url(url)
+        except requests.exceptions.HTTPError as e:
+            print(f"WARNING: HTTPError on url {url}:\n{e}\n")
+            continue
+        sha256_by_arch[arch] = sha
+    # construct entry
+    entry = ENTRY_TEMPLATE.format(
+        hub_name = HUB_NAME, 
+        name = pkg, 
+        urls_by_arch = str(urls_by_arch),
+        sha256_by_arch = str(sha256_by_arch)
+    )
+    output.append(entry)
+
+print("\n***** COPY THE FOLLOWING TO YOUR MODULE.bazel file *****\n")
+print("\n".join(output))


### PR DESCRIPTION

## Change Overview

adds script to generate bosdyn_msgs additional debs, updates to include arm64

## Testing Done

- built and ran a target that uses these additional debs to confirm working on amd64. arm64 remains to be tested.
