### PR TITLE
Robot state rate and image rate parameters

### DIFF
--- a/spot_driver/config/spot_ros_example.yaml
+++ b/spot_driver/config/spot_ros_example.yaml
@@ -11,6 +11,8 @@
     metrics_rate: 0.04
     lease_rate: 1.0
     async_tasks_rate: 10.0
+    robot_state_rate: 50.0  # Rate in Hz at which you receive joint state, TF, status updates, etc from state publisher node
+    image_rate: 15.0  # Rate in Hz at which you receive images from the image publisher node. Hard to get faster than 15 Hz from Spot.
 
     # Some boolean parameters
     auto_claim: False

--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -52,6 +52,7 @@ class ParameterInterfaceBase {
   virtual std::chrono::seconds getTimeSyncTimeout() const = 0;
   virtual std::optional<double> getLeaseRate() const = 0;
   virtual double getRobotStateRate() const = 0;
+  virtual double getImageRate() const = 0;
 
  protected:
   // These are the definitions of the default values for optional parameters.
@@ -75,5 +76,6 @@ class ParameterInterfaceBase {
   static constexpr std::chrono::seconds kDefaultTimeSyncTimeout{5};
   static constexpr double kDefaultLeaseRate{0.0};
   static constexpr double kDefaultRobotStateRate{50.0};
+  static constexpr double kDefaultImageRate{15.0};
 };
 }  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
+++ b/spot_driver/include/spot_driver/interfaces/parameter_interface_base.hpp
@@ -51,6 +51,7 @@ class ParameterInterfaceBase {
                                                                                     bool gripperless) const = 0;
   virtual std::chrono::seconds getTimeSyncTimeout() const = 0;
   virtual std::optional<double> getLeaseRate() const = 0;
+  virtual double getRobotStateRate() const = 0;
 
  protected:
   // These are the definitions of the default values for optional parameters.
@@ -73,5 +74,6 @@ class ParameterInterfaceBase {
   static constexpr auto kCamerasWithHand = {"frontleft", "frontright", "left", "right", "back", "hand"};
   static constexpr std::chrono::seconds kDefaultTimeSyncTimeout{5};
   static constexpr double kDefaultLeaseRate{0.0};
+  static constexpr double kDefaultRobotStateRate{50.0};
 };
 }  // namespace spot_ros2

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
@@ -47,6 +47,7 @@ class RclcppParameterInterface : public ParameterInterfaceBase {
       const bool has_arm, const bool gripperless) const override;
   [[nodiscard]] std::chrono::seconds getTimeSyncTimeout() const override;
   [[nodiscard]] std::optional<double> getLeaseRate() const override;
+  [[nodiscard]] double getRobotStateRate() const override;
 
  private:
   std::shared_ptr<rclcpp::Node> node_;

--- a/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
+++ b/spot_driver/include/spot_driver/interfaces/rclcpp_parameter_interface.hpp
@@ -48,6 +48,7 @@ class RclcppParameterInterface : public ParameterInterfaceBase {
   [[nodiscard]] std::chrono::seconds getTimeSyncTimeout() const override;
   [[nodiscard]] std::optional<double> getLeaseRate() const override;
   [[nodiscard]] double getRobotStateRate() const override;
+  [[nodiscard]] double getImageRate() const override;
 
  private:
   std::shared_ptr<rclcpp::Node> node_;

--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -19,7 +19,6 @@
 #include <optional>
 
 namespace {
-constexpr auto kImageCallbackPeriod = std::chrono::duration<double>{1.0 / 15.0};  // 15 Hz
 constexpr auto kDefaultDepthImageQuality = 100.0;
 }  // namespace
 

--- a/spot_driver/src/images/spot_image_publisher.cpp
+++ b/spot_driver/src/images/spot_image_publisher.cpp
@@ -90,6 +90,7 @@ bool SpotImagePublisher::initialize() {
   const auto uncompress_images = parameters_->getUncompressImages();
   const auto publish_compressed_images = parameters_->getPublishCompressedImages();
   const auto gripperless = parameters_->getGripperless();
+  const auto image_rate = parameters_->getImageRate();
 
   std::set<spot_ros2::SpotCamera> cameras_used;
   const auto cameras_used_parameter = parameters_->getCamerasUsed(has_arm_, gripperless);
@@ -111,8 +112,10 @@ bool SpotImagePublisher::initialize() {
   // Create a publisher for each image source
   middleware_handle_->createPublishers(sources, uncompress_images, publish_compressed_images);
 
+  const auto image_callback_period = std::chrono::duration<double>{1.0 / image_rate};
+
   // Create a timer to request and publish images at a fixed rate
-  timer_->setTimer(kImageCallbackPeriod, [this, uncompress_images, publish_compressed_images]() {
+  timer_->setTimer(image_callback_period, [this, uncompress_images, publish_compressed_images]() {
     timerCallback(uncompress_images, publish_compressed_images);
   });
 

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -34,6 +34,7 @@ constexpr auto kParameterFramePrefix = "frame_prefix";
 constexpr auto kParameterNameGripperless = "gripperless";
 constexpr auto kParameterTimeSyncTimeout = "timesync_timeout";
 constexpr auto kParameterNameLeaseRate = "lease_rate";
+constexpr auto kParameterNameRobotStateRate = "robot_state_rate";
 
 namespace type_traits {
 template <typename, typename = void>
@@ -316,6 +317,11 @@ std::string RclcppParameterInterface::getFramePrefixWithDefaultFallback() const 
 std::optional<double> RclcppParameterInterface::getLeaseRate() const {
   const double lease_rate = declareAndGetParameter<double>(node_, kParameterNameLeaseRate, kDefaultLeaseRate);
   return lease_rate > 0.0 ? std::make_optional(lease_rate) : std::nullopt;
+}
+
+double RclcppParameterInterface::getRobotStateRate() const {
+  const double state_rate = declareAndGetParameter<double>(node_, kParameterNameRobotStateRate, kDefaultRobotStateRate);
+  return state_rate > 0.0 ? state_rate : kDefaultRobotStateRate;
 }
 
 }  // namespace spot_ros2

--- a/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
+++ b/spot_driver/src/interfaces/rclcpp_parameter_interface.cpp
@@ -35,6 +35,7 @@ constexpr auto kParameterNameGripperless = "gripperless";
 constexpr auto kParameterTimeSyncTimeout = "timesync_timeout";
 constexpr auto kParameterNameLeaseRate = "lease_rate";
 constexpr auto kParameterNameRobotStateRate = "robot_state_rate";
+constexpr auto kParameterNameImageRate = "image_rate";
 
 namespace type_traits {
 template <typename, typename = void>
@@ -322,6 +323,11 @@ std::optional<double> RclcppParameterInterface::getLeaseRate() const {
 double RclcppParameterInterface::getRobotStateRate() const {
   const double state_rate = declareAndGetParameter<double>(node_, kParameterNameRobotStateRate, kDefaultRobotStateRate);
   return state_rate > 0.0 ? state_rate : kDefaultRobotStateRate;
+}
+
+double RclcppParameterInterface::getImageRate() const {
+  const double image_rate = declareAndGetParameter<double>(node_, kParameterNameImageRate, kDefaultImageRate);
+  return image_rate > 0.0 ? image_rate : kDefaultImageRate;
 }
 
 }  // namespace spot_ros2

--- a/spot_driver/src/robot_state/state_publisher.cpp
+++ b/spot_driver/src/robot_state/state_publisher.cpp
@@ -9,10 +9,6 @@
 #include <spot_driver/types.hpp>
 #include <utility>
 
-namespace {
-constexpr auto kRobotStateCallbackPeriod = std::chrono::duration<double>{1.0 / 50.0};  // 50 Hz
-}
-
 namespace spot_ros2 {
 
 StatePublisher::StatePublisher(const std::shared_ptr<StateClientInterface>& state_client_interface,
@@ -34,8 +30,11 @@ StatePublisher::StatePublisher(const std::shared_ptr<StateClientInterface>& stat
   is_using_vision_ = parameter_interface_->getPreferredOdomFrame() == "vision";
   full_tf_root_id_ = frame_prefix_ + parameter_interface_->getTFRoot();
 
+  const auto robot_state_rate = parameter_interface_->getRobotStateRate();
+  const auto robot_state_callback_period = std::chrono::duration<double>{1.0 / robot_state_rate};
+
   // Create a timer to request and publish robot state at a fixed rate
-  timer_interface_->setTimer(kRobotStateCallbackPeriod, [this] {
+  timer_interface_->setTimer(robot_state_callback_period, [this] {
     timerCallback();
   });
 }

--- a/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
+++ b/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
@@ -51,6 +51,8 @@ class FakeParameterInterface : public ParameterInterfaceBase {
 
   std::optional<double> getLeaseRate() const override { return 1.0; }
 
+  double getRobotStateRate() const override { return kDefaultRobotStateRate; }
+
   std::set<spot_ros2::SpotCamera> getDefaultCamerasUsed(const bool has_arm, const bool gripperless) const override {
     const auto kDefaultCamerasUsed = (has_arm && !gripperless) ? kCamerasWithHand : kCamerasWithoutHand;
     std::set<spot_ros2::SpotCamera> spot_cameras_used;

--- a/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
+++ b/spot_driver/test/include/spot_driver/fake/fake_parameter_interface.hpp
@@ -53,6 +53,8 @@ class FakeParameterInterface : public ParameterInterfaceBase {
 
   double getRobotStateRate() const override { return kDefaultRobotStateRate; }
 
+  double getImageRate() const override { return kDefaultImageRate; }
+
   std::set<spot_ros2::SpotCamera> getDefaultCamerasUsed(const bool has_arm, const bool gripperless) const override {
     const auto kDefaultCamerasUsed = (has_arm && !gripperless) ? kCamerasWithHand : kCamerasWithoutHand;
     std::set<spot_ros2::SpotCamera> spot_cameras_used;

--- a/spot_driver/test/src/test_parameter_interface.cpp
+++ b/spot_driver/test/src/test_parameter_interface.cpp
@@ -225,6 +225,8 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromParameters) {
   node_->declare_parameter("frame_prefix", kFramePrefix);
   constexpr auto timesync_timeout_parameter = 42;
   node_->declare_parameter("timesync_timeout", timesync_timeout_parameter);
+  constexpr auto robot_state_rate_parameter = 15.0;
+  node_->declare_parameter("robot_state_rate", robot_state_rate_parameter);
 
   // GIVEN we create a RclcppParameterInterface using the node
   RclcppParameterInterface parameter_interface{node_};
@@ -247,6 +249,7 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromParameters) {
   EXPECT_THAT(parameter_interface.getPreferredOdomFrame(), StrEq(preferred_odom_frame_parameter));
   EXPECT_THAT(parameter_interface.getFramePrefix(), Optional(kFramePrefix));
   EXPECT_THAT(parameter_interface.getTimeSyncTimeout(), Eq(std::chrono::seconds(timesync_timeout_parameter)));
+  EXPECT_THAT(parameter_interface.getRobotStateRate(), Eq(robot_state_rate_parameter));
 }
 
 TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigEnvVarsOverruleParameters) {
@@ -310,6 +313,7 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetConfigDefaults) {
   EXPECT_THAT(parameter_interface.getPreferredOdomFrame(), StrEq("odom"));
   EXPECT_THAT(parameter_interface.getFramePrefix(), Eq(std::nullopt));
   EXPECT_THAT(parameter_interface.getTimeSyncTimeout(), Eq(std::chrono::seconds(5)));
+  EXPECT_THAT(parameter_interface.getRobotStateRate(), Eq(50.0));
 }
 
 TEST_F(RclcppParameterInterfaceEnvVarTest, GetCamerasUsedDefaultWithArm) {

--- a/spot_driver/test/src/test_parameter_interface.cpp
+++ b/spot_driver/test/src/test_parameter_interface.cpp
@@ -225,8 +225,10 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromParameters) {
   node_->declare_parameter("frame_prefix", kFramePrefix);
   constexpr auto timesync_timeout_parameter = 42;
   node_->declare_parameter("timesync_timeout", timesync_timeout_parameter);
-  constexpr auto robot_state_rate_parameter = 15.0;
+  constexpr auto robot_state_rate_parameter = 25.0;
   node_->declare_parameter("robot_state_rate", robot_state_rate_parameter);
+  constexpr auto image_rate_parameter = 7.0;
+  node_->declare_parameter("image_rate", image_rate_parameter);
 
   // GIVEN we create a RclcppParameterInterface using the node
   RclcppParameterInterface parameter_interface{node_};
@@ -250,6 +252,7 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigFromParameters) {
   EXPECT_THAT(parameter_interface.getFramePrefix(), Optional(kFramePrefix));
   EXPECT_THAT(parameter_interface.getTimeSyncTimeout(), Eq(std::chrono::seconds(timesync_timeout_parameter)));
   EXPECT_THAT(parameter_interface.getRobotStateRate(), Eq(robot_state_rate_parameter));
+  EXPECT_THAT(parameter_interface.getImageRate(), Eq(image_rate_parameter));
 }
 
 TEST_F(RclcppParameterInterfaceEnvVarTest, GetSpotConfigEnvVarsOverruleParameters) {
@@ -314,6 +317,7 @@ TEST_F(RclcppParameterInterfaceEnvVarTest, GetConfigDefaults) {
   EXPECT_THAT(parameter_interface.getFramePrefix(), Eq(std::nullopt));
   EXPECT_THAT(parameter_interface.getTimeSyncTimeout(), Eq(std::chrono::seconds(5)));
   EXPECT_THAT(parameter_interface.getRobotStateRate(), Eq(50.0));
+  EXPECT_THAT(parameter_interface.getImageRate(), Eq(15.0));
 }
 
 TEST_F(RclcppParameterInterfaceEnvVarTest, GetCamerasUsedDefaultWithArm) {


### PR DESCRIPTION
## Change Overview

Currently on main, robot state rate is hardcoded to 50 Hz and image publish rate is hardcoded to 15 Hz. This PR makes this info come from ROS parameters (while leaving the default behavior unchanged). 

## Testing Done

- [x] Tested on robot -- default behavior is unchanged, but I can manually lower the rate of state/image publishing by changing the new parameters 
