### PR TITLE
Example for mixed level API 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,5 +57,5 @@ strict_equality = true
 warn_unreachable = true
 warn_redundant_casts = true
 no_implicit_optional = true
-files = ['spot_driver', 'spot_examples']
+files = ['spot_driver', 'spot_examples', "spot_ros2_control"]
 exclude = '^(docker|.*external|.*thirdparty|.*install|.*build|.*_experimental|.*conversions.py)/'

--- a/spot_ros2_control/CMakeLists.txt
+++ b/spot_ros2_control/CMakeLists.txt
@@ -62,6 +62,13 @@ install(
 )
 
 install(
+  PROGRAMS
+  examples/mixed_level_example.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME mixed_level_example
+)
+
+install(
   DIRECTORY include/
   DESTINATION include
 )

--- a/spot_ros2_control/README.md
+++ b/spot_ros2_control/README.md
@@ -141,4 +141,4 @@ We have provided simple forwarding controllers as examples in [`spot_controllers
 It is important to note that once these controllers have been activated, you will not be able to interact with the `spot_driver` provided interfaces anymore, as the hardware interface owns the Spot's lease.
 
 To switch back to "high level" mode, use the same controller manager services to deactivate and unload the controllers and set the hardware interface back to `unconfigured` (specifically by calling `switch_controllers`, `unload_controller`, and `set_hardware_component_state`).
-After this, you can use the standard ROS interfaces to communicate with `spot_driver` nodes as it once again has control of the Spot lease`.
+After this, you can go back to using the standard ROS interfaces to communicate with `spot_driver` nodes as it once again has control of the Spot lease.

--- a/spot_ros2_control/README.md
+++ b/spot_ros2_control/README.md
@@ -88,6 +88,13 @@ ros2 launch spot_ros2_control spot_ros2_control.launch.py hardware_interface:=mo
 
 By default, this will load a robot with no arm. If you want your mock robot to have an arm, add the launch argument `mock_arm:=True`. 
 
+
+## Additional Arguments
+* `controllers_config`: If this argument is unset, a general purpose controller configuration will be loaded containing a forward position controller and a joint state publisher, that is filled appropriately based on whether or not the robot used (mock or real) has an arm. The forward state controller and spot joint controller are also specified here. If you wish to load different controllers, this can be set here.
+* `robot_controllers`: These are the names of the robot controllers that will be started when the launchfile is called. The default is the simple forward position controller. Each name must match a controller in the `controllers_config` file.
+* `launch_rviz`: If you do not want rviz to be launched, add the argument `launch_rviz:=False`.
+* `auto_start`: If you do not want hardware interfaces and controllers to be activated on launch, add the argument `auto_start:=False`.
+
 ## Examples
 
 Examples are provided to replicate [these joint control examples](https://github.com/boston-dynamics/spot-cpp-sdk/tree/master/cpp/examples/joint_control) from Boston Dynamics.
@@ -112,11 +119,7 @@ ros2 run spot_ros2_control set_grippper_gains
 Include the argument `--robot <namespace>` if the ros2 control stack was launched in a namespace.
 This demo will repeatedly open and close the gripper, and after each motion, will take user input on new k_q_p and k_qd_p values to use next.
 
-## Additional Arguments
-* `controllers_config`: If this argument is unset, a general purpose controller configuration will be loaded containing a forward position controller and a joint state publisher, that is filled appropriately based on whether or not the robot used (mock or real) has an arm. The forward state controller and spot joint controller are also specified here. If you wish to load different controllers, this can be set here.
-* `robot_controllers`: These are the names of the robot controllers that will be started when the launchfile is called. The default is the simple forward position controller. Each name must match a controller in the `controllers_config` file.
-* `launch_rviz`: If you do not want rviz to be launched, add the argument `launch_rviz:=False`.
-* `auto_start`: If you do not want hardware interfaces and controllers to be activated on launch, add the argument `auto_start:=False`.
+An example demonstrating how to switch between low level and high level control is also provided -- more details about the unique setup this requires can be found in the following section.
 
 ## Mixed Level API
 
@@ -129,8 +132,9 @@ ros2 launch spot_driver spot_driver.launch.py controllable:=True <other launch a
 
 > [!TIP]
 > A simple Python example demonstrating how to switch between these two modes (assuming the driver is run with the `controllable` flag) can be found in [examples/mixed_level_example.py](examples/mixed_level_example.py).
+> You can run it with `ros2 run spot_ros2_control mixed_level_example` with the optional `--robot <namespace>` argument if the driver was launched in a namespace.
 
-This command will launch the nodes in `spot_driver` as usual, but also bring up ROS 2 control stack for Spot side by side in the `unconfigured` state.
+Launching the driver in this way will bring up the nodes in `spot_driver` as usual, but also bring up ROS 2 control stack for Spot side by side in the `unconfigured` state.
 
 At this point, you can use the `spot_driver` interfaces as usual, such as the `claim`, `power_on`, `stand`, services, or the `robot_command` action for more complicated commands, but you cannot interact with any of the joint level commands from ROS 2 control yet as none of the controllers are active.
 

--- a/spot_ros2_control/README.md
+++ b/spot_ros2_control/README.md
@@ -133,6 +133,7 @@ ros2 launch spot_driver spot_driver.launch.py controllable:=True <other launch a
 > [!TIP]
 > A simple Python example demonstrating how to switch between these two modes (assuming the driver is run with the `controllable` flag) can be found in [examples/mixed_level_example.py](examples/mixed_level_example.py).
 > You can run it with `ros2 run spot_ros2_control mixed_level_example` with the optional `--robot <namespace>` argument if the driver was launched in a namespace.
+> Note that you will have to release control of the robot on the tablet before running in order for this example to work.
 
 Launching the driver in this way will bring up the nodes in `spot_driver` as usual, but also bring up ROS 2 control stack for Spot side by side in the `unconfigured` state.
 

--- a/spot_ros2_control/examples/mixed_level_example.py
+++ b/spot_ros2_control/examples/mixed_level_example.py
@@ -14,6 +14,7 @@ from controller_manager_msgs.srv import (
 )
 from lifecycle_msgs.msg import State
 from rclpy.node import Node
+from sensor_msgs.msg import JointState
 from std_srvs.srv import Trigger
 
 from spot_msgs.msg import JointCommand  # type: ignore
@@ -30,36 +31,40 @@ class SwitchState(Node):
     def __init__(self, robot_name: str | None) -> None:
         super().__init__("switch_state")
         self.prefix = robot_name + "/" if robot_name is not None else ""
-        self.get_logger().info(f"Robot name: {robot_name} {self.prefix=}")
+        self.get_logger().info(f"Robot name: {robot_name}")
 
-        self._load_controller = self.create_client(LoadController, f"{self.prefix}controller_manager/load_controller")
+        # services for connecting and disconnecting from ROS 2 controllers
+        self._load_controller = self.create_client(LoadController, self.prefix + "controller_manager/load_controller")
         self._unload_controller = self.create_client(
-            UnloadController, f"{self.prefix}controller_manager/unload_controller"
+            UnloadController, self.prefix + "controller_manager/unload_controller"
         )
         self._configure_controller = self.create_client(
-            ConfigureController, f"{self.prefix}controller_manager/configure_controller"
+            ConfigureController, self.prefix + "controller_manager/configure_controller"
         )
         self._switch_controllers = self.create_client(
-            SwitchController, f"{self.prefix}controller_manager/switch_controller"
+            SwitchController, self.prefix + "controller_manager/switch_controller"
         )
         self._set_hardware_interface_state = self.create_client(
-            SetHardwareComponentState, f"{self.prefix}controller_manager/set_hardware_component_state"
+            SetHardwareComponentState, self.prefix + "controller_manager/set_hardware_component_state"
         )
 
+        # for low level command
+        # Here we are only moving the gripper, similarly to set_gripper_gains.py as a minimal example
         self._command_pub = self.create_publisher(
-            JointCommand, f"{self.prefix}spot_joint_controller/joint_commands", 10
+            JointCommand, self.prefix + "spot_joint_controller/joint_commands", 10
         )
-
         self._joint_command = JointCommand()
         self._joint_command.name = [self.prefix + GRIPPER_JOINT_NAME]
+        self.current_gripper_angle: float | None = None
 
-        self._claim = self.create_client(Trigger, f"{self.prefix}claim")
-        self._stand = self.create_client(Trigger, f"{self.prefix}stand")
-        self._sit = self.create_client(Trigger, f"{self.prefix}sit")
-        self._power_on = self.create_client(Trigger, f"{self.prefix}power_on")
+        # services for the high level spot driver. Again a minimal list for a simple example.
+        self._claim = self.create_client(Trigger, self.prefix + "claim")
+        self._stand = self.create_client(Trigger, self.prefix + "stand")
+        self._sit = self.create_client(Trigger, self.prefix + "sit")
+        self._power_on = self.create_client(Trigger, self.prefix + "power_on")
 
-    def connect(self, controller_name: str) -> None:
-        print(f"Connecting to {controller_name}...")
+    def connect(self, controller_names: list[str]) -> None:
+        print(f"Connecting to {controller_names}...")
         # activate hardware interface
         req = SetHardwareComponentState.Request()
         req.name = SPOT_HARDWARE_INTERFACE
@@ -68,43 +73,48 @@ class SwitchState(Node):
         rclpy.spin_until_future_complete(self, future)
         print(f"Set hardware interface to active: {future.result()}")
 
-        # load controller
-        req = LoadController.Request()
-        req.name = controller_name
-        future = self._load_controller.call_async(req)
-        rclpy.spin_until_future_complete(self, future)
-        print(f"Load controller: {future.result()}")
+        for controller in controller_names:
+            # load controller
+            req = LoadController.Request()
+            req.name = controller
+            future = self._load_controller.call_async(req)
+            rclpy.spin_until_future_complete(self, future)
+            print(f"Load {controller}: {future.result()}")
 
-        # configure controller
-        req = ConfigureController.Request()
-        req.name = controller_name
-        future = self._configure_controller.call_async(req)
-        rclpy.spin_until_future_complete(self, future)
-        print(f"Configure controller: {future.result()}")
+            # configure controller
+            req = ConfigureController.Request()
+            req.name = controller
+            future = self._configure_controller.call_async(req)
+            rclpy.spin_until_future_complete(self, future)
+            print(f"Configure {controller}: {future.result()}")
 
         # activate controller
         req = SwitchController.Request()
-        req.activate_controllers = [controller_name]
+        req.activate_controllers = controller_names
         req.strictness = SwitchController.Request.STRICT
         future = self._switch_controllers.call_async(req)
         rclpy.spin_until_future_complete(self, future)
         print(f"Activate controller: {future.result()}")
 
-    def disconnect(self, controller_name: str) -> None:
-        print(f"Disconnecting from {controller_name}...")
+    def disconnect(self, controller_names: list[str]) -> None:
+        print(f"Disconnecting from {controller_names}...")
+        # Deactivate the controllers
         req = SwitchController.Request()
-        req.deactivate_controllers = [controller_name]
+        req.deactivate_controllers = controller_names
         req.strictness = SwitchController.Request.STRICT
         future = self._switch_controllers.call_async(req)
         rclpy.spin_until_future_complete(self, future)
         print(f"Deactivate controller: {future.result()}")
 
-        req = UnloadController.Request()
-        req.name = controller_name
-        future = self._unload_controller.call_async(req)
-        rclpy.spin_until_future_complete(self, future)
-        print(f"Unload controller: {future.result()}")
+        for controller in controller_names:
+            # unload each controller
+            req = UnloadController.Request()
+            req.name = controller
+            future = self._unload_controller.call_async(req)
+            rclpy.spin_until_future_complete(self, future)
+            print(f"Unload {controller}: {future.result()}")
 
+        # unconfigure the hardware interface
         req = SetHardwareComponentState.Request()
         req.name = SPOT_HARDWARE_INTERFACE
         req.target_state.id = State.PRIMARY_STATE_UNCONFIGURED
@@ -113,6 +123,7 @@ class SwitchState(Node):
         print(f"Unconfigure hardware interface: {future.result()}")
 
     def _trigger_wrapper(self, client: rclpy.client.Client, name: str) -> None:
+        # This is a simple wrapper around the high level spot driver services
         self.get_logger().info(f"{name}")
         future = client.call_async(Trigger.Request())
         rclpy.spin_until_future_complete(self, future)
@@ -135,6 +146,10 @@ class SwitchState(Node):
         self._joint_command.position = [goal_joint_angle]
         self._command_pub.publish(self._joint_command)
 
+    def _joint_state_callback(self, msg: JointState) -> None:
+        gripper_index = msg.name.index(self.prefix + GRIPPER_JOINT_NAME)
+        self.current_gripper_angle = msg.position[gripper_index]
+
     def open_and_close(self, duration_sec: float = 1.0, frequency_hz: float = 50.0) -> None:
         """Open and close the gripper by streaming position commands.
 
@@ -142,13 +157,22 @@ class SwitchState(Node):
             duration_sec (float): Duration in seconds of each open and close movement
             frequency_hz (int): Frequency in Hz of the command publish rate.
         """
-        current_gripper_angle = 0.0
+        # get current gripper angle from low level joint states
+        gripper_sub = self.create_subscription(
+            JointState, self.prefix + "low_level/joint_states", self._joint_state_callback, 10
+        )
+        while self.current_gripper_angle is None:
+            rclpy.spin_once(self)
+            self.get_logger().info(f"current gripper angle {self.current_gripper_angle}")
+        self.destroy_subscription(gripper_sub)
+
+        # most of this logic is taken from set_gripper_gains.py
         npoints = int(duration_sec * frequency_hz)
         dt = 1.0 / frequency_hz
-        step_size_open = (GRIPPER_OPEN_ANGLE - current_gripper_angle) / npoints
+        step_size_open = (GRIPPER_OPEN_ANGLE - self.current_gripper_angle) / npoints
         self._logger.info("Opening...")
         for i in range(npoints):
-            self.move_gripper(goal_joint_angle=(current_gripper_angle + i * step_size_open))
+            self.move_gripper(goal_joint_angle=(self.current_gripper_angle + i * step_size_open))
             time.sleep(dt)
         self._logger.info("Closing...")
         step_size_close = (GRIPPER_OPEN_ANGLE - GRIPPER_CLOSE_ANGLE) / npoints
@@ -164,27 +188,31 @@ def main(args: list[str] | None = None) -> None:
 
     rclpy.init(args=args)
 
+    # in this example, we will activate and deactivate the spot joint controller for streaming joint commands
+    # and the joint state broadcaster for getting the robot's joint states.
+    controllers = ["spot_joint_controller", "joint_state_broadcaster"]
+
     switch_state = SwitchState(parser_args.robot)
 
+    # we first start by interacting with the spot driver provided interface --
+    # claiming the lease, powering the robot on, and sending a high level "stand" command.
     switch_state.claim()
     switch_state.power_on()
     switch_state.stand()
 
-    input("press to sit")
-    switch_state.sit()
-
+    # next we bring up the hardware interface and relevant controllers in the Spot ROS 2 control stack
     input("press to connect to joint controller")
-    switch_state.connect("spot_joint_controller")
+    switch_state.connect(controllers)
 
+    # here we interact with the spot joint controller and joint state broadcaster we activated to send commands
     input("press to open and close")
     switch_state.open_and_close()
 
+    # next, bring down the hardware interface and controllers to prepare for "high level" commands again
     input("press to disconnect")
-    switch_state.disconnect("spot_joint_controller")
+    switch_state.disconnect(controllers)
 
-    input("press to stand")
-    switch_state.stand()
-
+    # finally, we are back to where we started, sending high level commands to the spot driver!
     input("press to sit")
     switch_state.sit()
 

--- a/spot_ros2_control/examples/mixed_level_example.py
+++ b/spot_ros2_control/examples/mixed_level_example.py
@@ -188,8 +188,14 @@ class SwitchState(Node):
 
 
 def main(args: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--robot", type=str, help="Namespace the driver is in", default=None)
+    parser = argparse.ArgumentParser(
+        description=(
+            "This example shows how to switch back and forth between high level commands to spot driver and low level"
+            " commands to the spot_ros2_control_stack. Make sure you run the driver with the controllable flag enabled"
+            " before running this example: ros2 launch spot_driver spot_driver.launch.py controllable:=True ..."
+        )
+    )
+    parser.add_argument("--robot", type=str, help="Optional namespace the driver is in", default=None)
     parser_args = parser.parse_args()
 
     rclpy.init(args=args)
@@ -200,7 +206,7 @@ def main(args: list[str] | None = None) -> None:
 
     switch_state = SwitchState(parser_args.robot)
 
-    # we first start by interacting with the spot driver provided interface --
+    # we first start by interacting with the spot driver provided interfaces --
     # claiming the lease, powering the robot on, and sending a high level "stand" command.
     switch_state.claim()
     switch_state.power_on()

--- a/spot_ros2_control/examples/mixed_level_example.py
+++ b/spot_ros2_control/examples/mixed_level_example.py
@@ -64,14 +64,14 @@ class SwitchState(Node):
         self._power_on = self.create_client(Trigger, self.prefix + "power_on")
 
     def connect(self, controller_names: list[str]) -> None:
-        print(f"Connecting to {controller_names}...")
+        self.get_logger().info(f"Connecting to {controller_names}...")
         # activate hardware interface
         req = SetHardwareComponentState.Request()
         req.name = SPOT_HARDWARE_INTERFACE
         req.target_state.id = State.PRIMARY_STATE_ACTIVE
         future = self._set_hardware_interface_state.call_async(req)
         rclpy.spin_until_future_complete(self, future)
-        print(f"Set hardware interface to active: {future.result()}")
+        self.get_logger().info(f"Set hardware interface to active: {future.result()}")
 
         for controller in controller_names:
             # load controller
@@ -79,14 +79,14 @@ class SwitchState(Node):
             req.name = controller
             future = self._load_controller.call_async(req)
             rclpy.spin_until_future_complete(self, future)
-            print(f"Load {controller}: {future.result()}")
+            self.get_logger().info(f"Load {controller}: {future.result()}")
 
             # configure controller
             req = ConfigureController.Request()
             req.name = controller
             future = self._configure_controller.call_async(req)
             rclpy.spin_until_future_complete(self, future)
-            print(f"Configure {controller}: {future.result()}")
+            self.get_logger().info(f"Configure {controller}: {future.result()}")
 
         # activate controller
         req = SwitchController.Request()
@@ -94,17 +94,17 @@ class SwitchState(Node):
         req.strictness = SwitchController.Request.STRICT
         future = self._switch_controllers.call_async(req)
         rclpy.spin_until_future_complete(self, future)
-        print(f"Activate controller: {future.result()}")
+        self.get_logger().info(f"Activate controller: {future.result()}")
 
     def disconnect(self, controller_names: list[str]) -> None:
-        print(f"Disconnecting from {controller_names}...")
+        self.get_logger().info(f"Disconnecting from {controller_names}...")
         # Deactivate the controllers
         req = SwitchController.Request()
         req.deactivate_controllers = controller_names
         req.strictness = SwitchController.Request.STRICT
         future = self._switch_controllers.call_async(req)
         rclpy.spin_until_future_complete(self, future)
-        print(f"Deactivate controller: {future.result()}")
+        self.get_logger().info(f"Deactivate controller: {future.result()}")
 
         for controller in controller_names:
             # unload each controller
@@ -112,7 +112,7 @@ class SwitchState(Node):
             req.name = controller
             future = self._unload_controller.call_async(req)
             rclpy.spin_until_future_complete(self, future)
-            print(f"Unload {controller}: {future.result()}")
+            self.get_logger().info(f"Unload {controller}: {future.result()}")
 
         # unconfigure the hardware interface
         req = SetHardwareComponentState.Request()
@@ -120,7 +120,7 @@ class SwitchState(Node):
         req.target_state.id = State.PRIMARY_STATE_UNCONFIGURED
         future = self._set_hardware_interface_state.call_async(req)
         rclpy.spin_until_future_complete(self, future)
-        print(f"Unconfigure hardware interface: {future.result()}")
+        self.get_logger().info(f"Unconfigure hardware interface: {future.result()}")
 
     def _trigger_wrapper(self, client: rclpy.client.Client, name: str) -> None:
         # This is a simple wrapper around the high level spot driver services

--- a/spot_ros2_control/examples/mixed_level_example.py
+++ b/spot_ros2_control/examples/mixed_level_example.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+import argparse
+
+import rclpy
+from controller_manager_msgs.srv import (
+    ConfigureController,
+    LoadController,
+    SetHardwareComponentState,
+    SwitchController,
+    UnloadController,
+)
+from lifecycle_msgs.msg import State
+from rclpy.node import Node
+
+from spot_msgs.msg import JointCommand  # type: ignore
+
+# maximum and minimum joint angles in radians.
+GRIPPER_OPEN_ANGLE = -1.57
+GRIPPER_CLOSE_ANGLE = 0.0
+GRIPPER_JOINT_NAME = "arm_f1x"
+
+SPOT_HARDWARE_INTERFACE = "SpotSystem"
+
+
+class SwitchState(Node):
+    def __init__(self, robot_name: str | None) -> None:
+        super().__init__("switch_state")
+        self._robot_name = robot_name
+        prefix = robot_name + "/" if robot_name is not None else ""
+        self.get_logger().info(f"Robot name: {robot_name} {prefix=}")
+
+        self._load_controller = self.create_client(LoadController, f"{prefix}controller_manager/load_controller")
+        self._unload_controller = self.create_client(UnloadController, f"{prefix}controller_manager/unload_controller")
+        self._configure_controller = self.create_client(
+            ConfigureController, f"{prefix}controller_manager/configure_controller"
+        )
+        self._switch_controllers = self.create_client(SwitchController, f"{prefix}controller_manager/switch_controller")
+        self._set_hardware_interface_state = self.create_client(
+            SetHardwareComponentState, f"{prefix}controller_manager/set_hardware_component_state"
+        )
+
+        self._command_pub = self.create_publisher(JointCommand, f"{prefix}spot_joint_controller/joint_commands", 10)
+
+    def connect(self, controller_name: str) -> None:
+        print(f"Connecting to {controller_name}...")
+        # activate hardware interface
+        req = SetHardwareComponentState.Request()
+        req.name = SPOT_HARDWARE_INTERFACE
+        req.target_state.id = State.PRIMARY_STATE_ACTIVE
+        future = self._set_hardware_interface_state.call_async(req)
+        rclpy.spin_until_future_complete(self, future)
+        print(f"Set hardware interface to active: {future.result()}")
+
+        # load controller
+        req = LoadController.Request()
+        req.name = controller_name
+        future = self._load_controller.call_async(req)
+        rclpy.spin_until_future_complete(self, future)
+        print(f"Load controller: {future.result()}")
+
+        # configure controller
+        req = ConfigureController.Request()
+        req.name = controller_name
+        future = self._configure_controller.call_async(req)
+        rclpy.spin_until_future_complete(self, future)
+        print(f"Configure controller: {future.result()}")
+
+        # activate controller
+        req = SwitchController.Request()
+        req.activate_controllers = [controller_name]
+        req.strictness = SwitchController.Request.STRICT
+        future = self._switch_controllers.call_async(req)
+        rclpy.spin_until_future_complete(self, future)
+        print(f"Activate controller: {future.result()}")
+
+    def disconnect(self, controller_name: str) -> None:
+        print(f"Disconnecting from {controller_name}...")
+        req = SwitchController.Request()
+        req.deactivate_controllers = [controller_name]
+        req.strictness = SwitchController.Request.STRICT
+        future = self._switch_controllers.call_async(req)
+        rclpy.spin_until_future_complete(self, future)
+        print(f"Deactivate controller: {future.result()}")
+
+        req = UnloadController.Request()
+        req.name = controller_name
+        future = self._unload_controller.call_async(req)
+        rclpy.spin_until_future_complete(self, future)
+        print(f"Unload controller: {future.result()}")
+
+        req = SetHardwareComponentState.Request()
+        req.name = SPOT_HARDWARE_INTERFACE
+        req.target_state.id = State.PRIMARY_STATE_UNCONFIGURED
+        future = self._set_hardware_interface_state.call_async(req)
+        rclpy.spin_until_future_complete(self, future)
+        print(f"Unconfigure hardware interface: {future.result()}")
+
+
+def main(args: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--robot", type=str, help="Namespace the driver is in", default=None)
+    parser_args = parser.parse_args()
+
+    rclpy.init(args=args)
+
+    switch_state = SwitchState(parser_args.robot)
+
+    switch_state.connect("forward_position_controller")
+
+    switch_state.disconnect("forward_position_controller")
+
+    switch_state.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/spot_ros2_control/examples/set_gripper_gains.py
+++ b/spot_ros2_control/examples/set_gripper_gains.py
@@ -11,7 +11,7 @@ from synchros2.node import Node
 from synchros2.subscription import Subscription
 from synchros2.utilities import namespace_with
 
-from spot_msgs.msg import JointCommand
+from spot_msgs.msg import JointCommand  # type: ignore
 
 # maximum and minimum joint angles in radians.
 GRIPPER_OPEN_ANGLE = -1.57

--- a/spot_ros2_control/launch/noarm_squat.launch.py
+++ b/spot_ros2_control/launch/noarm_squat.launch.py
@@ -6,7 +6,7 @@ from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
-def generate_launch_description():
+def generate_launch_description() -> LaunchDescription:
     return LaunchDescription(
         [
             DeclareLaunchArgument(

--- a/spot_ros2_control/launch/spot_ros2_control.launch.py
+++ b/spot_ros2_control/launch/spot_ros2_control.launch.py
@@ -227,7 +227,7 @@ def launch_setup(context: LaunchContext, ld: LaunchDescription) -> None:
     return
 
 
-def generate_launch_description():
+def generate_launch_description() -> LaunchDescription:
     # Populate launch description with launch arguments
     ld = LaunchDescription(
         [

--- a/spot_ros2_control/launch/wiggle_arm.launch.py
+++ b/spot_ros2_control/launch/wiggle_arm.launch.py
@@ -6,7 +6,7 @@ from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
-def generate_launch_description():
+def generate_launch_description() -> LaunchDescription:
     return LaunchDescription(
         [
             DeclareLaunchArgument(

--- a/spot_ros2_control/test/pytests/conftest.py
+++ b/spot_ros2_control/test/pytests/conftest.py
@@ -23,7 +23,7 @@ from spot_wrapper.testing.mocks import MockSpot
 # this mocks a spot with an arm
 @spot_wrapper.testing.fixture
 class simple_spot(MockSpot):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         # force an entry in manipulator state to indicate robot has arm
         manipulator_state = self.robot_state.manipulator_state

--- a/spot_ros2_control/test/pytests/test_spot_ros2_control.py
+++ b/spot_ros2_control/test/pytests/test_spot_ros2_control.py
@@ -42,9 +42,9 @@ def state_stream_response(position: list[float], velocity: list[float], load: li
 @pytest.mark.launch(fixture=pytest.robot_spot_ros2_control)
 def test_joint_states(simple_spot: SpotFixture, ros: ROSAwareScope) -> None:
     # Create a state stream response containing unique joint state values for each joint
-    position = list(range(0, NUM_JOINTS_ARM))
-    velocity = list(range(NUM_JOINTS_ARM, 2 * NUM_JOINTS_ARM))
-    load = list(range(2 * NUM_JOINTS_ARM, 3 * NUM_JOINTS_ARM))
+    position = [float(x) for x in range(0, NUM_JOINTS_ARM)]
+    velocity = [float(x) for x in range(NUM_JOINTS_ARM, 2 * NUM_JOINTS_ARM)]
+    load = [float(x) for x in range(2 * NUM_JOINTS_ARM, 3 * NUM_JOINTS_ARM)]
     stream_response = state_stream_response(position=position, velocity=velocity, load=load)
     # send this response to the mock robot
     simple_spot.api.GetRobotStateStream.future.returns(itertools.repeat(stream_response))


### PR DESCRIPTION
## Change Overview

I wanted to make an example for the mixed level API in this repo, as a more barebones example that doesn't use any of our internal tooling. 
As a part of this I updated the readme to point to this example and also added mypy checks for the `spot_ros2_control` package which adds a few minor changes to other files.
Arguably this example could also live in `spot_examples`, but I opted to put it in `spot_ros2_control/examples` to keep anything involving low level control isolated in this package. 

## Testing Done

- [x] Ran on robot
