### PR TITLE
[N/A] Disable image publishers for `spot_driver` launch tests

### DIFF
--- a/spot_driver/test/pytests/conftest.py
+++ b/spot_driver/test/pytests/conftest.py
@@ -172,7 +172,11 @@ def spot_graph_description(simple_spot: SpotFixture, domain_id: int) -> typing.I
                             ]
                         )
                     ),
-                    launch_arguments=[("config_file", temp.file.name), ("spot_name", simple_spot.api.name), ("launch_image_publishers", "False")],
+                    launch_arguments=[
+                        ("config_file", temp.file.name),
+                        ("spot_name", simple_spot.api.name),
+                        ("launch_image_publishers", "False"),
+                    ],
                 ),
                 launch_pytest.actions.ReadyToTest(),
             ],


### PR DESCRIPTION
## Change Overview

Precisely what the title says. It's not so much a fix as it is a workaround. Some `launch` tests, particularly `test_joint_states.py`, race with image publishers launch. Component loading takes time and we don't have a good way of synchronizing the tests with Spot ROS 2 bringup.  If the test finishes before image publishers load, the local ROS 2 gets killed and component loading crashes the test.

## Testing Done

Ran `pytest test_joint_states.py` locally like 10 times.