### PR TITLE
Stairs mode improvement

### DIFF
--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -103,6 +103,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/SetGripperCameraParameters.srv"
   "srv/OverrideGraspOrCarry.srv"
   "srv/SetStandHeight.srv"
+  "srv/SetStairsMode.srv"
   "action/ArmSurfaceContact.action"
   "action/ExecuteDance.action"
   "action/NavigateTo.action"

--- a/spot_msgs/msg/MobilityParams.msg
+++ b/spot_msgs/msg/MobilityParams.msg
@@ -1,3 +1,3 @@
 geometry_msgs/Pose body_control
 uint32 locomotion_hint
-bool stair_hint
+uint32 stairs_mode

--- a/spot_msgs/srv/SetStairsMode.srv
+++ b/spot_msgs/srv/SetStairsMode.srv
@@ -1,0 +1,4 @@
+bosdyn_spot_api_msgs/MobilityParamsStairsMode stairs_mode
+---
+bool success
+string message


### PR DESCRIPTION
## Introduction

The aim of this PR is to update the service `/stair_mode` in order to modify the MobilityParams variable `stairs_mode` instead of the deprecated one `stair_hint`. With this change the robot will be able to be set in stairs mode ON, OFF, AUTO and PROHIBITED.

## Change Overview

- Added SetStairsMode.srv

- Modified MobilityParams.msg to include stairs_mode and deleted stair_hint variable on message

- Changed service `/stair_mode` to `/stairs_mode`
- Changed `/stairs_mode` service type to SetStairsMode
- Changed `/stairs_mode` service callback to match the new message type `bosdyn_spot_api_msgs/msg/MobilityParamsStairsMode`

## Testing Done

- Compiled without errors
- Launched spot_driver
- Several service calls to the new service
- Tested on real Spot Explorer going upstairs and downstairs. If stairs mode ON or AUTO spot centers on the stairs. If stairs mode OFF, a message appears on Spot's pad indicating stairs mode is not enabled.
