### PR TITLE
Add QtUiTools dependency for spot_rviz_plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update -q && \
     python3-rosdep \
     libpython3-dev \
     python3-tk \
+    qttools5-dev \
     ros-humble-ros-base \
     ros-dev-tools \
     #check if Zenoh should be installed

--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -30,6 +30,9 @@ if ! [[ $(ls /etc/ros/rosdep/sources.list.d/*default.list 2> /dev/null) ]]; then
 fi
 source /opt/ros/humble/setup.bash && rosdep update && rosdep install --from-paths ./ --ignore-src -y -r --rosdistro=humble
 
+# Install Qt5UiTools
+sudo apt-get install -y qttools5-dev
+
 # Install the dist-utils
 sudo apt-get install -y python3-distutils
 sudo apt-get install -y python3-apt


### PR DESCRIPTION
I don't believe `rosdep` is install `QtUiTools`, so I added it to the install script. I'll add it to the Dockerfile and README too.

## Change Overview

Please include a summary of the changes made and the relevant ticket or issue.

## Testing Done

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).
