### PR TITLE
Bump timeout for spot ros2 control tests

### DIFF
--- a/spot_ros2_control/test/pytests/conftest.py
+++ b/spot_ros2_control/test/pytests/conftest.py
@@ -92,3 +92,4 @@ def robot_spot_ros2_control(simple_spot: SpotFixture, domain_id: int) -> Iterato
 
 def pytest_configure() -> None:
     pytest.robot_spot_ros2_control = robot_spot_ros2_control
+    pytest.DEFAULT_TIMEOUT = 10.0  # CI often takes a weirdly long time to do stuff

--- a/spot_ros2_control/test/pytests/test_spot_ros2_control.py
+++ b/spot_ros2_control/test/pytests/test_spot_ros2_control.py
@@ -52,7 +52,7 @@ def test_joint_states(simple_spot: SpotFixture, ros: ROSAwareScope) -> None:
     response.status = RobotCommandResponse.Status.STATUS_OK
     simple_spot.api.RobotCommand.future.returns(response)
     # start the mock joint control stream
-    call = simple_spot.api.JointControlStream.serve(timeout=2.0)
+    call = simple_spot.api.JointControlStream.serve(timeout=pytest.DEFAULT_TIMEOUT)
     assert call is not None
 
     # Grab the latest joint states message from the joint state broadcaster


### PR DESCRIPTION
## Change Overview

Bumps timeout for spot ros2 control pytests, follow up to #730 

## Testing Done

CI passing
