### PR TITLE
added an extra sudo command to install script

### DIFF
--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -13,7 +13,7 @@ while true; do
   esac
 done
 
-sudo apt-get update && apt-get install -y python3-rosdep python3-pip wget
+sudo apt-get update && sudo apt-get install -y python3-rosdep python3-pip wget
 
 if test -f "$REQUIREMENTS_FILE"; then
     sudo pip3 install --no-cache-dir -r $REQUIREMENTS_FILE


### PR DESCRIPTION
## Change Overview

Line 16 will not fully execute due to one `sudo` being used for the `update` but not the `install` command.

## Testing Done

I ran the `./install_spot_ros2.sh` script again and no longer get the following error:

```bash
Reading package lists... Done
E: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)
E: unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?
```
