### PR TITLE
Add a MutateWorldObject service

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -128,6 +128,7 @@ from spot_msgs.srv import (  # type: ignore
     ListSounds,
     ListWorldObjects,
     LoadSound,
+    MutateWorldObject,
     OverrideGraspOrCarry,
     PlaySound,
     RetrieveLogpoint,
@@ -899,6 +900,13 @@ class SpotROS(Node):
 
         # This doesn't use the service wrapper because it's not a trigger, and we want different mock responses
         self.create_service(ListWorldObjects, "list_world_objects", self.handle_list_world_objects)
+
+        self.create_service(
+            MutateWorldObject,
+            "mutate_world_objects",
+            self.handle_mutate_world_objects,
+            callback_group=self.group,
+        )
 
         self.create_service(
             GraphNavUploadGraph,
@@ -2887,6 +2895,17 @@ class SpotROS(Node):
         else:
             proto_response = self.spot_wrapper.spot_world_objects.list_world_objects(object_types, time_start_point)
         convert(proto_response, response.response)
+        return response
+
+    def handle_mutate_world_objects(
+        self, request: MutateWorldObject.Request, response: MutateWorldObject.Response
+    ) -> MutateWorldObject.Response:
+        proto_request = world_object_pb2.MutateWorldObjectRequest()
+        convert(request.request, proto_request)
+        self.get_logger().info("Requesting world object mutation")
+        if self.spot_wrapper:
+            proto_response = self.spot_wrapper.mutate_world_objects(proto_request)
+            convert(proto_response, response.response)
         return response
 
     def handle_execute_dance_feedback(self) -> None:

--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -104,6 +104,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/OverrideGraspOrCarry.srv"
   "srv/SetStandHeight.srv"
   "srv/SetStairsMode.srv"
+  "srv/MutateWorldObject.srv"
   "action/ArmSurfaceContact.action"
   "action/ExecuteDance.action"
   "action/NavigateTo.action"

--- a/spot_msgs/srv/MutateWorldObject.srv
+++ b/spot_msgs/srv/MutateWorldObject.srv
@@ -1,0 +1,3 @@
+bosdyn_api_msgs/MutateWorldObjectRequest request
+---
+bosdyn_api_msgs/MutateWorldObjectResponse response


### PR DESCRIPTION
## Change Overview

This adds a service to spot ros2 to access the spot API's world object mutation.  This will allow us to add nogo regions for our demo.

Note: This re-opens and updates @khughes-bdai 's previous branch.  Thanks @khughes-bdai !

## Testing Done

- [x] Ran the example in the PR above this in the stack and saw the nogo regions appear and disappear