### PR TITLE
[EK-71] Handle MutateWorldObjects exceptions

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -2904,8 +2904,11 @@ class SpotROS(Node):
         convert(request.request, proto_request)
         self.get_logger().info("Requesting world object mutation")
         if self.spot_wrapper:
-            proto_response = self.spot_wrapper.mutate_world_objects(proto_request)
-            convert(proto_response, response.response)
+            try:
+                proto_response = self.spot_wrapper.mutate_world_objects(proto_request)
+                convert(proto_response, response.response)
+            except Exception:
+                self.get_logger().error(f"Exception while handling world object mutation: {traceback.format_exc()}")
         return response
 
     def handle_execute_dance_feedback(self) -> None:


### PR DESCRIPTION
## Change Overview

Follow-up to https://github.com/bdaiinstitute/spot_ros2/pull/766. `spot_wrapper` call can raise and we need to catch it.

## Testing Done

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/bdaiinstitute/ros_utilities/wiki/Testing-guidelines).

- [x[ Manually run nogo region examples