### PR TITLE
Fix headers: cv_bridge.hpp migration & gmock include cleanup

### DIFF
--- a/spot_driver/src/api/default_image_client.cpp
+++ b/spot_driver/src/api/default_image_client.cpp
@@ -4,9 +4,9 @@
 
 #include <bosdyn/api/directory.pb.h>
 #include <bosdyn/api/image.pb.h>
-#include <cv_bridge/cv_bridge.h>
 #include <google/protobuf/duration.pb.h>
 #include <builtin_interfaces/msg/time.hpp>
+#include <cv_bridge/cv_bridge.hpp>
 #include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/vector3.hpp>

--- a/spot_driver/src/conversions/decompress_images.cpp
+++ b/spot_driver/src/conversions/decompress_images.cpp
@@ -2,8 +2,8 @@
 
 #include <bosdyn/api/directory.pb.h>
 #include <bosdyn/api/image.pb.h>
-#include <cv_bridge/cv_bridge.h>
 #include <google/protobuf/duration.pb.h>
+#include <cv_bridge/cv_bridge.hpp>
 #include <opencv2/imgcodecs.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <spot_driver/api/default_time_sync_api.hpp>

--- a/spot_driver/src/image_stitcher/image_stitcher.cpp
+++ b/spot_driver/src/image_stitcher/image_stitcher.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
-#include <cv_bridge/cv_bridge.h>
 #include <builtin_interfaces/msg/detail/time__struct.hpp>
+#include <cv_bridge/cv_bridge.hpp>
 #include <geometry_msgs/msg/detail/transform_stamped__struct.hpp>
 #include <image_transport/subscriber_filter.hpp>
 #include <memory>

--- a/spot_driver/test/include/spot_driver/matchers.hpp
+++ b/spot_driver/test/include/spot_driver/matchers.hpp
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <gmock/gmock-generated-matchers.h>
+// #include <gmock/gmock-generated-matchers.h>
 #include <gmock/gmock-matchers.h>
 #include <gmock/gmock.h>
 #include <google/protobuf/timestamp.pb.h>


### PR DESCRIPTION


## Change Overview

- changed cv_bridge.h imports to cv_bridge.hpp imports  in these files : 

1. spot_driver/src/api/default_image_client.cpp
2. spot_driver/src/conversions/decompress_images.cpp
3. spot_driver/src/image_stitcher/image_stitcher.cpp

- Commented gmock-generated-matchers.h import in spot_driver/test/include/spot_driver/matchers.hpp, as gmock-generated-matchers is not part of new versions of gmock.



