### PR TITLE
Publish transient local arm availability flag

### DIFF
--- a/spot_driver/spot_driver/spot_ros2.py
+++ b/spot_driver/spot_driver/spot_ros2.py
@@ -611,9 +611,9 @@ class SpotROS(Node):
 
         self.declare_parameter("has_arm", self.has_arm)
         self.has_arm_pub = self.create_publisher(
-            Bool, "status/has_arm", qos_profile=rclpy.qos.QoSProfile(
-                durability=rclpy.qos.DurabilityPolicy.TRANSIENT_LOCAL, depth=1
-            )
+            Bool,
+            "status/has_arm",
+            qos_profile=rclpy.qos.QoSProfile(durability=rclpy.qos.DurabilityPolicy.TRANSIENT_LOCAL, depth=1),
         )
         self.has_arm_pub.publish(Bool(data=self.has_arm))
 


### PR DESCRIPTION
## Change Overview

Closes https://github.com/bdaiinstitute/spot_ros2/issues/783. Precisely what the title says. As an alternative to node parameter checks, which are known to be flaky (but kept for backwards compatibility).

## Testing Done

Tested on a mock driver using `ros2 topic echo`.