### PR TITLE
Add repository migration notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Announcement: We are gauging interest for a new wrapper! Please check out our [poll](https://github.com/bdaiinstitute/spot_ros2/discussions/757) in the Discussions tab!
 
+> [!IMPORTANT]
+> This repository has moved from [`bdaiinstitute/spot_ros2`](https://github.com/bdaiinstitute/spot_ros2) to [`rai-opensource/spot_ros2`](https://github.com/rai-opensource/spot_ros2).
+
 
 
 <p align="center">


### PR DESCRIPTION
This repository was recently transferred from `bdaiinstitute/spot_ros2` to `rai-opensource/spot_ros2`.

This PR adds a notice to the top of the README to inform users and redirect them to the correct location.