### PR TITLE
Fix spot_imu_broadcaster_parameters missing from link and install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Build packages
         run: |
           source /opt/ros/$ROS_DISTRO/setup.bash
-          colcon build --symlink-install --packages-up-to spot_driver spot_description spot_msgs spot_examples spot_ros2_control spot_common --cmake-args -DCMAKE_CXX_FLAGS="--coverage"
+          colcon build --symlink-install --packages-up-to spot_driver spot_description spot_msgs spot_examples spot_ros2_control spot_common spot_controllers --cmake-args -DCMAKE_CXX_FLAGS="--coverage"
         working-directory: ${{ github.workspace }}/../../
 
       - name: Test non-spot-driver packages

--- a/spot_controllers/CMakeLists.txt
+++ b/spot_controllers/CMakeLists.txt
@@ -77,6 +77,7 @@ target_link_libraries(
   spot_joint_controller_parameters
   foot_state_broadcaster_parameters
   spot_pose_broadcaster_parameters
+  spot_imu_broadcaster_parameters
   forward_command_controller::forward_command_controller
   imu_sensor_broadcaster::imu_sensor_broadcaster
 )
@@ -97,7 +98,7 @@ install(
   DESTINATION include/${PROJECT_NAME}
 )
 
-install(TARGETS spot_controllers forward_state_controller_parameters spot_joint_controller_parameters foot_state_broadcaster_parameters spot_pose_broadcaster_parameters
+install(TARGETS spot_controllers forward_state_controller_parameters spot_joint_controller_parameters foot_state_broadcaster_parameters spot_pose_broadcaster_parameters spot_imu_broadcaster_parameters
   EXPORT export_spot_controllers
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib


### PR DESCRIPTION
`spot_imu_broadcaster_parameters` was added via `generate_parameter_library` in #670 but was never added to `target_link_libraries` or `install(TARGETS ...)`. This causes the generated header to never be built, breaking fresh builds with:

```
fatal error: spot_controllers/spot_imu_broadcaster_parameters.hpp: No such file or directory
```