### PR TITLE
Bump Spot SDK from 5.0.1 to 5.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 # Overview
 `spot_ros2` is a set of ROS 2 packages for interacting with Boston Dynamics' Spot, based off the [the ROS 1 equivalent](https://github.com/heuristicus/spot_ros).
 Its [`spot_driver`](spot_driver) package is designed to bridge the core functionality of the Spot SDK to ROS 2, and exposes topics, services, and actions necessary to control Spot and receive state information (such as images). 
-Currently, this repository corresponds to version 5.0.1 of the [spot-sdk](https://github.com/boston-dynamics/spot-sdk/releases/tag/v5.0.1).
+Currently, this repository corresponds to version 5.1.4 of the [spot-sdk](https://github.com/boston-dynamics/spot-sdk/releases/tag/v5.1.4).
 
 ## Requirements
 This repository is supported for use with Ubuntu 22.04 and [ROS 2 Humble](https://docs.ros.org/en/humble/index.html) on both ARM64 and AMD64 platforms.
@@ -132,32 +132,32 @@ It can be installed from source as a normal ROS package [here](https://github.co
 If you encounter problems when using this repository, feel free to ask a question in the [discussions](https://github.com/rai-opensource/spot_ros2/discussions), or open an [issue](https://github.com/rai-opensource/spot_ros2/issues) describing the problem in context.
 
 ## Verify Package Versions
-If you encounter `ModuleNotFoundErrors` with `bosdyn` packages upon running the driver, it is likely that the necessary Boston Dynamics API packages did not get installed with `install_spot_ros2.sh`. To check this, you can run the following command. Note that all versions should be `5.0.1`.
+If you encounter `ModuleNotFoundErrors` with `bosdyn` packages upon running the driver, it is likely that the necessary Boston Dynamics API packages did not get installed with `install_spot_ros2.sh`. To check this, you can run the following command. Note that all versions should be `5.1.4`.
 ```bash
 $ pip list | grep bosdyn
-bosdyn-api                               5.0.1
-bosdyn-api-msgs                          5.0.1
-bosdyn-auto-return-api-msgs              5.0.1
-bosdyn-autowalk-api-msgs                 5.0.1
-bosdyn-choreography-client               5.0.1
-bosdyn-client                            5.0.1
-bosdyn-core                              5.0.1
-bosdyn-graph-nav-api-msgs                5.0.1
-bosdyn-keepalive-api-msgs                5.0.1
-bosdyn-log-status-api-msgs               5.0.1
-bosdyn-metrics-logging-api-msgs          5.0.1
-bosdyn-mission                           5.0.1
-bosdyn-mission-api-msgs                  5.0.1
-bosdyn-msgs                              5.0.1
-bosdyn-spot-api-msgs                     5.0.1
-bosdyn-spot-cam-api-msgs                 5.0.1
+bosdyn-api                               5.1.4
+bosdyn-api-msgs                          5.1.4
+bosdyn-auto-return-api-msgs              5.1.4
+bosdyn-autowalk-api-msgs                 5.1.4
+bosdyn-choreography-client               5.1.4
+bosdyn-client                            5.1.4
+bosdyn-core                              5.1.4
+bosdyn-graph-nav-api-msgs                5.1.4
+bosdyn-keepalive-api-msgs                5.1.4
+bosdyn-log-status-api-msgs               5.1.4
+bosdyn-metrics-logging-api-msgs          5.1.4
+bosdyn-mission                           5.1.4
+bosdyn-mission-api-msgs                  5.1.4
+bosdyn-msgs                              5.1.4
+bosdyn-spot-api-msgs                     5.1.4
+bosdyn-spot-cam-api-msgs                 5.1.4
 ```
 If these packages were not installed correctly on your system, you can try manually installing them following [Boston Dynamics' guide](https://dev.bostondynamics.com/docs/python/quickstart#install-spot-python-packages).
 
 The above command verifies the installation of the `bosdyn` packages from Boston Dynamics and the generated protobuf to ROS messages in the `bosdyn_msgs` package (these have `msgs` in the name). You can also verify the `bosdyn_msgs` installation was correct with the following command:
 ```bash
 $ ros2 pkg xml bosdyn_msgs -t version
-5.0.1
+5.1.4
 ```
 
 Finally, you can verify the installation of the `spot-cpp-sdk` with the following command:
@@ -165,7 +165,7 @@ Finally, you can verify the installation of the `spot-cpp-sdk` with the followin
 $ dpkg -l spot-cpp-sdk
 ||/ Name           Version      Architecture Description
 +++-==============-============-============-=================================
-ii  spot-cpp-sdk   5.0.1        amd64        Boston Dynamics Spot C++ SDK
+ii  spot-cpp-sdk   5.1.4        amd64        Boston Dynamics Spot C++ SDK
 ```
 
 # License

--- a/install_spot_ros2.sh
+++ b/install_spot_ros2.sh
@@ -1,5 +1,5 @@
 ARCH="amd64"
-SDK_VERSION="5.0.1"
+SDK_VERSION="5.1.4"
 MSG_VERSION="${SDK_VERSION}"
 HELP=$'--arm64: Installs ARM64 version'
 REQUIREMENTS_FILE=spot_wrapper/requirements.txt


### PR DESCRIPTION
## Change Overview

Precisely what the title says. Pending https://github.com/rai-opensource/spot_wrapper/pull/198.

## Testing Done

TBD
