### PR TITLE
chore: Move spot_utilities_msgs

### DIFF
--- a/spot_msgs/CMakeLists.txt
+++ b/spot_msgs/CMakeLists.txt
@@ -33,6 +33,7 @@ find_package(common_interfaces REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(action_msgs REQUIRED)
 
 find_package(rosidl_default_generators REQUIRED)
 
@@ -57,6 +58,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/LeaseResource.msg"
   "msg/PowerState.msg"
   "msg/SystemFaultState.msg"
+  "msg/GraspResult.msg"
+  "msg/ManipulationPhase.msg"
   "srv/AcquireLease.srv"
   "srv/ChoreographyRecordedStateToAnimation.srv"
   "srv/ChoreographyStartRecordingState.srv"
@@ -111,6 +114,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "action/RobotCommand.action"
   "action/Trajectory.action"
   "action/Manipulation.action"
+  "action/SpotGraspingPipeline.action"
   DEPENDENCIES
     bosdyn_api_msgs
     bosdyn_spot_api_msgs

--- a/spot_msgs/action/SpotGraspingPipeline.action
+++ b/spot_msgs/action/SpotGraspingPipeline.action
@@ -1,0 +1,48 @@
+# Copyright (c) 2023-2026 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+# Request
+#
+# reference frame (currently VISION, BODY, HAND, ODOM supported):
+string ref_frame
+#
+# A flag that enables moving to the retract pose if set to true.
+bool retract
+#
+# Pregrasp, grasp, and retract poses:
+# Spot will first move to the pregrasp pose, open its gripper, move to the
+# grasp pose, close its gripper, and then optionally move to a retract pose
+# if `retract` is set to True.
+geometry_msgs/Pose ref_frame_t_pregrasp
+geometry_msgs/Pose ref_frame_t_grasp
+# Note that this is in the hand frame at grasp time!  Since we don't know where the grasp will actually be we usually
+# want to retract relative to where it ended up.
+geometry_msgs/Pose hand_t_retract
+#
+# Timeouts and durations for movements:
+float64 pregrasp_trans_speed_ms 1.0  # Translational speed during move to pregrasp in m/s
+float64 pregrasp_rot_speed_rads 2.0  # Rotational speed during move to pregrasp in rot/s
+float64 grasp_trajectory_speed 1.0  # Translational speed during move pregrasp to grasp in m/s (shouldn't be rotation here)
+float64 additional_grasp_timeout_sec  # Additional timeout for pregrasp to grasp
+float64 retract_duration_sec
+float64 retract_timeout_sec
+float64 gripper_open_timeout_sec
+float64 gripper_close_timeout_sec
+
+bool disallow_body_follow  # Don't allow body follow during move to pregrasp
+
+#
+# Grasp force max and response:
+# If `grasp_max_force` is 0 or negative it will be ignored.
+# If Spot senses a EE force larger than `grasp_max_force`, it will respond according to `response_max_force`:
+#   - if `response_max_force` is set to STOP_GRASP, cancel the command.
+#   - if `response_max_force` is set to CONTINUE_GRASP, continue execution.
+float64 grasp_max_force
+int32 CONTINUE_GRASP = 0
+int32 STOP_GRASP    = 1
+int32 response_max_force
+---
+# Result
+GraspResult grasp_pipeline_result
+---
+# Feedback
+ManipulationPhase manipulation_phase
+geometry_msgs/Pose vision_t_hand

--- a/spot_msgs/msg/GraspResult.msg
+++ b/spot_msgs/msg/GraspResult.msg
@@ -1,0 +1,29 @@
+# Copyright (c) 2023-2026 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+# Result codes for the grasping pipeline.
+
+# The entire grasp pipeline succeeded and the final hand pose is "close" to the
+# requested retract pose.
+int32 SUCCESS                  = 0
+
+# Result if the move to the pregrasp pose fails.
+int32 PREPARE_TO_GRASP_FAILED  = 1
+
+# Result if the move to the retract pose fails.
+int32 RETRACT_FAILED           = 2
+
+# Result if the move to the pregrasp pose fails.
+int32 OPEN_GRIPPER_FAILED      = 3
+
+# Result if the move to the pregrasp pose fails.
+int32 CLOSE_GRIPPER_FAILED     = 4
+
+# Failure if a transform could not be looked up.
+int32 TRANSFORM_LOOKUP_FAILURE = 5
+
+# Failures not to do with grasping; should be accounted for in separate result
+# codes that account for middleware connections, transforms, hardware (whether
+# or not Spot has an arm), etc.
+int32 OTHER_FAILURE            = 6
+
+# Result code to be set.
+int32 result_code

--- a/spot_msgs/msg/ManipulationPhase.msg
+++ b/spot_msgs/msg/ManipulationPhase.msg
@@ -1,0 +1,8 @@
+# Copyright (c) 2023-2026 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+# Result codes for the grasping pipeline.
+
+int32 OPENING_GRIPPER    = 0
+int32 PREPARE_TO_GRASP   = 1
+int32 CLOSING_GRIPPER    = 2
+int32 MOVING_TO_RETRACT  = 3
+int32 phase

--- a/spot_msgs/package.xml
+++ b/spot_msgs/package.xml
@@ -4,7 +4,7 @@
   <name>spot_msgs</name>
   <version>0.0.0</version>
   <description>Custom ROS messages, actions, and services for Spot</description>
-  <maintainer email="engineering@theaiinstitute.com">AI Institute</maintainer>
+  <maintainer email="opensource@rai-inst.com">RAI Institute</maintainer>
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
## Change Overview

Move messages from `spot_utilities_msgs` to `spot_msgs` 

## Testing Done

Please create a checklist of tests you plan to do and check off the ones that have been completed successfully. Ensure that ROS 2 tests use `domain_coordinator` to prevent port conflicts. Further guidance for testing can be found on the [ros utilities wiki](https://github.com/rai-opensource/ros_utilities/wiki/Testing-guidelines).
