### PR TITLE
Update get_name_and_prefix with upstream PathJoinSubstitution change

### DIFF
--- a/spot_common/spot_common/launch/spot_launch_helpers.py
+++ b/spot_common/spot_common/launch/spot_launch_helpers.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 import yaml
 from launch import LaunchContext, Substitution
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import PathJoinSubstitution
+from launch.substitutions import PythonExpression
 
 from spot_wrapper.wrapper import SpotWrapper
 from synchros2.launch.actions import DeclareBooleanLaunchArgument
@@ -312,7 +312,7 @@ def get_name_and_prefix(ros_params: Dict[str, Any]) -> Tuple[Union[str, Substitu
     tf_prefix: Optional[Union[str, Substitution]] = ros_params[_FRAME_PREFIX] if _FRAME_PREFIX in ros_params else None
     if tf_prefix is None:
         if isinstance(spot_name, Substitution):
-            tf_prefix = PathJoinSubstitution([spot_name, ""])
+            tf_prefix = PythonExpression(['"', spot_name, '" + "/"'])
         elif isinstance(spot_name, str) and spot_name:
             tf_prefix = spot_name + "/"
         else:


### PR DESCRIPTION
## Change Overview

`PathJoinSubstitution` recently had a sync that broke how the spot name and TF prefix were assembled, causing the TF prefix to not have a "/" in it when `spot_name` was set. ([before](https://github.com/ros2/launch/blob/e716d1fcc719b4155b7c99f2ae25cc3466634231/launch/launch/substitutions/path_join_substitution.py) vs [after](https://github.com/ros2/launch/blob/cf96072c2045e821eecf43c80c326ab74cb74b7a/launch/launch/substitutions/path_join_substitution.py)). 
* expected: `spot_name:=Spot` -> TF prefix is `Spot/`
* actual: `spot_name:=Spot` -> TF prefix is `Spot` 

This change uses a `PythonExpression` instead of `PathJoinSubstitution` to ensure that the tf prefix is created properly

## Testing Done
- [x] Unit tests pass
- [x] Tested with and without spot_name launch arg set in `spot_driver.launch.py`, matches expected behavior: 
  - [x] `spot_name` is unset -> TF prefix is empty string
  - [x] `spot_name:=Spot` -> TF prefix is `Spot/`