### PR TITLE
fix: Segfault caused by newer Fast RTPS

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,6 +27,17 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
     ros-${ROS_DISTRO}-tl-expected && \
     rm -rf /var/lib/apt/lists/*
 
+# Install an older Fast RTPS which does not generate segfaults
+ARG FASTRTPS_URL="http://snapshots.ros.org/humble/2025-08-15/ubuntu/pool/main/r/ros-humble-fastrtps/ros-humble-fastrtps_2.6.10-1jammy.20250718.233605_amd64.deb"
+ARG FASTRTPS_CHECKSUM="31c3f9fee5fe90f3dc81b101d81a43ff8086df38db032ff8ed65915b56025a46"
+RUN FASTRTPS_TMP_DIR=$(mktemp -d) \
+    && curl -fsSL "$FASTRTPS_URL" -o $FASTRTPS_TMP_DIR/fastrtps.deb \
+    && (echo "$FASTRTPS_CHECKSUM  $FASTRTPS_TMP_DIR/fastrtps.deb" | sha256sum --quiet -c -) \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        --allow-downgrades $FASTRTPS_TMP_DIR/fastrtps.deb \
+    && apt-mark hold "ros-*-fastrtps" \
+    && rm -rf $FASTRTPS_TMP_DIR
+
 RUN source "/opt/ros/${ROS_DISTRO}/setup.bash"
 
 ARG SPOT_SDK_VERSION="5.0.1"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
 #
 # The bug has actually been fixed, but the fix has not yet been released. So
 # this block of code can be removed when the new Fast RTPS package is published,
-# which I would expcet to be a minor bump, that is, version 2.6.12.
+# which I would expect to be a minor bump, that is, version 2.6.12.
 ARG FASTRTPS_URL="http://snapshots.ros.org/humble/2025-08-15/ubuntu/pool/main/r/ros-humble-fastrtps/ros-humble-fastrtps_2.6.10-1jammy.20250718.233605_amd64.deb"
 ARG FASTRTPS_CHECKSUM="31c3f9fee5fe90f3dc81b101d81a43ff8086df38db032ff8ed65915b56025a46"
 RUN FASTRTPS_TMP_DIR=$(mktemp -d) \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,7 +27,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -q && \
     ros-${ROS_DISTRO}-tl-expected && \
     rm -rf /var/lib/apt/lists/*
 
-# Install an older Fast RTPS which does not generate segfaults
+# Install an older Fast RTPS which does not generate segfaults. The bug is
+# documented here: https://github.com/eProsima/Fast-DDS/issues/6291
+#
+# The bug has actually been fixed, but the fix has not yet been released. So
+# this block of code can be removed when the new Fast RTPS package is published,
+# which I would expcet to be a minor bump, that is, version 2.6.12.
 ARG FASTRTPS_URL="http://snapshots.ros.org/humble/2025-08-15/ubuntu/pool/main/r/ros-humble-fastrtps/ros-humble-fastrtps_2.6.10-1jammy.20250718.233605_amd64.deb"
 ARG FASTRTPS_CHECKSUM="31c3f9fee5fe90f3dc81b101d81a43ff8086df38db032ff8ed65915b56025a46"
 RUN FASTRTPS_TMP_DIR=$(mktemp -d) \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -40,7 +40,7 @@ RUN FASTRTPS_TMP_DIR=$(mktemp -d) \
     && (echo "$FASTRTPS_CHECKSUM  $FASTRTPS_TMP_DIR/fastrtps.deb" | sha256sum --quiet -c -) \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         --allow-downgrades $FASTRTPS_TMP_DIR/fastrtps.deb \
-    && apt-mark hold "ros-*-fastrtps" \
+    && apt-mark hold ros-${ROS_DISTRO}-fastrtps \
     && rm -rf $FASTRTPS_TMP_DIR
 
 RUN source "/opt/ros/${ROS_DISTRO}/setup.bash"


### PR DESCRIPTION
## Change Overview

Downgrades the Fast RTPS package to the previous version, which does not segfault under unit tests.

The original bug is here: https://github.com/eProsima/Fast-DDS/issues/6291

The bug has actually been fixed, but the fix has not yet been released. So this block of code can be removed when the new Fast RTPS package is published, which I would expect to be a minor bump, that is, version 2.6.12.

## Testing Done

- [x] Verified installed package `ros-humble-fastrtps` with:

```
$ docker run --rm -it  ghcr.io/rai-opensource/spot_ros2_jammy_humble:pr-813
root@3711ef6c42e2:/# dpkg-query -W \
    -f='${binary:Package}\t${Version}\t${Status}\n' ros-humble-fastrtps
ros-humble-fastrtps	2.6.10-1jammy.20250718.233605	hold ok installed
```

- [x] Unit tests pass with new Docker image.